### PR TITLE
Rename FingerPrint to Fingerprint

### DIFF
--- a/common/auth/configuration.go
+++ b/common/auth/configuration.go
@@ -45,7 +45,7 @@ func (p instancePrincipalConfigurationProvider) UserOCID() (string, error) {
 	return "", nil
 }
 
-func (p instancePrincipalConfigurationProvider) KeyFingerPrint() (string, error) {
+func (p instancePrincipalConfigurationProvider) KeyFingerprint() (string, error) {
 	return "", nil
 }
 

--- a/common/auth/federation_client.go
+++ b/common/auth/federation_client.go
@@ -58,8 +58,8 @@ func newAuthClient(region common.Region, provider common.KeyProvider) *common.Ba
 // For authClient to sign requests to X509 Federation Endpoint
 func (c *x509FederationClient) KeyID() (string, error) {
 	tenancy := c.tenancyId
-	fingerPrint := fingerPrint(c.leafCertificateRetriever.Certificate())
-	return fmt.Sprintf("%s/fed-x509/%s", tenancy, fingerPrint), nil
+	fingerprint := fingerprint(c.leafCertificateRetriever.Certificate())
+	return fmt.Sprintf("%s/fed-x509/%s", tenancy, fingerprint), nil
 }
 
 // For authClient to sign requests to X509 Federation Endpoint

--- a/common/auth/federation_client_test.go
+++ b/common/auth/federation_client_test.go
@@ -18,7 +18,7 @@ import (
 func TestX509FederationClient_VeryFirstSecurityToken(t *testing.T) {
 	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify request
-		expectedKeyId := fmt.Sprintf("%s/fed-x509/%s", tenancyId, leafCertFingerPrint)
+		expectedKeyId := fmt.Sprintf("%s/fed-x509/%s", tenancyId, leafCertFingerprint)
 		assert.True(t, strings.HasPrefix(r.Header.Get("Authorization"), fmt.Sprintf(`Signature version="1",headers="date (request-target) content-length content-type x-content-sha256",keyId="%s",algorithm="rsa-sha256",signature=`, expectedKeyId)))
 
 		expectedBody := fmt.Sprintf(`{"certificate":"%s","publicKey":"%s","intermediateCertificates":["%s"]}`,
@@ -69,7 +69,7 @@ func TestX509FederationClient_VeryFirstSecurityToken(t *testing.T) {
 func TestX509FederationClient_RenewSecurityToken(t *testing.T) {
 	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify request
-		expectedKeyId := fmt.Sprintf("%s/fed-x509/%s", tenancyId, leafCertFingerPrint)
+		expectedKeyId := fmt.Sprintf("%s/fed-x509/%s", tenancyId, leafCertFingerprint)
 		assert.True(t, strings.HasPrefix(r.Header.Get("Authorization"), fmt.Sprintf(`Signature version="1",headers="date (request-target) content-length content-type x-content-sha256",keyId="%s",algorithm="rsa-sha256",signature=`, expectedKeyId)))
 
 		expectedBody := fmt.Sprintf(`{"certificate":"%s","publicKey":"%s","intermediateCertificates":["%s"]}`,
@@ -401,7 +401,7 @@ ysvMnQwaC0432ceRJ3r6vPAI2EPRd9KOE7Va1IFNJNmOuIkmRx8t`
 	//	certPem = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: newCertBytes})
 	//	return
 	//}
-	leafCertFingerPrint  = `52:3c:9d:93:8b:b8:07:21:ce:36:30:98:ba:fc:e2:4a:bc:3a:2e:0b`
+	leafCertFingerprint  = `52:3c:9d:93:8b:b8:07:21:ce:36:30:98:ba:fc:e2:4a:bc:3a:2e:0b`
 	intermediateCertBody = `MIIC4TCCAcmgAwIBAgIRAK7jQKVEO6ssUBICuPw4OwQwDQYJKoZIhvcNAQELBQAw
 KjEoMCYGA1UEAxMfUEtJU1ZDIElkZW50aXR5IEludGVybWVkaWF0ZSByMjAeFw0x
 NzExMzAwMDE0MDhaFw0xODExMzAwMDE0MDhaMCoxKDAmBgNVBAMTH1BLSVNWQyBJ

--- a/common/auth/utils.go
+++ b/common/auth/utils.go
@@ -51,12 +51,12 @@ func extractTenancyIdFromCertificate(cert *x509.Certificate) string {
 	return ""
 }
 
-func fingerPrint(certificate *x509.Certificate) string {
-	fingerPrint := sha1.Sum(certificate.Raw)
-	return colonSeparatedString(fingerPrint)
+func fingerprint(certificate *x509.Certificate) string {
+	fingerprint := sha1.Sum(certificate.Raw)
+	return colonSeparatedString(fingerprint)
 }
 
-func colonSeparatedString(fingerPrint [sha1.Size]byte) string {
-	spaceSeparated := fmt.Sprintf("% x", fingerPrint)
+func colonSeparatedString(fingerprint [sha1.Size]byte) string {
+	spaceSeparated := fmt.Sprintf("% x", fingerprint)
 	return strings.Replace(spaceSeparated, " ", ":", -1)
 }

--- a/common/configuration.go
+++ b/common/configuration.go
@@ -14,14 +14,14 @@ type ConfigurationProvider interface {
 	KeyProvider
 	TenancyOCID() (string, error)
 	UserOCID() (string, error)
-	KeyFingerPrint() (string, error)
+	KeyFingerprint() (string, error)
 	Region() (string, error)
 }
 
 // Test to each part of the configration provider does not return an error
 // If it does the function return false and the first error that caused the failure
 func IsConfigurationProviderValid(conf ConfigurationProvider) (ok bool, err error) {
-	baseFn := []func() (string, error){conf.TenancyOCID, conf.UserOCID, conf.KeyFingerPrint, conf.Region, conf.KeyID}
+	baseFn := []func() (string, error){conf.TenancyOCID, conf.UserOCID, conf.KeyFingerprint, conf.Region, conf.KeyID}
 	for _, fn := range baseFn {
 		_, err = fn()
 		ok = err == nil
@@ -85,12 +85,12 @@ func (p environmentConfigurationProvider) KeyID() (keyID string, err error) {
 		return
 	}
 
-	fingerPrint, err := p.KeyFingerPrint()
+	fingerprint, err := p.KeyFingerprint()
 	if err != nil {
 		return
 	}
 
-	return fmt.Sprintf("%s/%s/%s", ocid, userocid, fingerPrint), nil
+	return fmt.Sprintf("%s/%s/%s", ocid, userocid, fingerprint), nil
 }
 
 func (p environmentConfigurationProvider) TenancyOCID() (value string, err error) {
@@ -111,7 +111,7 @@ func (p environmentConfigurationProvider) UserOCID() (value string, err error) {
 	return
 }
 
-func (p environmentConfigurationProvider) KeyFingerPrint() (value string, err error) {
+func (p environmentConfigurationProvider) KeyFingerprint() (value string, err error) {
 	environmentVariable := fmt.Sprintf("%s_%s", p.EnvironmentVariablePrefix, "fingerprint")
 	var ok bool
 	if value, ok = os.LookupEnv(environmentVariable); !ok {
@@ -158,7 +158,7 @@ type configFileInfo struct {
 const (
 	hasTenancy = 1 << iota
 	hasUser
-	hasFingerPrint
+	hasFingerprint
 	hasRegion
 	hasKeyFile
 	none
@@ -184,7 +184,7 @@ func parseConfigFile(data []byte) (info *configFileInfo, err error) {
 			configurationPresent = configurationPresent | hasUser
 			info.UserOcid = value
 		case "fingerprint":
-			configurationPresent = configurationPresent | hasFingerPrint
+			configurationPresent = configurationPresent | hasFingerprint
 			info.Fingerprint = value
 		case "key_file":
 			configurationPresent = configurationPresent | hasKeyFile
@@ -262,13 +262,13 @@ func (p fileConfigurationProvider) UserOCID() (value string, err error) {
 	return
 }
 
-func (p fileConfigurationProvider) KeyFingerPrint() (value string, err error) {
+func (p fileConfigurationProvider) KeyFingerprint() (value string, err error) {
 	info, err := p.readAndParseConfigFile()
 	if err != nil {
 		err = fmt.Errorf("can not read tenancy configuration due to: %s", err.Error())
 		return
 	}
-	value, err = presentOrError(info.Fingerprint, hasFingerPrint, info.PresentConfiguration, "fingerprint")
+	value, err = presentOrError(info.Fingerprint, hasFingerprint, info.PresentConfiguration, "fingerprint")
 	return
 }
 
@@ -349,9 +349,9 @@ func (c composingConfigurationProvider) UserOCID() (string, error) {
 	return "", fmt.Errorf("did not find a proper configuration for user")
 }
 
-func (c composingConfigurationProvider) KeyFingerPrint() (string, error) {
+func (c composingConfigurationProvider) KeyFingerprint() (string, error) {
 	for _, p := range c.Providers {
-		val, err := p.KeyFingerPrint()
+		val, err := p.KeyFingerprint()
 		if err == nil {
 			return val, nil
 		}

--- a/common/configuration_test.go
+++ b/common/configuration_test.go
@@ -82,7 +82,7 @@ region=someregion
 	defer removeFileFn(filename)
 
 	c := fileConfigurationProvider{ConfigPath: filename}
-	fns := []func() (string, error){c.TenancyOCID, c.UserOCID, c.KeyFingerPrint}
+	fns := []func() (string, error){c.TenancyOCID, c.UserOCID, c.KeyFingerprint}
 
 	for i, fn := range fns {
 		val, e := fn()
@@ -93,7 +93,7 @@ region=someregion
 
 func TestFileConfigurationProvider_NoFile(t *testing.T) {
 	c := fileConfigurationProvider{ConfigPath: "/no/file"}
-	fns := []func() (string, error){c.TenancyOCID, c.UserOCID, c.KeyFingerPrint}
+	fns := []func() (string, error){c.TenancyOCID, c.UserOCID, c.KeyFingerprint}
 
 	for _, fn := range fns {
 		_, e := fn()
@@ -230,7 +230,7 @@ region=someregion
 
 	provider, ec := ComposingConfigurationProvider([]ConfigurationProvider{c0, c})
 	assert.NoError(t, ec)
-	fns := []func() (string, error){provider.TenancyOCID, provider.UserOCID, provider.KeyFingerPrint}
+	fns := []func() (string, error){provider.TenancyOCID, provider.UserOCID, provider.KeyFingerprint}
 
 	for _, fn := range fns {
 		val, e := fn()
@@ -259,7 +259,7 @@ func TestComposingConfigurationProvider_MultipleFilesNoConf(t *testing.T) {
 
 	provider, ec := ComposingConfigurationProvider([]ConfigurationProvider{c0, c})
 	assert.NoError(t, ec)
-	fns := []func() (string, error){provider.TenancyOCID, provider.UserOCID, provider.KeyFingerPrint}
+	fns := []func() (string, error){provider.TenancyOCID, provider.UserOCID, provider.KeyFingerprint}
 
 	for _, fn := range fns {
 		_, e := fn()

--- a/common/http_signer_test.go
+++ b/common/http_signer_test.go
@@ -3,19 +3,20 @@ package common
 import (
 	"bytes"
 	"crypto/rsa"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var (
 	testTenancyOCID    = "ocid1.tenancy.oc1..aaaaaaaaba3pv6wkcr4jqae5f15p2b2m2yt2j6rx32uzr4h25vqstifsfdsq"
 	testUserOCID       = "ocid1.user.oc1..aaaaaaaat5nvwcna5j6aqzjcaty5eqbb6qt2jvpkanghtgdaqedqw3rynjq"
-	testFingerPrint    = "20:3b:97:13:55:1c:5b:0d:d3:37:d8:50:4e:c5:3a:34"
+	testFingerprint    = "20:3b:97:13:55:1c:5b:0d:d3:37:d8:50:4e:c5:3a:34"
 	testComparmentOCID = "ocid1.compartment.oc1..aaaaaaaam3we6vgnherjq5q2idnccdflvjsnog7mlr6rtdb25gilchfeyjxa"
 
 	testURL = "https://iaas.us-phoenix-1.oraclecloud.com/20160918/instances" +
@@ -73,7 +74,7 @@ func (kp testKeyProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
 }
 
 func (kp testKeyProvider) KeyID() (string, error) {
-	keyID := strings.Join([]string{testTenancyOCID, testUserOCID, testFingerPrint}, "/")
+	keyID := strings.Join([]string{testTenancyOCID, testUserOCID, testFingerprint}, "/")
 	return keyID, nil
 }
 


### PR DESCRIPTION
Fingerprint isn't two words so `print` shouldn't be capitalized. This is how the generated code is as well. 