### PR TITLE
Fixed typo where returned error message appears to be incorrect.

### DIFF
--- a/common/configuration.go
+++ b/common/configuration.go
@@ -462,7 +462,7 @@ func (c composingConfigurationProvider) Region() (string, error) {
 			return val, nil
 		}
 	}
-	return "", fmt.Errorf("did not find a proper configuration for keyFingerprint")
+	return "", fmt.Errorf("did not find a proper configuration for region")
 }
 
 func (c composingConfigurationProvider) KeyID() (string, error) {


### PR DESCRIPTION
Looked like this might be a small error and should have returned 'region' as part of the error message?

Signed-off-by: timothy_langford <timothy.langford@oracle.com>