### PR TITLE
Add additional helper functions for dealing with pointer values

### DIFF
--- a/common/helpers.go
+++ b/common/helpers.go
@@ -17,9 +17,25 @@ func String(value string) *string {
 	return &value
 }
 
+// GetString returns the zero value for a pointer to string
+func GetString(value *string) string {
+	if value != nil {
+		return *value
+	}
+	return ""
+}
+
 // Int returns a pointer to the provided int
 func Int(value int) *int {
 	return &value
+}
+
+// GetInt returns the zero value for a pointer to int
+func GetInt(value *int) int {
+	if value == nil {
+		return *value
+	}
+	return 0
 }
 
 // Uint returns a pointer to the provided uint
@@ -27,24 +43,48 @@ func Uint(value uint) *uint {
 	return &value
 }
 
-//Float32 returns a pointer to the provided float32
+// Float32 returns a pointer to the provided float32
 func Float32(value float32) *float32 {
 	return &value
 }
 
-//Float64 returns a pointer to the provided float64
+// GetFloat32 returns the zero value for a pointer to float32
+func GetFloat32(value *float32) float32 {
+	if value == nil {
+		return *value
+	}
+	return 0
+}
+
+// Float64 returns a pointer to the provided float64
 func Float64(value float64) *float64 {
 	return &value
 }
 
-//Bool returns a pointer to the provided bool
+// GetFloat64 returns the zero value for a pointer to float64
+func GetFloat64(value *float64) float64 {
+	if value == nil {
+		return *value
+	}
+	return 0
+}
+
+// Bool returns a pointer to the provided bool
 func Bool(value bool) *bool {
 	return &value
 }
 
-//PointerString prints the values of pointers in a struct
-//Producing a human friendly string for an struct with pointers.
-//useful when debugging the values of a struct
+// GetBool returns the zero value for a pointer to bool
+func GetBool(value *bool) bool {
+	if value != nil {
+		return *value
+	}
+	return false
+}
+
+// PointerString prints the values of pointers in a struct
+// Producing a human friendly string for an struct with pointers.
+// useful when debugging the values of a struct
 func PointerString(datastruct interface{}) (representation string) {
 	val := reflect.ValueOf(datastruct)
 	typ := reflect.TypeOf(datastruct)


### PR DESCRIPTION
When using the SDK we often have a need to do verbose error checking since the SDK returns pointers everywhere. This change adds some helper functions to make this easier to deal with.