### PR TITLE
fixed DefaultHostUrlTemplate for LoadBalancerClient

### DIFF
--- a/loadbalancer/loadbalancer_client.go
+++ b/loadbalancer/loadbalancer_client.go
@@ -23,7 +23,7 @@ type LoadBalancerClient struct {
 func NewLoadBalancerClientForRegion(region common.Region) (client LoadBalancerClient) {
 	client = LoadBalancerClient{BaseClient: common.NewClientForRegion(region)}
 
-	client.Host = fmt.Sprintf(common.DefaultHostUrlTemplate, "loadbalancer", string(region))
+	client.Host = fmt.Sprintf(common.DefaultHostUrlTemplate, "iaas", string(region))
 	client.BasePath = "20170115"
 	return
 }


### PR DESCRIPTION
Was hitting this error:

Get https://loadbalancer.us-ashburn-1.oraclecloud.com/20170115/loadBalancers?compartmentId=__stage&sortBy=&sortOrder=: dial tcp: lookup loadbalancer.us-ashburn-1.oraclecloud.com: no such host

I compared to bcc-go-sdk and changed the first part of the host name to "iaas" and got past the issue.
