### PR TITLE
reduce write operation for identity in tests

### DIFF
--- a/integtest/identity_client_integ_test.go
+++ b/integtest/identity_client_integ_test.go
@@ -188,34 +188,27 @@ func TestIdentityClient_ListUsers(t *testing.T) {
 }
 
 func TestIdentityClient_UserCRUD(t *testing.T) {
-	// test should not fail if a previous run failed to clean up
-	userName := getUniqueName("User_")
 	c, clerr := identity.NewIdentityClientWithConfigurationProvider(common.DefaultConfigProvider())
 	failIfError(t, clerr)
-	request := identity.CreateUserRequest{}
-	request.CompartmentId = common.String(getTenancyID())
-	request.Name = common.String(userName)
-	request.Description = common.String("Test user for golang sdk2")
-	resCreate, err := c.CreateUser(context.Background(), request)
-	fmt.Println(resCreate)
-	assert.NotEmpty(t, resCreate, fmt.Sprint(resCreate))
-	assert.NoError(t, err)
+	user := createTestUser(t, common.String(getUniqueName("User_")))
+	assert.NotEmpty(t, user)
+	assert.NotEmpty(t, user.Id)
 
 	// if we've successfully created a user during testing, make sure that we delete it
 	defer func() {
 		//remove
 		rDelete := identity.DeleteUserRequest{}
-		rDelete.UserId = resCreate.Id
+		rDelete.UserId = user.Id
 		resDelete, err := c.DeleteUser(context.Background(), rDelete)
 		assert.NotEmpty(t, resDelete.OpcRequestId)
 		assert.NoError(t, err)
 	}()
 
 	// validate user lifecycle state enum value after read
-	assert.Equal(t, identity.UserLifecycleStateActive, resCreate.LifecycleState)
+	assert.Equal(t, identity.UserLifecycleStateActive, user.LifecycleState)
 
 	//Read
-	rRead := identity.GetUserRequest{UserId: resCreate.Id}
+	rRead := identity.GetUserRequest{UserId: user.Id}
 	resRead, err := c.GetUser(context.Background(), rRead)
 	assert.NotEmpty(t, resRead, fmt.Sprint(resRead))
 	assert.NoError(t, err)
@@ -225,7 +218,7 @@ func TestIdentityClient_UserCRUD(t *testing.T) {
 
 	//Update
 	rUpdate := identity.UpdateUserRequest{}
-	rUpdate.UserId = resCreate.Id
+	rUpdate.UserId = user.Id
 	rUpdate.Description = common.String("This is a new description")
 	resUpdate, err := c.UpdateUser(context.Background(), rUpdate)
 	assert.NotEmpty(t, resUpdate, fmt.Sprint(resUpdate))
@@ -332,21 +325,16 @@ func TestIdentityClient_CreateOrResetUIPassword(t *testing.T) {
 	c, clerr := identity.NewIdentityClientWithConfigurationProvider(common.DefaultConfigProvider())
 	failIfError(t, clerr)
 
-	//create the user
-	u, err := createTestUser(c)
-	failIfError(t, err)
-	defer func() {
-		failIfError(t, deleteTestUser(c, u.Id))
-	}()
-
+	// create or get the test user
+	user := createOrGetUser(t)
 	request := identity.CreateOrResetUIPasswordRequest{}
-	request.UserId = u.Id
+	request.UserId = user.Id
 	rspCreate, err := c.CreateOrResetUIPassword(context.Background(), request)
 	failIfError(t, err)
 	verifyResponseIsValid(t, rspCreate, err)
 
 	assert.NotEmpty(t, rspCreate.OpcRequestId)
-	assert.Equal(t, u.Id, rspCreate.UserId)
+	assert.Equal(t, user.Id, rspCreate.UserId)
 	assert.NotEmpty(t, rspCreate.Password)
 	assert.Equal(t, identity.UiPasswordLifecycleStateActive, rspCreate.LifecycleState)
 
@@ -369,10 +357,7 @@ func TestIdentityClient_SwiftPasswordCRUD(t *testing.T) {
 	c, clerr := identity.NewIdentityClientWithConfigurationProvider(common.DefaultConfigProvider())
 	failIfError(t, clerr)
 
-	usr, usrErr := createTestUser(c)
-	failIfError(t, usrErr)
-
-	defer deleteTestUser(c, usr.Id)
+	usr := createOrGetUser(t)
 
 	// Create Swift Password
 	addReq := identity.CreateSwiftPasswordRequest{UserId: usr.Id}
@@ -380,11 +365,13 @@ func TestIdentityClient_SwiftPasswordCRUD(t *testing.T) {
 	rspPwd, err := c.CreateSwiftPassword(context.Background(), addReq)
 	verifyResponseIsValid(t, rspPwd, err)
 
-	//Delete Swift Password
+	// Delete Swift Password
 	defer func() {
 		delReq := identity.DeleteSwiftPasswordRequest{}
 		delReq.UserId = usr.Id
 		delReq.SwiftPasswordId = rspPwd.Id
+		_, err := c.DeleteSwiftPassword(context.Background(), delReq)
+		failIfError(t, err)
 	}()
 
 	assert.NotEmpty(t, rspPwd.Id)
@@ -413,9 +400,26 @@ func TestIdentityClient_ListSwiftPasswords(t *testing.T) {
 	c, clerr := identity.NewIdentityClientWithConfigurationProvider(common.DefaultConfigProvider())
 	failIfError(t, clerr)
 
-	usr, usrErr := createTestUser(c)
-	failIfError(t, usrErr)
-	defer deleteTestUser(c, usr.Id)
+	usr := createOrGetUser(t)
+
+	request := identity.ListSwiftPasswordsRequest{UserId: usr.Id}
+	r, err := c.ListSwiftPasswords(context.Background(), request)
+	verifyResponseIsValid(t, r, err)
+
+	deletePwd := func(pwdId *string) {
+		delReq := identity.DeleteSwiftPasswordRequest{}
+		delReq.UserId = usr.Id
+		delReq.SwiftPasswordId = pwdId
+		_, err := c.DeleteSwiftPassword(context.Background(), delReq)
+		failIfError(t, err)
+	}
+
+	// delete password if already there
+	if len(r.Items) != 0 {
+		for _, item := range r.Items {
+			deletePwd(item.Id)
+		}
+	}
 
 	pwdReq := identity.CreateSwiftPasswordRequest{UserId: usr.Id}
 	pwdReq.Description = common.String("Test Swift Password 1")
@@ -426,13 +430,20 @@ func TestIdentityClient_ListSwiftPasswords(t *testing.T) {
 	pwdRsp2, err := c.CreateSwiftPassword(context.Background(), pwdReq)
 	verifyResponseIsValid(t, pwdRsp2, err)
 
-	request := identity.ListSwiftPasswordsRequest{UserId: usr.Id}
-	r, err := c.ListSwiftPasswords(context.Background(), request)
+	request = identity.ListSwiftPasswordsRequest{UserId: usr.Id}
+	r, err = c.ListSwiftPasswords(context.Background(), request)
 	verifyResponseIsValid(t, r, err)
-
 	assert.Equal(t, 2, len(r.Items))
 	assert.NotEqual(t, r.Items[0].Id, r.Items[1].Id)
 	assert.NotEqual(t, r.Items[0].Description, r.Items[1].Description)
+
+	// Delete Swift Password just created
+	defer func() {
+		pwdIDs := []*string{pwdRsp1.Id, pwdRsp2.Id}
+		for _, pwdID := range pwdIDs {
+			deletePwd(pwdID)
+		}
+	}()
 
 	return
 }
@@ -658,14 +669,7 @@ func TestIdentityClient_IdentityProviderCRUD(t *testing.T) {
 	assert.Equal(t, *rspCreate.GetId(), *rspUpdate.GetId())
 	assert.Equal(t, "New description", *rspUpdate.GetDescription())
 
-	// Create the group mapping
-	u, uErr := createTestUser(c)
-	failIfError(t, uErr)
-	defer deleteTestUser(c, u.Id)
-
-	g, gErr := createTestGroup(c)
-	failIfError(t, gErr)
-	defer deleteTestGroup(c, g.Id)
+	g := createOrGetTestGroup(t)
 
 	reqCreateMapping := identity.CreateIdpGroupMappingRequest{}
 	reqCreateMapping.IdentityProviderId = rspCreate.GetId()
@@ -862,9 +866,7 @@ func TestIdentityClient_ListRegions(t *testing.T) {
 func TestIdentityClient_UpdateUserState(t *testing.T) {
 	c, clerr := identity.NewIdentityClientWithConfigurationProvider(common.DefaultConfigProvider())
 	failIfError(t, clerr)
-	usr, usrErr := createTestUser(c)
-	failIfError(t, usrErr)
-	defer deleteTestUser(c, usr.Id)
+	usr := createOrGetUser(t)
 
 	request := identity.UpdateUserStateRequest{}
 	request.UserId = usr.Id

--- a/integtest/test_helpers.go
+++ b/integtest/test_helpers.go
@@ -245,15 +245,6 @@ func verifyResponseIsValid(t *testing.T, response interface{}, err error) {
 	assert.NoError(t, err)
 }
 
-func createTestUser(client identity.IdentityClient) (identity.User, error) {
-	req := identity.CreateUserRequest{}
-	req.CompartmentId = common.String(getTenancyID())
-	req.Name = common.String(getUniqueName("AUTG_User_"))
-	req.Description = common.String("GoSDK Test User")
-	rsp, err := client.CreateUser(context.Background(), req)
-	return rsp.User, err
-}
-
 func deleteTestUser(client identity.IdentityClient, userID *string) error {
 	req := identity.DeleteUserRequest{UserId: userID}
 	_, err := client.DeleteUser(context.Background(), req)
@@ -272,15 +263,6 @@ func readSampleFederationMetadata(t *testing.T) string {
 	bytes, e := ioutil.ReadFile("sampleFederationMetadata.xml")
 	failIfError(t, e)
 	return string(bytes)
-}
-
-func createTestGroup(client identity.IdentityClient) (identity.Group, error) {
-	req := identity.CreateGroupRequest{}
-	req.CompartmentId = common.String(getTenancyID())
-	req.Name = common.String(getUniqueName("Test_Group_"))
-	req.Description = common.String("Go SDK Test Group")
-	rsp, err := client.CreateGroup(context.Background(), req)
-	return rsp.Group, err
 }
 
 func deleteTestGroup(client identity.IdentityClient, groupId *string) error {

--- a/integtest/test_service_deps_helpers.go
+++ b/integtest/test_service_deps_helpers.go
@@ -36,6 +36,8 @@ const (
 	dbHomeDisplayName            = "GOSDK2_Test_Deps_DatabaseHome"
 	loadbalancerDisplayName      = "GOSDK2_Test_Deps_Loadbalancer"
 	volumeDisplayName            = "GOSDK2_Test_Deps_Volume"
+	testUserDisplayName          = "GOSDK2_Test_Deps_TestUser"
+	testGroupDisplayName         = "GOSDK2_Test_Deps_TestGroup"
 )
 
 // a helper method to either create a new vcn or get the one already exist
@@ -939,4 +941,74 @@ func listVolumes(t *testing.T) []core.Volume {
 
 	assert.NotEmpty(t, r)
 	return r.Items
+}
+
+func createOrGetUser(t *testing.T) identity.User {
+	c, clerr := identity.NewIdentityClientWithConfigurationProvider(common.DefaultConfigProvider())
+	failIfError(t, clerr)
+
+	listReq := identity.ListUsersRequest{
+		CompartmentId: common.String(getTenancyID()),
+		Limit:         common.Int(500), // not ideal here, but easy and reduce number of requests
+	}
+
+	listResp, err := c.ListUsers(context.Background(), listReq)
+	failIfError(t, err)
+
+	for _, user := range listResp.Items {
+		if *user.Name == testUserDisplayName {
+			// found test user, return it
+			return user
+		}
+	}
+
+	user := createTestUser(t, common.String(testUserDisplayName))
+	return user
+}
+
+func createTestUser(t *testing.T, name *string) identity.User {
+	c, clerr := identity.NewIdentityClientWithConfigurationProvider(common.DefaultConfigProvider())
+	failIfError(t, clerr)
+	req := identity.CreateUserRequest{}
+	req.CompartmentId = common.String(getTenancyID())
+	req.Name = name
+	req.Description = common.String("GoSDK Test User")
+	rsp, err := c.CreateUser(context.Background(), req)
+	failIfError(t, err)
+	return rsp.User
+}
+
+func createOrGetTestGroup(t *testing.T) identity.Group {
+	c, clerr := identity.NewIdentityClientWithConfigurationProvider(common.DefaultConfigProvider())
+	failIfError(t, clerr)
+
+	listReq := identity.ListGroupsRequest{
+		CompartmentId: common.String(getTenancyID()),
+		Limit:         common.Int(500),
+	}
+
+	listResp, err := c.ListGroups(context.Background(), listReq)
+	failIfError(t, err)
+
+	for _, group := range listResp.Items {
+		if *group.Name == testGroupDisplayName {
+			// found test group, return it
+			return group
+		}
+	}
+
+	group := createTestGroup(t, common.String(testGroupDisplayName))
+	return group
+}
+
+func createTestGroup(t *testing.T, name *string) identity.Group {
+	c, clerr := identity.NewIdentityClientWithConfigurationProvider(common.DefaultConfigProvider())
+	failIfError(t, clerr)
+	req := identity.CreateGroupRequest{}
+	req.CompartmentId = common.String(getTenancyID())
+	req.Name = name
+	req.Description = common.String("Go SDK Test Group")
+	rsp, err := c.CreateGroup(context.Background(), req)
+	failIfError(t, err)
+	return rsp.Group
 }


### PR DESCRIPTION
reduce the write operation to identity service in our integration tests.

re-use the test user and test group for this PR.