### PR TITLE
Fix for DebugLn not working with Terraform

### DIFF
--- a/common/log.go
+++ b/common/log.go
@@ -3,7 +3,6 @@ package common
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -17,34 +16,32 @@ var mainLog = log.New(os.Stderr, "", log.Ldate|log.Ltime|log.Lshortfile)
 var isDebugLogEnabled bool
 var checkDebug sync.Once
 
-func getOutputForEnv() (writer io.Writer) {
+func setOutputForEnv() {
 	checkDebug.Do(func() {
 		isDebugLogEnabled = *new(bool)
 		_, isDebugLogEnabled = os.LookupEnv("OCI_GO_SDK_DEBUG")
-	})
 
-	writer = ioutil.Discard
-	if isDebugLogEnabled {
-		writer = os.Stderr
-	}
-	return
+		if !isDebugLogEnabled {
+			debugLog.SetOutput(ioutil.Discard)
+		}
+	})
 }
 
 // Debugf logs v with the provided format if debug mode is set
 func Debugf(format string, v ...interface{}) {
-	debugLog.SetOutput(getOutputForEnv())
+	setOutputForEnv()
 	debugLog.Output(3, fmt.Sprintf(format, v...))
 }
 
 // Debug  logs v if debug mode is set
 func Debug(v ...interface{}) {
-	debugLog.SetOutput(getOutputForEnv())
+	setOutputForEnv()
 	debugLog.Output(3, fmt.Sprint(v...))
 }
 
 // Debugln logs v appending a new line if debug mode is set
 func Debugln(v ...interface{}) {
-	debugLog.SetOutput(getOutputForEnv())
+	setOutputForEnv()
 	debugLog.Output(3, fmt.Sprintln(v...))
 }
 


### PR DESCRIPTION
A different approach to tackle Ramy's issue (https://github.com/oracle/oci-go-sdk/pull/81):
> `DebugLn(...)` doesn't work with `TF_LOG=DEBUG OCI_GO_SDK=1 terraform <action>`

This solution fixes the issue while maintaining the original strategy of having separate log streams. 