### PR TITLE
Implement a raw configuration provider

### DIFF
--- a/common/configuration.go
+++ b/common/configuration.go
@@ -39,6 +39,60 @@ func IsConfigurationProviderValid(conf ConfigurationProvider) (ok bool, err erro
 	return true, nil
 }
 
+// rawConfigurationProvider allows a user to simply construct a configuration provider from raw values.
+type rawConfigurationProvider struct {
+	tenancy              string
+	user                 string
+	region               string
+	fingerprint          string
+	privateKey           string
+	privateKeyPassphrase *string
+}
+
+// NewRawConfigurationProvider will create a rawConfigurationProvider
+func NewRawConfigurationProvider(tenancy, user, region, fingerprint, privateKey string, privateKeyPassphrase *string) ConfigurationProvider {
+	return rawConfigurationProvider{tenancy, user, region, fingerprint, privateKey, privateKeyPassphrase}
+}
+
+func (p rawConfigurationProvider) PrivateRSAKey() (key *rsa.PrivateKey, err error) {
+	return PrivateKeyFromBytes([]byte(p.privateKey), p.privateKeyPassphrase)
+}
+
+func (p rawConfigurationProvider) KeyID() (keyID string, err error) {
+	tenancy, err := p.TenancyOCID()
+	if err != nil {
+		return
+	}
+
+	user, err := p.UserOCID()
+	if err != nil {
+		return
+	}
+
+	fingerprint, err := p.KeyFingerprint()
+	if err != nil {
+		return
+	}
+
+	return fmt.Sprintf("%s/%s/%s", tenancy, user, fingerprint), nil
+}
+
+func (p rawConfigurationProvider) TenancyOCID() (string, error) {
+	return p.tenancy, nil
+}
+
+func (p rawConfigurationProvider) UserOCID() (string, error) {
+	return p.user, nil
+}
+
+func (p rawConfigurationProvider) KeyFingerprint() (string, error) {
+	return p.fingerprint, nil
+}
+
+func (p rawConfigurationProvider) Region() (string, error) {
+	return p.region, nil
+}
+
 // environmentConfigurationProvider reads configuration from environment variables
 type environmentConfigurationProvider struct { // TODO: Support Instance Principal
 	PrivateKeyPassword        string

--- a/common/configuration_test.go
+++ b/common/configuration_test.go
@@ -2,10 +2,11 @@ package common
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -44,6 +45,40 @@ func writeTempFile(data string) (filename string) {
 	return
 }
 
+func TestRawConfigurationProvider(t *testing.T) {
+	var (
+		testTenancy     = "ocid1.tenancy.oc1..aaaaaaaaxf3fuazos"
+		testUser        = "ocid1.user.oc1..aaaaaaaa3p67n2kmpxnbcnff"
+		testRegion      = "us-ashburn-1"
+		testFingerprint = "af:81:71:8e:d2"
+	)
+
+	c := NewRawConfigurationProvider(testTenancy, testUser, testRegion, testFingerprint, testPrivateKeyConf, nil)
+
+	user, err := c.UserOCID()
+	assert.NoError(t, err)
+	assert.Equal(t, user, testUser)
+
+	fingerprint, err := c.KeyFingerprint()
+	assert.NoError(t, err)
+	assert.Equal(t, fingerprint, testFingerprint)
+
+	region, err := c.Region()
+	assert.NoError(t, err)
+	assert.Equal(t, region, testRegion)
+
+	rsaKey, err := c.PrivateRSAKey()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, rsaKey)
+
+	keyID, err := c.KeyID()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, keyID)
+
+	assert.Equal(t, keyID, "ocid1.tenancy.oc1..aaaaaaaaxf3fuazos/ocid1.user.oc1..aaaaaaaa3p67n2kmpxnbcnff/af:81:71:8e:d2")
+
+}
+
 func TestFileConfigurationProvider_parseConfigFileData(t *testing.T) {
 	data := `[DEFAULT]
 user=someuser
@@ -54,6 +89,7 @@ compartment = somecompartment
 region=someregion
 `
 	c, e := parseConfigFile([]byte(data), "DEFAULT")
+
 	assert.NoError(t, e)
 	assert.Equal(t, c.UserOcid, tuser)
 	assert.Equal(t, c.Fingerprint, tfingerprint)


### PR DESCRIPTION
This change implements a rawConfigurationProvider. We use this method of instantiating a client from raw values in our Kubernetes projects (rather than from file or environment vars).

Fixes #46 