### PR TITLE
resolves an issue where host is not in URL fixes #84

### DIFF
--- a/common/http_signer.go
+++ b/common/http_signer.go
@@ -95,6 +95,9 @@ func (signer ociRequestSigner) getSigningString(request *http.Request) string {
 			value = getRequestTarget(request)
 		case "host":
 			value = request.URL.Host
+			if len(value) == 0 {
+				value = request.Host
+			}
 		default:
 			value = request.Header.Get(part)
 		}

--- a/common/http_signer_test.go
+++ b/common/http_signer_test.go
@@ -80,6 +80,26 @@ func (kp testKeyProvider) KeyID() (string, error) {
 	return keyID, nil
 }
 
+func TestOCIRequestSigner_HTTPRequest(t *testing.T) {
+	s := ociRequestSigner{
+		KeyProvider:    testKeyProvider{},
+		GenericHeaders: defaultGenericHeaders,
+		ShouldHashBody: defaultBodyHashPredicate,
+		BodyHeaders:    defaultBodyHeaders,
+	}
+
+	r, err := http.NewRequest("GET", "http://localhost:7000/api", nil)
+	assert.NoError(t, err)
+
+	r.Header.Set("Date", "Thu, 05 Jan 2014 21:31:40 GMT")
+
+	err = s.Sign(r)
+	assert.NoError(t, err)
+
+	signature := s.getSigningString(r)
+	assert.Equal(t, "date: Thu, 05 Jan 2014 21:31:40 GMT\n(request-target): get /api\nhost: localhost:7000", signature)
+}
+
 func TestOCIRequestSigner_SigningString(t *testing.T) {
 	s := ociRequestSigner{
 		KeyProvider:    testKeyProvider{},


### PR DESCRIPTION
request.URL.Host is rebuilt from the URL. When the host
is not present in the URL, it results in an empty host.
This causes the request signing to fail and is not easily
resolvable in client code. URL.Host also can not be set
via the Host Header whereas request.Host will look at this
header.