### PR TITLE
Add support for service principals

### DIFF
--- a/common/auth/federation_client.go
+++ b/common/auth/federation_client.go
@@ -33,15 +33,15 @@ type x509FederationClient struct {
 	securityToken                     securityToken
 	authClient                        *common.BaseClient
 	mux                               sync.Mutex
-	refresh                           bool
+	validateTenancyID                 bool
 }
 
-func newX509FederationClient(region common.Region, tenancyID string, leafCertificateRetriever x509CertificateRetriever, intermediateCertificateRetrievers []x509CertificateRetriever, refresh bool) federationClient {
+func newX509FederationClient(region common.Region, tenancyID string, leafCertificateRetriever x509CertificateRetriever, intermediateCertificateRetrievers []x509CertificateRetriever, validateTenancyID bool) federationClient {
 	client := &x509FederationClient{
 		tenancyID:                         tenancyID,
 		leafCertificateRetriever:          leafCertificateRetriever,
 		intermediateCertificateRetrievers: intermediateCertificateRetrievers,
-		refresh: refresh,
+		validateTenancyID:                 validateTenancyID,
 	}
 	client.sessionKeySupplier = newSessionKeySupplier()
 	client.authClient = newAuthClient(region, client)
@@ -112,7 +112,7 @@ func (c *x509FederationClient) renewSecurityToken() (err error) {
 		return fmt.Errorf("failed to refresh leaf certificate: %s", err.Error())
 	}
 
-	if c.refresh {
+	if c.validateTenancyID {
 		updatedTenancyID := extractTenancyIDFromCertificate(c.leafCertificateRetriever.Certificate())
 		if c.tenancyID != updatedTenancyID {
 			err = fmt.Errorf("unexpected update of tenancy OCID in the leaf certificate. Previous tenancy: %s, Updated: %s", c.tenancyID, updatedTenancyID)

--- a/common/auth/federation_client.go
+++ b/common/auth/federation_client.go
@@ -10,13 +10,14 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"github.com/oracle/oci-go-sdk/common"
 	"net/http"
 	"strings"
 	"sync"
+
+	"github.com/oracle/oci-go-sdk/common"
 )
 
-// federationClient is a client to retrieve the security token for an instance principal necessary to sign a request.
+// federationClient is a client to retrieve the security token necessary to sign a request.
 // It also provides the private key whose corresponding public key is used to retrieve the security token.
 type federationClient interface {
 	PrivateKey() (*rsa.PrivateKey, error)
@@ -32,16 +33,19 @@ type x509FederationClient struct {
 	securityToken                     securityToken
 	authClient                        *common.BaseClient
 	mux                               sync.Mutex
+	refresh                           bool
 }
 
-func newX509FederationClient(region common.Region, tenancyID string, leafCertificateRetriever x509CertificateRetriever, intermediateCertificateRetrievers []x509CertificateRetriever) federationClient {
+func newX509FederationClient(region common.Region, tenancyID string, leafCertificateRetriever x509CertificateRetriever, intermediateCertificateRetrievers []x509CertificateRetriever, refresh bool) federationClient {
 	client := &x509FederationClient{
 		tenancyID:                         tenancyID,
 		leafCertificateRetriever:          leafCertificateRetriever,
 		intermediateCertificateRetrievers: intermediateCertificateRetrievers,
+		refresh: refresh,
 	}
 	client.sessionKeySupplier = newSessionKeySupplier()
 	client.authClient = newAuthClient(region, client)
+
 	return client
 }
 
@@ -108,10 +112,12 @@ func (c *x509FederationClient) renewSecurityToken() (err error) {
 		return fmt.Errorf("failed to refresh leaf certificate: %s", err.Error())
 	}
 
-	updatedTenancyID := extractTenancyIDFromCertificate(c.leafCertificateRetriever.Certificate())
-	if c.tenancyID != updatedTenancyID {
-		err = fmt.Errorf("unexpected update of tenancy OCID in the leaf certificate. Previous tenancy: %s, Updated: %s", c.tenancyID, updatedTenancyID)
-		return
+	if c.refresh {
+		updatedTenancyID := extractTenancyIDFromCertificate(c.leafCertificateRetriever.Certificate())
+		if c.tenancyID != updatedTenancyID {
+			err = fmt.Errorf("unexpected update of tenancy OCID in the leaf certificate. Previous tenancy: %s, Updated: %s", c.tenancyID, updatedTenancyID)
+			return
+		}
 	}
 
 	for _, retriever := range c.intermediateCertificateRetrievers {
@@ -147,7 +153,7 @@ func (c *x509FederationClient) getSecurityToken() (securityToken, error) {
 		return nil, fmt.Errorf("failed to unmarshal the response: %s", err.Error())
 	}
 
-	return newInstancePrincipalToken(response.Token.Token)
+	return newToken(response.Token.Token)
 }
 
 type x509FederationRequest struct {
@@ -266,23 +272,23 @@ type securityToken interface {
 	Valid() bool
 }
 
-type instancePrincipalToken struct {
+type token struct {
 	tokenString string
 	jwtToken    *jwtToken
 }
 
-func newInstancePrincipalToken(tokenString string) (newToken securityToken, err error) {
+func newToken(tokenString string) (newToken securityToken, err error) {
 	var jwtToken *jwtToken
 	if jwtToken, err = parseJwt(tokenString); err != nil {
 		return nil, fmt.Errorf("failed to parse the token string \"%s\": %s", tokenString, err.Error())
 	}
-	return &instancePrincipalToken{tokenString, jwtToken}, nil
+	return &token{tokenString, jwtToken}, nil
 }
 
-func (t *instancePrincipalToken) String() string {
+func (t *token) String() string {
 	return t.tokenString
 }
 
-func (t *instancePrincipalToken) Valid() bool {
+func (t *token) Valid() bool {
 	return !t.jwtToken.expired()
 }

--- a/common/auth/instance_principal_key_provider.go
+++ b/common/auth/instance_principal_key_provider.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"crypto/rsa"
 	"fmt"
+
 	"github.com/oracle/oci-go-sdk/common"
 )
 
@@ -59,7 +60,7 @@ func newInstancePrincipalKeyProvider() (provider *instancePrincipalKeyProvider, 
 	tenancyID := extractTenancyIDFromCertificate(leafCertificateRetriever.Certificate())
 
 	federationClient := newX509FederationClient(
-		region, tenancyID, leafCertificateRetriever, intermediateCertificateRetrievers)
+		region, tenancyID, leafCertificateRetriever, intermediateCertificateRetrievers, true)
 
 	provider = &instancePrincipalKeyProvider{regionForFederationClient: region, federationClient: federationClient}
 	return

--- a/common/auth/service_principal_configuration_provider.go
+++ b/common/auth/service_principal_configuration_provider.go
@@ -1,0 +1,47 @@
+package auth
+
+import (
+	"crypto/rsa"
+	"fmt"
+
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+type servicePrincipalConfigurationProvider struct {
+	keyProvider *servicePrincipalKeyProvider
+	region      string
+}
+
+// NewServicePrincipalConfigurationProvider will create a new service principal configuration provider
+func NewServicePrincipalConfigurationProvider(tenancyID, region, cert, key string, intermediates []string, passphrase *string) (common.ConfigurationProvider, error) {
+	var err error
+	var keyProvider *servicePrincipalKeyProvider
+	if keyProvider, err = newServicePrincipalKeyProvider(tenancyID, region, cert, key, intermediates, passphrase); err != nil {
+		return nil, fmt.Errorf("failed to create a new key provider: %s", err.Error())
+	}
+	return servicePrincipalConfigurationProvider{keyProvider: keyProvider, region: region}, nil
+}
+
+func (p servicePrincipalConfigurationProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
+	return p.keyProvider.PrivateRSAKey()
+}
+
+func (p servicePrincipalConfigurationProvider) KeyID() (string, error) {
+	return p.keyProvider.KeyID()
+}
+
+func (p servicePrincipalConfigurationProvider) TenancyOCID() (string, error) {
+	return "", nil
+}
+
+func (p servicePrincipalConfigurationProvider) UserOCID() (string, error) {
+	return "", nil
+}
+
+func (p servicePrincipalConfigurationProvider) KeyFingerprint() (string, error) {
+	return "", nil
+}
+
+func (p servicePrincipalConfigurationProvider) Region() (string, error) {
+	return p.region, nil
+}

--- a/common/auth/service_principal_key_provider.go
+++ b/common/auth/service_principal_key_provider.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+
+package auth
+
+import (
+	"crypto/rsa"
+	"fmt"
+
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+type servicePrincipalKeyProvider struct {
+	federationClient federationClient
+}
+
+func newServicePrincipalKeyProvider(tenancyID, region, cert, key string, intermediates []string, passphrase *string) (provider *servicePrincipalKeyProvider, err error) {
+	leafCertificateRetriever := newStaticX509CertificateRetriever([]byte(cert), []byte(key), passphrase)
+
+	intermediateCertificateRetrievers := []x509CertificateRetriever{}
+	for _, intermediate := range intermediates {
+		intermediateCertificateRetrievers =
+			append(intermediateCertificateRetrievers, newStaticX509CertificateRetriever([]byte(intermediate), []byte(key), passphrase))
+	}
+
+	federationClient := newX509FederationClient(
+		common.Region(region), tenancyID, leafCertificateRetriever, intermediateCertificateRetrievers, false)
+
+	provider = &servicePrincipalKeyProvider{federationClient: federationClient}
+	return
+}
+
+func (p *servicePrincipalKeyProvider) PrivateRSAKey() (privateKey *rsa.PrivateKey, err error) {
+	if privateKey, err = p.federationClient.PrivateKey(); err != nil {
+		err = fmt.Errorf("failed to get private key: %s", err.Error())
+		return nil, err
+	}
+	return privateKey, nil
+}
+
+func (p *servicePrincipalKeyProvider) KeyID() (string, error) {
+	var securityToken string
+	var err error
+	if securityToken, err = p.federationClient.SecurityToken(); err != nil {
+		return "", fmt.Errorf("failed to get security token: %s", err.Error())
+	}
+
+	return fmt.Sprintf("ST$%s", securityToken), nil
+}


### PR DESCRIPTION
This change adds support for service principals to the oci-go-sdk. Requires tests but awaiting feedback on approach first. 

This works for me locally using valid certificates.

Example use:

```go
func main() {
	p, _ := auth.NewServicePrincipalConfigurationProvider(tenancy, region, cert, key, intermediates, &passphrase)
	c, _ := identity.NewIdentityClientWithConfigurationProvider(p)
	request := identity.ListAvailabilityDomainsRequest{
		CompartmentId: common.String("ocid1.tenancy.oc1..."),
	}
	response, _ := c.ListAvailabilityDomains(context.Background(), request)
	fmt.Printf("Response %+v", response)
}
```