### PR TITLE
Implement support for signing patch requests

### DIFF
--- a/common/http_signer.go
+++ b/common/http_signer.go
@@ -46,7 +46,7 @@ var (
 	defaultGenericHeaders    = []string{"date", "(request-target)", "host"}
 	defaultBodyHeaders       = []string{"content-length", "content-type", "x-content-sha256"}
 	defaultBodyHashPredicate = func(r *http.Request) bool {
-		return r.Method == http.MethodPost || r.Method == http.MethodPut
+		return r.Method == http.MethodPost || r.Method == http.MethodPut || r.Method == http.MethodPatch
 	}
 )
 


### PR DESCRIPTION
We encountered an issue where HTTP PATCH requests were not being signed. The change here will ensure that patch requests are signed correctly. 