### PR TITLE
Pass missing retry policy options

### DIFF
--- a/audit/audit_client.go
+++ b/audit/audit_client.go
@@ -117,6 +117,7 @@ func (client AuditClient) UpdateConfiguration(ctx context.Context, request Updat
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -228,8 +228,12 @@ func TestBaseClient_CallWithInterceptor(t *testing.T) {
 
 	request := http.Request{}
 	request.URL = &url.URL{Path: restPath}
-	retRes, err := c.Call(context.Background(), &request)
-	assert.Equal(t, &response, retRes)
+	err := c.Call(context.Background(), &request, CallConfig{
+		ResponseCallback: func(retRes *http.Response, e error) error {
+			assert.Equal(t, &response, retRes)
+			return e
+		},
+	})
 	assert.NoError(t, err)
 
 }

--- a/core/core_blockstorage_client.go
+++ b/core/core_blockstorage_client.go
@@ -135,6 +135,7 @@ func (client BlockstorageClient) DeleteBootVolume(ctx context.Context, request D
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -158,6 +159,7 @@ func (client BlockstorageClient) DeleteVolume(ctx context.Context, request Delet
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -178,6 +180,7 @@ func (client BlockstorageClient) DeleteVolumeBackup(ctx context.Context, request
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }

--- a/core/core_compute_client.go
+++ b/core/core_compute_client.go
@@ -236,6 +236,7 @@ func (client ComputeClient) DeleteConsoleHistory(ctx context.Context, request De
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -256,6 +257,7 @@ func (client ComputeClient) DeleteImage(ctx context.Context, request DeleteImage
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -276,6 +278,7 @@ func (client ComputeClient) DeleteInstanceConsoleConnection(ctx context.Context,
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -298,6 +301,7 @@ func (client ComputeClient) DetachBootVolume(ctx context.Context, request Detach
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -326,6 +330,7 @@ func (client ComputeClient) DetachVnic(ctx context.Context, request DetachVnicRe
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -348,6 +353,7 @@ func (client ComputeClient) DetachVolume(ctx context.Context, request DetachVolu
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -866,6 +872,7 @@ func (client ComputeClient) TerminateInstance(ctx context.Context, request Termi
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }

--- a/core/core_virtualnetwork_client.go
+++ b/core/core_virtualnetwork_client.go
@@ -107,6 +107,7 @@ func (client VirtualNetworkClient) ConnectLocalPeeringGateways(ctx context.Conte
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -632,6 +633,7 @@ func (client VirtualNetworkClient) DeleteCpe(ctx context.Context, request Delete
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -653,6 +655,7 @@ func (client VirtualNetworkClient) DeleteCrossConnect(ctx context.Context, reque
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -675,6 +678,7 @@ func (client VirtualNetworkClient) DeleteCrossConnectGroup(ctx context.Context, 
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -698,6 +702,7 @@ func (client VirtualNetworkClient) DeleteDhcpOptions(ctx context.Context, reques
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -721,6 +726,7 @@ func (client VirtualNetworkClient) DeleteDrg(ctx context.Context, request Delete
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -743,6 +749,7 @@ func (client VirtualNetworkClient) DeleteDrgAttachment(ctx context.Context, requ
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -769,6 +776,7 @@ func (client VirtualNetworkClient) DeleteIPSecConnection(ctx context.Context, re
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -792,6 +800,7 @@ func (client VirtualNetworkClient) DeleteInternetGateway(ctx context.Context, re
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -814,6 +823,7 @@ func (client VirtualNetworkClient) DeleteLocalPeeringGateway(ctx context.Context
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -842,6 +852,7 @@ func (client VirtualNetworkClient) DeletePrivateIp(ctx context.Context, request 
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -865,6 +876,7 @@ func (client VirtualNetworkClient) DeleteRouteTable(ctx context.Context, request
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -888,6 +900,7 @@ func (client VirtualNetworkClient) DeleteSecurityList(ctx context.Context, reque
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -910,6 +923,7 @@ func (client VirtualNetworkClient) DeleteSubnet(ctx context.Context, request Del
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -932,6 +946,7 @@ func (client VirtualNetworkClient) DeleteVcn(ctx context.Context, request Delete
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -955,6 +970,7 @@ func (client VirtualNetworkClient) DeleteVirtualCircuit(ctx context.Context, req
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }

--- a/database/database_client.go
+++ b/database/database_client.go
@@ -174,6 +174,7 @@ func (client DatabaseClient) DeleteBackup(ctx context.Context, request DeleteBac
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -194,6 +195,7 @@ func (client DatabaseClient) DeleteDbHome(ctx context.Context, request DeleteDbH
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -794,6 +796,7 @@ func (client DatabaseClient) TerminateDbSystem(ctx context.Context, request Term
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }

--- a/identity/identity_client.go
+++ b/identity/identity_client.go
@@ -416,6 +416,7 @@ func (client IdentityClient) DeleteApiKey(ctx context.Context, request DeleteApi
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -436,6 +437,7 @@ func (client IdentityClient) DeleteCustomerSecretKey(ctx context.Context, reques
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -456,6 +458,7 @@ func (client IdentityClient) DeleteGroup(ctx context.Context, request DeleteGrou
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -477,6 +480,7 @@ func (client IdentityClient) DeleteIdentityProvider(ctx context.Context, request
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -497,6 +501,7 @@ func (client IdentityClient) DeleteIdpGroupMapping(ctx context.Context, request 
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -517,6 +522,7 @@ func (client IdentityClient) DeletePolicy(ctx context.Context, request DeletePol
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -537,6 +543,7 @@ func (client IdentityClient) DeleteSwiftPassword(ctx context.Context, request De
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -557,6 +564,7 @@ func (client IdentityClient) DeleteUser(ctx context.Context, request DeleteUserR
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -1088,6 +1096,7 @@ func (client IdentityClient) RemoveUserFromGroup(ctx context.Context, request Re
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }

--- a/loadbalancer/loadbalancer_client.go
+++ b/loadbalancer/loadbalancer_client.go
@@ -75,6 +75,7 @@ func (client LoadBalancerClient) CreateBackend(ctx context.Context, request Crea
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -95,6 +96,7 @@ func (client LoadBalancerClient) CreateBackendSet(ctx context.Context, request C
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -115,6 +117,7 @@ func (client LoadBalancerClient) CreateCertificate(ctx context.Context, request 
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -135,6 +138,7 @@ func (client LoadBalancerClient) CreateListener(ctx context.Context, request Cre
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -175,6 +179,7 @@ func (client LoadBalancerClient) CreateLoadBalancer(ctx context.Context, request
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -195,6 +200,7 @@ func (client LoadBalancerClient) DeleteBackend(ctx context.Context, request Dele
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -216,6 +222,7 @@ func (client LoadBalancerClient) DeleteBackendSet(ctx context.Context, request D
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -236,6 +243,7 @@ func (client LoadBalancerClient) DeleteCertificate(ctx context.Context, request 
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -256,6 +264,7 @@ func (client LoadBalancerClient) DeleteListener(ctx context.Context, request Del
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -276,6 +285,7 @@ func (client LoadBalancerClient) DeleteLoadBalancer(ctx context.Context, request
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -653,6 +663,7 @@ func (client LoadBalancerClient) UpdateBackend(ctx context.Context, request Upda
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -673,6 +684,7 @@ func (client LoadBalancerClient) UpdateBackendSet(ctx context.Context, request U
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -693,6 +705,7 @@ func (client LoadBalancerClient) UpdateHealthChecker(ctx context.Context, reques
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -713,6 +726,7 @@ func (client LoadBalancerClient) UpdateListener(ctx context.Context, request Upd
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -733,6 +747,7 @@ func (client LoadBalancerClient) UpdateLoadBalancer(ctx context.Context, request
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }

--- a/objectstorage/objectstorage_client.go
+++ b/objectstorage/objectstorage_client.go
@@ -85,6 +85,7 @@ func (client ObjectStorageClient) AbortMultipartUpload(ctx context.Context, requ
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -105,6 +106,7 @@ func (client ObjectStorageClient) CommitMultipartUpload(ctx context.Context, req
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -191,6 +193,7 @@ func (client ObjectStorageClient) DeleteBucket(ctx context.Context, request Dele
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -211,6 +214,7 @@ func (client ObjectStorageClient) DeleteObject(ctx context.Context, request Dele
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -231,6 +235,7 @@ func (client ObjectStorageClient) DeletePreauthenticatedRequest(ctx context.Cont
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -337,6 +342,7 @@ func (client ObjectStorageClient) HeadBucket(ctx context.Context, request HeadBu
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -357,6 +363,7 @@ func (client ObjectStorageClient) HeadObject(ctx context.Context, request HeadOb
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -492,6 +499,7 @@ func (client ObjectStorageClient) PutObject(ctx context.Context, request PutObje
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }
@@ -533,6 +541,7 @@ func (client ObjectStorageClient) UploadPart(ctx context.Context, request Upload
 
 			return common.UnmarshalResponse(httpResponse, &response)
 		},
+		RetryPolicyOptions: options,
 	})
 	return
 }


### PR DESCRIPTION
There are 285 operations that accept retry policy options as an argument; 61 out of them do not use that argument i.e. do not pass it internally to the common.Call function. This change addresses that by passing them correctly. Most of the occurrences are in load balancer. Most are also deletes/terminate operations. 

Please let me know if any of those should be left out intentionally & I'll remove the argument from the operation function signature.

Tests continue to pass successfully.