### PR TITLE
GO SDK 5.9.0 Release 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## 5.9.0 - 2019-06-04
+### Added
+- Support for autoscaling autonomous databases and autonomous data warehouses in the Database service
+- Support for specifying fault domains as part of instance configurations in the Compute Autoscaling service
+- Support for deleting tag definitions and tag namespaces in the Identity service
+
+### Fixed
+- Support for regions in realms other than oraclecloud.com in the Load Balancing service
+
 ## 5.8.0 - 2019-05-28
 ### Added
 - Support for the Work Requests service, and tracking of a number of Core Services operations through work requests

--- a/common/version.go
+++ b/common/version.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	major = "5"
-	minor = "8"
+	minor = "9"
 	patch = "0"
 	tag   = ""
 )

--- a/core/attach_boot_volume_request_response.go
+++ b/core/attach_boot_volume_request_response.go
@@ -56,8 +56,8 @@ type AttachBootVolumeResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/attach_load_balancer_request_response.go
+++ b/core/attach_load_balancer_request_response.go
@@ -64,8 +64,8 @@ type AttachLoadBalancerResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/attach_service_id_request_response.go
+++ b/core/attach_service_id_request_response.go
@@ -54,8 +54,8 @@ type AttachServiceIdResponse struct {
 	// The ServiceGateway instance
 	ServiceGateway `presentIn:"body"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/attach_vnic_request_response.go
+++ b/core/attach_vnic_request_response.go
@@ -56,8 +56,8 @@ type AttachVnicResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/attach_volume_request_response.go
+++ b/core/attach_volume_request_response.go
@@ -56,8 +56,8 @@ type AttachVolumeResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/boot_volume.go
+++ b/core/boot_volume.go
@@ -46,8 +46,8 @@ type BootVolume struct {
 	// The date and time the boot volume was created. Format defined by RFC3339.
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -56,8 +56,7 @@ type BootVolume struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/boot_volume_backup.go
+++ b/core/boot_volume_backup.go
@@ -47,8 +47,8 @@ type BootVolumeBackup struct {
 	// The OCID of the boot volume.
 	BootVolumeId *string `mandatory:"false" json:"bootVolumeId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -60,8 +60,7 @@ type BootVolumeBackup struct {
 	ExpirationTime *common.SDKTime `mandatory:"false" json:"expirationTime"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/capture_console_history_details.go
+++ b/core/capture_console_history_details.go
@@ -22,8 +22,8 @@ type CaptureConsoleHistoryDetails struct {
 	// The OCID of the instance to get the console history from.
 	InstanceId *string `mandatory:"true" json:"instanceId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -31,8 +31,7 @@ type CaptureConsoleHistoryDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/capture_console_history_request_response.go
+++ b/core/capture_console_history_request_response.go
@@ -56,8 +56,8 @@ type CaptureConsoleHistoryResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/connect_local_peering_gateways_request_response.go
+++ b/core/connect_local_peering_gateways_request_response.go
@@ -46,8 +46,8 @@ type ConnectLocalPeeringGatewaysResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/connect_remote_peering_connections_request_response.go
+++ b/core/connect_remote_peering_connections_request_response.go
@@ -46,8 +46,8 @@ type ConnectRemotePeeringConnectionsResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/console_history.go
+++ b/core/console_history.go
@@ -43,8 +43,8 @@ type ConsoleHistory struct {
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -54,8 +54,7 @@ type ConsoleHistory struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/copy_volume_backup_request_response.go
+++ b/core/copy_volume_backup_request_response.go
@@ -59,8 +59,8 @@ type CopyVolumeBackupResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/cpe.go
+++ b/core/cpe.go
@@ -37,8 +37,8 @@ type Cpe struct {
 	// The public IP address of the on-premises router.
 	IpAddress *string `mandatory:"true" json:"ipAddress"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -47,8 +47,7 @@ type Cpe struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/create_app_catalog_subscription_request_response.go
+++ b/core/create_app_catalog_subscription_request_response.go
@@ -56,8 +56,8 @@ type CreateAppCatalogSubscriptionResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_boot_volume_backup_details.go
+++ b/core/create_boot_volume_backup_details.go
@@ -22,8 +22,8 @@ type CreateBootVolumeBackupDetails struct {
 	// The OCID of the boot volume that needs to be backed up.
 	BootVolumeId *string `mandatory:"true" json:"bootVolumeId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -32,8 +32,7 @@ type CreateBootVolumeBackupDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/create_boot_volume_backup_request_response.go
+++ b/core/create_boot_volume_backup_request_response.go
@@ -56,8 +56,8 @@ type CreateBootVolumeBackupResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_boot_volume_details.go
+++ b/core/create_boot_volume_details.go
@@ -35,8 +35,8 @@ type CreateBootVolumeDetails struct {
 	// created boot volume. If omitted, no policy will be assigned.
 	BackupPolicyId *string `mandatory:"false" json:"backupPolicyId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -45,8 +45,7 @@ type CreateBootVolumeDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/create_boot_volume_request_response.go
+++ b/core/create_boot_volume_request_response.go
@@ -56,8 +56,8 @@ type CreateBootVolumeResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_cpe_details.go
+++ b/core/create_cpe_details.go
@@ -26,8 +26,8 @@ type CreateCpeDetails struct {
 	// Example: `143.19.23.16`
 	IpAddress *string `mandatory:"true" json:"ipAddress"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -35,8 +35,7 @@ type CreateCpeDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/create_cpe_request_response.go
+++ b/core/create_cpe_request_response.go
@@ -56,8 +56,8 @@ type CreateCpeResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_cross_connect_group_request_response.go
+++ b/core/create_cross_connect_group_request_response.go
@@ -56,8 +56,8 @@ type CreateCrossConnectGroupResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_cross_connect_request_response.go
+++ b/core/create_cross_connect_request_response.go
@@ -56,8 +56,8 @@ type CreateCrossConnectResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_dhcp_details.go
+++ b/core/create_dhcp_details.go
@@ -29,8 +29,8 @@ type CreateDhcpDetails struct {
 	// The OCID of the VCN the set of DHCP options belongs to.
 	VcnId *string `mandatory:"true" json:"vcnId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -38,8 +38,7 @@ type CreateDhcpDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/create_dhcp_options_request_response.go
+++ b/core/create_dhcp_options_request_response.go
@@ -56,8 +56,8 @@ type CreateDhcpOptionsResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_drg_attachment_request_response.go
+++ b/core/create_drg_attachment_request_response.go
@@ -56,8 +56,8 @@ type CreateDrgAttachmentResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_drg_details.go
+++ b/core/create_drg_details.go
@@ -22,8 +22,8 @@ type CreateDrgDetails struct {
 	// The OCID of the compartment to contain the DRG.
 	CompartmentId *string `mandatory:"true" json:"compartmentId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -31,8 +31,7 @@ type CreateDrgDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/create_drg_request_response.go
+++ b/core/create_drg_request_response.go
@@ -56,8 +56,8 @@ type CreateDrgResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_i_p_sec_connection_request_response.go
+++ b/core/create_i_p_sec_connection_request_response.go
@@ -56,8 +56,8 @@ type CreateIPSecConnectionResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_image_details.go
+++ b/core/create_image_details.go
@@ -23,8 +23,8 @@ type CreateImageDetails struct {
 	// The OCID of the compartment containing the instance you want to use as the basis for the image.
 	CompartmentId *string `mandatory:"true" json:"compartmentId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -35,8 +35,7 @@ type CreateImageDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/create_image_request_response.go
+++ b/core/create_image_request_response.go
@@ -56,8 +56,8 @@ type CreateImageResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 
 	// The OCID of the work request. Use GetWorkRequest

--- a/core/create_instance_configuration_details.go
+++ b/core/create_instance_configuration_details.go
@@ -25,8 +25,8 @@ type CreateInstanceConfigurationDetails struct {
 
 	InstanceDetails InstanceConfigurationInstanceDetails `mandatory:"true" json:"instanceDetails"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -34,8 +34,7 @@ type CreateInstanceConfigurationDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/create_instance_configuration_request_response.go
+++ b/core/create_instance_configuration_request_response.go
@@ -56,8 +56,8 @@ type CreateInstanceConfigurationResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_instance_console_connection_details.go
+++ b/core/create_instance_console_connection_details.go
@@ -26,14 +26,13 @@ type CreateInstanceConsoleConnectionDetails struct {
 	// The SSH public key used to authenticate the console connection.
 	PublicKey *string `mandatory:"true" json:"publicKey"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/create_instance_console_connection_request_response.go
+++ b/core/create_instance_console_connection_request_response.go
@@ -56,8 +56,8 @@ type CreateInstanceConsoleConnectionResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_instance_pool_details.go
+++ b/core/create_instance_pool_details.go
@@ -35,8 +35,8 @@ type CreateInstancePoolDetails struct {
 	// The number of instances that should be in the instance pool.
 	Size *int `mandatory:"true" json:"size"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -44,8 +44,7 @@ type CreateInstancePoolDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/create_instance_pool_request_response.go
+++ b/core/create_instance_pool_request_response.go
@@ -56,8 +56,8 @@ type CreateInstancePoolResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_internet_gateway_details.go
+++ b/core/create_internet_gateway_details.go
@@ -28,8 +28,8 @@ type CreateInternetGatewayDetails struct {
 	// The OCID of the VCN the internet gateway is attached to.
 	VcnId *string `mandatory:"true" json:"vcnId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -37,8 +37,7 @@ type CreateInternetGatewayDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/create_internet_gateway_request_response.go
+++ b/core/create_internet_gateway_request_response.go
@@ -56,8 +56,8 @@ type CreateInternetGatewayResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_ip_sec_connection_details.go
+++ b/core/create_ip_sec_connection_details.go
@@ -39,8 +39,8 @@ type CreateIpSecConnectionDetails struct {
 	// Example: `10.0.1.0/24`
 	StaticRoutes []string `mandatory:"true" json:"staticRoutes"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -48,8 +48,7 @@ type CreateIpSecConnectionDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 
@@ -58,6 +57,8 @@ type CreateIpSecConnectionDetails struct {
 	// to the value for `cpeLocalIdentifierType`.
 	// If you don't provide a value, the `ipAddress` attribute for the Cpe
 	// object specified by `cpeId` is used as the `cpeLocalIdentifier`.
+	// For information about why you'd provide this value, see
+	// If Your CPE Is Behind a NAT Device (https://docs.cloud.oracle.com/Content/Network/Tasks/overviewIPsec.htm#nat).
 	// Example IP address: `10.0.3.3`
 	// Example hostname: `cpe.example.com`
 	CpeLocalIdentifier *string `mandatory:"false" json:"cpeLocalIdentifier"`

--- a/core/create_ip_sec_connection_tunnel_details.go
+++ b/core/create_ip_sec_connection_tunnel_details.go
@@ -26,10 +26,11 @@ type CreateIpSecConnectionTunnelDetails struct {
 	// The type of routing to use for this tunnel (either BGP dynamic routing or static routing).
 	Routing CreateIpSecConnectionTunnelDetailsRoutingEnum `mandatory:"false" json:"routing,omitempty"`
 
-	// The shared secret (pre-shared key) to use for the IPSec tunnel. If you don't provide a value,
+	// The shared secret (pre-shared key) to use for the IPSec tunnel. Only numbers, letters, and
+	// spaces are allowed. If you don't provide a value,
 	// Oracle generates a value for you. You can specify your own shared secret later if
 	// you like with UpdateIPSecConnectionTunnelSharedSecret.
-	// Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
+	// Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
 	SharedSecret *string `mandatory:"false" json:"sharedSecret"`
 
 	// Information for establishing a BGP session for the IPSec tunnel. Required if the tunnel uses

--- a/core/create_local_peering_gateway_details.go
+++ b/core/create_local_peering_gateway_details.go
@@ -25,8 +25,8 @@ type CreateLocalPeeringGatewayDetails struct {
 	// The OCID of the VCN the LPG belongs to.
 	VcnId *string `mandatory:"true" json:"vcnId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -35,8 +35,7 @@ type CreateLocalPeeringGatewayDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/create_local_peering_gateway_request_response.go
+++ b/core/create_local_peering_gateway_request_response.go
@@ -56,8 +56,8 @@ type CreateLocalPeeringGatewayResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_nat_gateway_details.go
+++ b/core/create_nat_gateway_details.go
@@ -26,8 +26,8 @@ type CreateNatGatewayDetails struct {
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN the gateway belongs to.
 	VcnId *string `mandatory:"true" json:"vcnId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -36,8 +36,7 @@ type CreateNatGatewayDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/create_nat_gateway_request_response.go
+++ b/core/create_nat_gateway_request_response.go
@@ -56,8 +56,8 @@ type CreateNatGatewayResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_private_ip_details.go
+++ b/core/create_private_ip_details.go
@@ -23,8 +23,8 @@ type CreatePrivateIpDetails struct {
 	// must be in the same subnet.
 	VnicId *string `mandatory:"true" json:"vnicId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -33,8 +33,7 @@ type CreatePrivateIpDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/create_private_ip_request_response.go
+++ b/core/create_private_ip_request_response.go
@@ -56,8 +56,8 @@ type CreatePrivateIpResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_public_ip_details.go
+++ b/core/create_public_ip_details.go
@@ -28,8 +28,8 @@ type CreatePublicIpDetails struct {
 	// Public IP Addresses (https://docs.cloud.oracle.com/Content/Network/Tasks/managingpublicIPs.htm).
 	Lifetime CreatePublicIpDetailsLifetimeEnum `mandatory:"true" json:"lifetime"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -38,8 +38,7 @@ type CreatePublicIpDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/create_public_ip_request_response.go
+++ b/core/create_public_ip_request_response.go
@@ -56,8 +56,8 @@ type CreatePublicIpResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_remote_peering_connection_request_response.go
+++ b/core/create_remote_peering_connection_request_response.go
@@ -56,8 +56,8 @@ type CreateRemotePeeringConnectionResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_route_table_details.go
+++ b/core/create_route_table_details.go
@@ -28,8 +28,8 @@ type CreateRouteTableDetails struct {
 	// The OCID of the VCN the route table belongs to.
 	VcnId *string `mandatory:"true" json:"vcnId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -37,8 +37,7 @@ type CreateRouteTableDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/create_route_table_request_response.go
+++ b/core/create_route_table_request_response.go
@@ -56,8 +56,8 @@ type CreateRouteTableResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_security_list_details.go
+++ b/core/create_security_list_details.go
@@ -31,8 +31,8 @@ type CreateSecurityListDetails struct {
 	// The OCID of the VCN the security list belongs to.
 	VcnId *string `mandatory:"true" json:"vcnId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -40,8 +40,7 @@ type CreateSecurityListDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/create_security_list_request_response.go
+++ b/core/create_security_list_request_response.go
@@ -56,8 +56,8 @@ type CreateSecurityListResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_service_gateway_details.go
+++ b/core/create_service_gateway_details.go
@@ -35,8 +35,8 @@ type CreateServiceGatewayDetails struct {
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
 	VcnId *string `mandatory:"true" json:"vcnId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -45,8 +45,7 @@ type CreateServiceGatewayDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/create_service_gateway_request_response.go
+++ b/core/create_service_gateway_request_response.go
@@ -53,8 +53,8 @@ type CreateServiceGatewayResponse struct {
 	// The ServiceGateway instance
 	ServiceGateway `presentIn:"body"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_subnet_details.go
+++ b/core/create_subnet_details.go
@@ -41,8 +41,8 @@ type CreateSubnetDetails struct {
 	// Example: `Uocm:PHX-AD-1`
 	AvailabilityDomain *string `mandatory:"false" json:"availabilityDomain"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -67,8 +67,7 @@ type CreateSubnetDetails struct {
 	DnsLabel *string `mandatory:"false" json:"dnsLabel"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/create_subnet_request_response.go
+++ b/core/create_subnet_request_response.go
@@ -56,8 +56,8 @@ type CreateSubnetResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_vcn_details.go
+++ b/core/create_vcn_details.go
@@ -26,8 +26,8 @@ type CreateVcnDetails struct {
 	// The OCID of the compartment to contain the VCN.
 	CompartmentId *string `mandatory:"true" json:"compartmentId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -49,8 +49,7 @@ type CreateVcnDetails struct {
 	DnsLabel *string `mandatory:"false" json:"dnsLabel"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/create_vcn_request_response.go
+++ b/core/create_vcn_request_response.go
@@ -56,8 +56,8 @@ type CreateVcnResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_virtual_circuit_request_response.go
+++ b/core/create_virtual_circuit_request_response.go
@@ -56,8 +56,8 @@ type CreateVirtualCircuitResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_vnic_details.go
+++ b/core/create_vnic_details.go
@@ -47,8 +47,8 @@ type CreateVnicDetails struct {
 	// Example: `false`
 	AssignPublicIp *bool `mandatory:"false" json:"assignPublicIp"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -57,8 +57,7 @@ type CreateVnicDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/create_volume_backup_details.go
+++ b/core/create_volume_backup_details.go
@@ -22,8 +22,8 @@ type CreateVolumeBackupDetails struct {
 	// The OCID of the volume that needs to be backed up.
 	VolumeId *string `mandatory:"true" json:"volumeId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -32,8 +32,7 @@ type CreateVolumeBackupDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/create_volume_backup_policy_assignment_request_response.go
+++ b/core/create_volume_backup_policy_assignment_request_response.go
@@ -49,8 +49,8 @@ type CreateVolumeBackupPolicyAssignmentResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_volume_backup_request_response.go
+++ b/core/create_volume_backup_request_response.go
@@ -56,8 +56,8 @@ type CreateVolumeBackupResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_volume_details.go
+++ b/core/create_volume_details.go
@@ -31,8 +31,8 @@ type CreateVolumeDetails struct {
 	// created volume. If omitted, no policy will be assigned.
 	BackupPolicyId *string `mandatory:"false" json:"backupPolicyId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -41,8 +41,7 @@ type CreateVolumeDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/create_volume_group_backup_details.go
+++ b/core/create_volume_group_backup_details.go
@@ -25,8 +25,8 @@ type CreateVolumeGroupBackupDetails struct {
 	// The OCID of the compartment that will contain the volume group backup. This parameter is optional, by default backup will be created in the same compartment and source volume group.
 	CompartmentId *string `mandatory:"false" json:"compartmentId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -34,8 +34,7 @@ type CreateVolumeGroupBackupDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/create_volume_group_backup_request_response.go
+++ b/core/create_volume_group_backup_request_response.go
@@ -56,8 +56,8 @@ type CreateVolumeGroupBackupResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_volume_group_details.go
+++ b/core/create_volume_group_details.go
@@ -30,8 +30,8 @@ type CreateVolumeGroupDetails struct {
 	// volume ids in the same availability domain, another volume group or a volume group backup.
 	SourceDetails VolumeGroupSourceDetails `mandatory:"true" json:"sourceDetails"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -39,8 +39,7 @@ type CreateVolumeGroupDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/create_volume_group_request_response.go
+++ b/core/create_volume_group_request_response.go
@@ -56,8 +56,8 @@ type CreateVolumeGroupResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/create_volume_request_response.go
+++ b/core/create_volume_request_response.go
@@ -56,8 +56,8 @@ type CreateVolumeResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_app_catalog_subscription_request_response.go
+++ b/core/delete_app_catalog_subscription_request_response.go
@@ -14,7 +14,7 @@ type DeleteAppCatalogSubscriptionRequest struct {
 	// The OCID of the listing.
 	ListingId *string `mandatory:"true" contributesTo:"query" name:"listingId"`
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// Listing Resource Version.
@@ -49,8 +49,8 @@ type DeleteAppCatalogSubscriptionResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_boot_volume_backup_request_response.go
+++ b/core/delete_boot_volume_backup_request_response.go
@@ -48,8 +48,8 @@ type DeleteBootVolumeBackupResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_boot_volume_kms_key_request_response.go
+++ b/core/delete_boot_volume_kms_key_request_response.go
@@ -48,8 +48,8 @@ type DeleteBootVolumeKmsKeyResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_boot_volume_request_response.go
+++ b/core/delete_boot_volume_request_response.go
@@ -48,8 +48,8 @@ type DeleteBootVolumeResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_console_history_request_response.go
+++ b/core/delete_console_history_request_response.go
@@ -48,8 +48,8 @@ type DeleteConsoleHistoryResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_cpe_request_response.go
+++ b/core/delete_cpe_request_response.go
@@ -48,8 +48,8 @@ type DeleteCpeResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_cross_connect_group_request_response.go
+++ b/core/delete_cross_connect_group_request_response.go
@@ -48,8 +48,8 @@ type DeleteCrossConnectGroupResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_cross_connect_request_response.go
+++ b/core/delete_cross_connect_request_response.go
@@ -48,8 +48,8 @@ type DeleteCrossConnectResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_dhcp_options_request_response.go
+++ b/core/delete_dhcp_options_request_response.go
@@ -48,8 +48,8 @@ type DeleteDhcpOptionsResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_drg_attachment_request_response.go
+++ b/core/delete_drg_attachment_request_response.go
@@ -48,8 +48,8 @@ type DeleteDrgAttachmentResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_drg_request_response.go
+++ b/core/delete_drg_request_response.go
@@ -48,8 +48,8 @@ type DeleteDrgResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_i_p_sec_connection_request_response.go
+++ b/core/delete_i_p_sec_connection_request_response.go
@@ -48,8 +48,8 @@ type DeleteIPSecConnectionResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_image_request_response.go
+++ b/core/delete_image_request_response.go
@@ -48,8 +48,8 @@ type DeleteImageResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_instance_configuration_request_response.go
+++ b/core/delete_instance_configuration_request_response.go
@@ -48,8 +48,8 @@ type DeleteInstanceConfigurationResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_instance_console_connection_request_response.go
+++ b/core/delete_instance_console_connection_request_response.go
@@ -48,8 +48,8 @@ type DeleteInstanceConsoleConnectionResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_internet_gateway_request_response.go
+++ b/core/delete_internet_gateway_request_response.go
@@ -48,8 +48,8 @@ type DeleteInternetGatewayResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_local_peering_gateway_request_response.go
+++ b/core/delete_local_peering_gateway_request_response.go
@@ -48,8 +48,8 @@ type DeleteLocalPeeringGatewayResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_nat_gateway_request_response.go
+++ b/core/delete_nat_gateway_request_response.go
@@ -48,8 +48,8 @@ type DeleteNatGatewayResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_private_ip_request_response.go
+++ b/core/delete_private_ip_request_response.go
@@ -48,8 +48,8 @@ type DeletePrivateIpResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_public_ip_request_response.go
+++ b/core/delete_public_ip_request_response.go
@@ -48,8 +48,8 @@ type DeletePublicIpResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_remote_peering_connection_request_response.go
+++ b/core/delete_remote_peering_connection_request_response.go
@@ -48,8 +48,8 @@ type DeleteRemotePeeringConnectionResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_route_table_request_response.go
+++ b/core/delete_route_table_request_response.go
@@ -48,8 +48,8 @@ type DeleteRouteTableResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_security_list_request_response.go
+++ b/core/delete_security_list_request_response.go
@@ -48,8 +48,8 @@ type DeleteSecurityListResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_service_gateway_request_response.go
+++ b/core/delete_service_gateway_request_response.go
@@ -48,8 +48,8 @@ type DeleteServiceGatewayResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_subnet_request_response.go
+++ b/core/delete_subnet_request_response.go
@@ -48,8 +48,8 @@ type DeleteSubnetResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_vcn_request_response.go
+++ b/core/delete_vcn_request_response.go
@@ -11,7 +11,7 @@ import (
 // DeleteVcnRequest wrapper for the DeleteVcn operation
 type DeleteVcnRequest struct {
 
-	// The OCID of the VCN.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
 	VcnId *string `mandatory:"true" contributesTo:"path" name:"vcnId"`
 
 	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
@@ -48,8 +48,8 @@ type DeleteVcnResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_virtual_circuit_request_response.go
+++ b/core/delete_virtual_circuit_request_response.go
@@ -48,8 +48,8 @@ type DeleteVirtualCircuitResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_volume_backup_policy_assignment_request_response.go
+++ b/core/delete_volume_backup_policy_assignment_request_response.go
@@ -48,8 +48,8 @@ type DeleteVolumeBackupPolicyAssignmentResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_volume_backup_request_response.go
+++ b/core/delete_volume_backup_request_response.go
@@ -48,8 +48,8 @@ type DeleteVolumeBackupResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_volume_group_backup_request_response.go
+++ b/core/delete_volume_group_backup_request_response.go
@@ -48,8 +48,8 @@ type DeleteVolumeGroupBackupResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_volume_group_request_response.go
+++ b/core/delete_volume_group_request_response.go
@@ -48,8 +48,8 @@ type DeleteVolumeGroupResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_volume_kms_key_request_response.go
+++ b/core/delete_volume_kms_key_request_response.go
@@ -48,8 +48,8 @@ type DeleteVolumeKmsKeyResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/delete_volume_request_response.go
+++ b/core/delete_volume_request_response.go
@@ -48,8 +48,8 @@ type DeleteVolumeResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/detach_boot_volume_request_response.go
+++ b/core/detach_boot_volume_request_response.go
@@ -48,8 +48,8 @@ type DetachBootVolumeResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/detach_load_balancer_request_response.go
+++ b/core/detach_load_balancer_request_response.go
@@ -64,8 +64,8 @@ type DetachLoadBalancerResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/detach_service_id_request_response.go
+++ b/core/detach_service_id_request_response.go
@@ -54,8 +54,8 @@ type DetachServiceIdResponse struct {
 	// The ServiceGateway instance
 	ServiceGateway `presentIn:"body"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/detach_vnic_request_response.go
+++ b/core/detach_vnic_request_response.go
@@ -48,8 +48,8 @@ type DetachVnicResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/detach_volume_request_response.go
+++ b/core/detach_volume_request_response.go
@@ -48,8 +48,8 @@ type DetachVolumeResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/dhcp_options.go
+++ b/core/dhcp_options.go
@@ -51,8 +51,8 @@ type DhcpOptions struct {
 	// The OCID of the VCN the set of DHCP options belongs to.
 	VcnId *string `mandatory:"true" json:"vcnId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -61,8 +61,7 @@ type DhcpOptions struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/drg.go
+++ b/core/drg.go
@@ -37,8 +37,8 @@ type Drg struct {
 	// The DRG's current state.
 	LifecycleState DrgLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -47,8 +47,7 @@ type Drg struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/export_image_request_response.go
+++ b/core/export_image_request_response.go
@@ -64,8 +64,8 @@ type ExportImageResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 
 	// The OCID of the work request. Use GetWorkRequest

--- a/core/get_app_catalog_listing_agreements_request_response.go
+++ b/core/get_app_catalog_listing_agreements_request_response.go
@@ -52,8 +52,8 @@ type GetAppCatalogListingAgreementsResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_app_catalog_listing_request_response.go
+++ b/core/get_app_catalog_listing_request_response.go
@@ -49,8 +49,8 @@ type GetAppCatalogListingResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_app_catalog_listing_resource_version_request_response.go
+++ b/core/get_app_catalog_listing_resource_version_request_response.go
@@ -52,8 +52,8 @@ type GetAppCatalogListingResourceVersionResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_boot_volume_attachment_request_response.go
+++ b/core/get_boot_volume_attachment_request_response.go
@@ -49,8 +49,8 @@ type GetBootVolumeAttachmentResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_boot_volume_backup_request_response.go
+++ b/core/get_boot_volume_backup_request_response.go
@@ -49,8 +49,8 @@ type GetBootVolumeBackupResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_boot_volume_kms_key_request_response.go
+++ b/core/get_boot_volume_kms_key_request_response.go
@@ -54,8 +54,8 @@ type GetBootVolumeKmsKeyResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_boot_volume_request_response.go
+++ b/core/get_boot_volume_request_response.go
@@ -49,8 +49,8 @@ type GetBootVolumeResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_console_history_content_request_response.go
+++ b/core/get_console_history_content_request_response.go
@@ -55,8 +55,8 @@ type GetConsoleHistoryContentResponse struct {
 	// The number of bytes remaining in the snapshot.
 	OpcBytesRemaining *int `presentIn:"header" name:"opc-bytes-remaining"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_console_history_request_response.go
+++ b/core/get_console_history_request_response.go
@@ -49,8 +49,8 @@ type GetConsoleHistoryResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_cpe_request_response.go
+++ b/core/get_cpe_request_response.go
@@ -49,8 +49,8 @@ type GetCpeResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_cross_connect_group_request_response.go
+++ b/core/get_cross_connect_group_request_response.go
@@ -49,8 +49,8 @@ type GetCrossConnectGroupResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_cross_connect_letter_of_authority_request_response.go
+++ b/core/get_cross_connect_letter_of_authority_request_response.go
@@ -46,8 +46,8 @@ type GetCrossConnectLetterOfAuthorityResponse struct {
 	// The LetterOfAuthority instance
 	LetterOfAuthority `presentIn:"body"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_cross_connect_request_response.go
+++ b/core/get_cross_connect_request_response.go
@@ -49,8 +49,8 @@ type GetCrossConnectResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_cross_connect_status_request_response.go
+++ b/core/get_cross_connect_status_request_response.go
@@ -46,8 +46,8 @@ type GetCrossConnectStatusResponse struct {
 	// The CrossConnectStatus instance
 	CrossConnectStatus `presentIn:"body"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_dhcp_options_request_response.go
+++ b/core/get_dhcp_options_request_response.go
@@ -49,8 +49,8 @@ type GetDhcpOptionsResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_drg_attachment_request_response.go
+++ b/core/get_drg_attachment_request_response.go
@@ -49,8 +49,8 @@ type GetDrgAttachmentResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_drg_request_response.go
+++ b/core/get_drg_request_response.go
@@ -49,8 +49,8 @@ type GetDrgResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_fast_connect_provider_service_key_request_response.go
+++ b/core/get_fast_connect_provider_service_key_request_response.go
@@ -52,8 +52,8 @@ type GetFastConnectProviderServiceKeyResponse struct {
 	// The FastConnectProviderServiceKey instance
 	FastConnectProviderServiceKey `presentIn:"body"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_fast_connect_provider_service_request_response.go
+++ b/core/get_fast_connect_provider_service_request_response.go
@@ -46,8 +46,8 @@ type GetFastConnectProviderServiceResponse struct {
 	// The FastConnectProviderService instance
 	FastConnectProviderService `presentIn:"body"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_i_p_sec_connection_device_config_request_response.go
+++ b/core/get_i_p_sec_connection_device_config_request_response.go
@@ -49,8 +49,8 @@ type GetIPSecConnectionDeviceConfigResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_i_p_sec_connection_device_status_request_response.go
+++ b/core/get_i_p_sec_connection_device_status_request_response.go
@@ -49,8 +49,8 @@ type GetIPSecConnectionDeviceStatusResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_i_p_sec_connection_request_response.go
+++ b/core/get_i_p_sec_connection_request_response.go
@@ -49,8 +49,8 @@ type GetIPSecConnectionResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_i_p_sec_connection_tunnel_request_response.go
+++ b/core/get_i_p_sec_connection_tunnel_request_response.go
@@ -52,8 +52,8 @@ type GetIPSecConnectionTunnelResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_i_p_sec_connection_tunnel_shared_secret_request_response.go
+++ b/core/get_i_p_sec_connection_tunnel_shared_secret_request_response.go
@@ -52,8 +52,8 @@ type GetIPSecConnectionTunnelSharedSecretResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_image_request_response.go
+++ b/core/get_image_request_response.go
@@ -49,8 +49,8 @@ type GetImageResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_instance_configuration_request_response.go
+++ b/core/get_instance_configuration_request_response.go
@@ -49,8 +49,8 @@ type GetInstanceConfigurationResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_instance_console_connection_request_response.go
+++ b/core/get_instance_console_connection_request_response.go
@@ -46,8 +46,8 @@ type GetInstanceConsoleConnectionResponse struct {
 	// The InstanceConsoleConnection instance
 	InstanceConsoleConnection `presentIn:"body"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_instance_pool_request_response.go
+++ b/core/get_instance_pool_request_response.go
@@ -49,8 +49,8 @@ type GetInstancePoolResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_instance_request_response.go
+++ b/core/get_instance_request_response.go
@@ -49,8 +49,8 @@ type GetInstanceResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_internet_gateway_request_response.go
+++ b/core/get_internet_gateway_request_response.go
@@ -49,8 +49,8 @@ type GetInternetGatewayResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_local_peering_gateway_request_response.go
+++ b/core/get_local_peering_gateway_request_response.go
@@ -49,8 +49,8 @@ type GetLocalPeeringGatewayResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_nat_gateway_request_response.go
+++ b/core/get_nat_gateway_request_response.go
@@ -49,8 +49,8 @@ type GetNatGatewayResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_private_ip_request_response.go
+++ b/core/get_private_ip_request_response.go
@@ -49,8 +49,8 @@ type GetPrivateIpResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_public_ip_by_ip_address_request_response.go
+++ b/core/get_public_ip_by_ip_address_request_response.go
@@ -49,8 +49,8 @@ type GetPublicIpByIpAddressResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
-	// particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_public_ip_by_private_ip_id_request_response.go
+++ b/core/get_public_ip_by_private_ip_id_request_response.go
@@ -49,8 +49,8 @@ type GetPublicIpByPrivateIpIdResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
-	// particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_public_ip_request_response.go
+++ b/core/get_public_ip_request_response.go
@@ -49,8 +49,8 @@ type GetPublicIpResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_remote_peering_connection_request_response.go
+++ b/core/get_remote_peering_connection_request_response.go
@@ -49,8 +49,8 @@ type GetRemotePeeringConnectionResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_route_table_request_response.go
+++ b/core/get_route_table_request_response.go
@@ -49,8 +49,8 @@ type GetRouteTableResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_security_list_request_response.go
+++ b/core/get_security_list_request_response.go
@@ -49,8 +49,8 @@ type GetSecurityListResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_service_gateway_request_response.go
+++ b/core/get_service_gateway_request_response.go
@@ -49,8 +49,8 @@ type GetServiceGatewayResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_service_request_response.go
+++ b/core/get_service_request_response.go
@@ -49,8 +49,8 @@ type GetServiceResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_subnet_request_response.go
+++ b/core/get_subnet_request_response.go
@@ -49,8 +49,8 @@ type GetSubnetResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_vcn_request_response.go
+++ b/core/get_vcn_request_response.go
@@ -11,7 +11,7 @@ import (
 // GetVcnRequest wrapper for the GetVcn operation
 type GetVcnRequest struct {
 
-	// The OCID of the VCN.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
 	VcnId *string `mandatory:"true" contributesTo:"path" name:"vcnId"`
 
 	// Unique Oracle-assigned identifier for the request.
@@ -49,8 +49,8 @@ type GetVcnResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_virtual_circuit_request_response.go
+++ b/core/get_virtual_circuit_request_response.go
@@ -49,8 +49,8 @@ type GetVirtualCircuitResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_vnic_attachment_request_response.go
+++ b/core/get_vnic_attachment_request_response.go
@@ -49,8 +49,8 @@ type GetVnicAttachmentResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_vnic_request_response.go
+++ b/core/get_vnic_request_response.go
@@ -49,8 +49,8 @@ type GetVnicResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_volume_attachment_request_response.go
+++ b/core/get_volume_attachment_request_response.go
@@ -49,8 +49,8 @@ type GetVolumeAttachmentResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_volume_backup_policy_asset_assignment_request_response.go
+++ b/core/get_volume_backup_policy_asset_assignment_request_response.go
@@ -57,13 +57,13 @@ type GetVolumeBackupPolicyAssetAssignmentResponse struct {
 	// A list of []VolumeBackupPolicyAssignment instances
 	Items []VolumeBackupPolicyAssignment `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_volume_backup_policy_assignment_request_response.go
+++ b/core/get_volume_backup_policy_assignment_request_response.go
@@ -49,8 +49,8 @@ type GetVolumeBackupPolicyAssignmentResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_volume_backup_policy_request_response.go
+++ b/core/get_volume_backup_policy_request_response.go
@@ -49,8 +49,8 @@ type GetVolumeBackupPolicyResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_volume_backup_request_response.go
+++ b/core/get_volume_backup_request_response.go
@@ -49,8 +49,8 @@ type GetVolumeBackupResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_volume_group_backup_request_response.go
+++ b/core/get_volume_group_backup_request_response.go
@@ -49,8 +49,8 @@ type GetVolumeGroupBackupResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_volume_group_request_response.go
+++ b/core/get_volume_group_request_response.go
@@ -49,8 +49,8 @@ type GetVolumeGroupResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_volume_kms_key_request_response.go
+++ b/core/get_volume_kms_key_request_response.go
@@ -54,8 +54,8 @@ type GetVolumeKmsKeyResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_volume_request_response.go
+++ b/core/get_volume_request_response.go
@@ -49,8 +49,8 @@ type GetVolumeResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/get_windows_instance_initial_credentials_request_response.go
+++ b/core/get_windows_instance_initial_credentials_request_response.go
@@ -46,8 +46,8 @@ type GetWindowsInstanceInitialCredentialsResponse struct {
 	// The InstanceCredentials instance
 	InstanceCredentials `presentIn:"body"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/image.go
+++ b/core/image.go
@@ -53,8 +53,8 @@ type Image struct {
 	// The OCID of the image originally used to launch the instance.
 	BaseImageId *string `mandatory:"false" json:"baseImageId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -65,8 +65,7 @@ type Image struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/image_source_details.go
+++ b/core/image_source_details.go
@@ -19,6 +19,9 @@ import (
 
 // ImageSourceDetails The representation of ImageSourceDetails
 type ImageSourceDetails interface {
+	GetOperatingSystem() *string
+
+	GetOperatingSystemVersion() *string
 
 	// The format of the image to be imported.  Only monolithic
 	// images are supported. This attribute is not used for exported Oracle images with the OCI image format.
@@ -26,9 +29,11 @@ type ImageSourceDetails interface {
 }
 
 type imagesourcedetails struct {
-	JsonData        []byte
-	SourceImageType ImageSourceDetailsSourceImageTypeEnum `mandatory:"false" json:"sourceImageType,omitempty"`
-	SourceType      string                                `json:"sourceType"`
+	JsonData               []byte
+	OperatingSystem        *string                               `mandatory:"false" json:"operatingSystem"`
+	OperatingSystemVersion *string                               `mandatory:"false" json:"operatingSystemVersion"`
+	SourceImageType        ImageSourceDetailsSourceImageTypeEnum `mandatory:"false" json:"sourceImageType,omitempty"`
+	SourceType             string                                `json:"sourceType"`
 }
 
 // UnmarshalJSON unmarshals json
@@ -42,6 +47,8 @@ func (m *imagesourcedetails) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
+	m.OperatingSystem = s.Model.OperatingSystem
+	m.OperatingSystemVersion = s.Model.OperatingSystemVersion
 	m.SourceImageType = s.Model.SourceImageType
 	m.SourceType = s.Model.SourceType
 
@@ -68,6 +75,16 @@ func (m *imagesourcedetails) UnmarshalPolymorphicJSON(data []byte) (interface{},
 	default:
 		return *m, nil
 	}
+}
+
+//GetOperatingSystem returns OperatingSystem
+func (m imagesourcedetails) GetOperatingSystem() *string {
+	return m.OperatingSystem
+}
+
+//GetOperatingSystemVersion returns OperatingSystemVersion
+func (m imagesourcedetails) GetOperatingSystemVersion() *string {
+	return m.OperatingSystemVersion
 }
 
 //GetSourceImageType returns SourceImageType

--- a/core/image_source_via_object_storage_tuple_details.go
+++ b/core/image_source_via_object_storage_tuple_details.go
@@ -29,9 +29,23 @@ type ImageSourceViaObjectStorageTupleDetails struct {
 	// The Object Storage name for the image.
 	ObjectName *string `mandatory:"true" json:"objectName"`
 
+	OperatingSystem *string `mandatory:"false" json:"operatingSystem"`
+
+	OperatingSystemVersion *string `mandatory:"false" json:"operatingSystemVersion"`
+
 	// The format of the image to be imported.  Only monolithic
 	// images are supported. This attribute is not used for exported Oracle images with the OCI image format.
 	SourceImageType ImageSourceDetailsSourceImageTypeEnum `mandatory:"false" json:"sourceImageType,omitempty"`
+}
+
+//GetOperatingSystem returns OperatingSystem
+func (m ImageSourceViaObjectStorageTupleDetails) GetOperatingSystem() *string {
+	return m.OperatingSystem
+}
+
+//GetOperatingSystemVersion returns OperatingSystemVersion
+func (m ImageSourceViaObjectStorageTupleDetails) GetOperatingSystemVersion() *string {
+	return m.OperatingSystemVersion
 }
 
 //GetSourceImageType returns SourceImageType

--- a/core/image_source_via_object_storage_uri_details.go
+++ b/core/image_source_via_object_storage_uri_details.go
@@ -23,9 +23,23 @@ type ImageSourceViaObjectStorageUriDetails struct {
 	// The Object Storage URL for the image.
 	SourceUri *string `mandatory:"true" json:"sourceUri"`
 
+	OperatingSystem *string `mandatory:"false" json:"operatingSystem"`
+
+	OperatingSystemVersion *string `mandatory:"false" json:"operatingSystemVersion"`
+
 	// The format of the image to be imported.  Only monolithic
 	// images are supported. This attribute is not used for exported Oracle images with the OCI image format.
 	SourceImageType ImageSourceDetailsSourceImageTypeEnum `mandatory:"false" json:"sourceImageType,omitempty"`
+}
+
+//GetOperatingSystem returns OperatingSystem
+func (m ImageSourceViaObjectStorageUriDetails) GetOperatingSystem() *string {
+	return m.OperatingSystem
+}
+
+//GetOperatingSystemVersion returns OperatingSystemVersion
+func (m ImageSourceViaObjectStorageUriDetails) GetOperatingSystemVersion() *string {
+	return m.OperatingSystemVersion
 }
 
 //GetSourceImageType returns SourceImageType

--- a/core/instance.go
+++ b/core/instance.go
@@ -56,8 +56,8 @@ type Instance struct {
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -82,8 +82,7 @@ type Instance struct {
 	FaultDomain *string `mandatory:"false" json:"faultDomain"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/instance_action_request_response.go
+++ b/core/instance_action_request_response.go
@@ -64,8 +64,8 @@ type InstanceActionResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/instance_configuration.go
+++ b/core/instance_configuration.go
@@ -30,8 +30,8 @@ type InstanceConfiguration struct {
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -39,8 +39,7 @@ type InstanceConfiguration struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/instance_configuration_create_volume_details.go
+++ b/core/instance_configuration_create_volume_details.go
@@ -31,8 +31,8 @@ type InstanceConfigurationCreateVolumeDetails struct {
 	// The OCID of the compartment that contains the volume.
 	CompartmentId *string `mandatory:"false" json:"compartmentId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -41,8 +41,7 @@ type InstanceConfigurationCreateVolumeDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/instance_configuration_launch_instance_details.go
+++ b/core/instance_configuration_launch_instance_details.go
@@ -31,8 +31,8 @@ type InstanceConfigurationLaunchInstanceDetails struct {
 	// the instance is launched.
 	CreateVnicDetails *InstanceConfigurationCreateVnicDetails `mandatory:"false" json:"createVnicDetails"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -46,8 +46,7 @@ type InstanceConfigurationLaunchInstanceDetails struct {
 	ExtendedMetadata map[string]interface{} `mandatory:"false" json:"extendedMetadata"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 
@@ -125,6 +124,19 @@ type InstanceConfigurationLaunchInstanceDetails struct {
 	// Details for creating an instance.
 	// Use this parameter to specify whether a boot volume or an image should be used to launch a new instance.
 	SourceDetails InstanceConfigurationInstanceSourceDetails `mandatory:"false" json:"sourceDetails"`
+
+	// A fault domain is a grouping of hardware and infrastructure within an availability domain.
+	// Each availability domain contains three fault domains. Fault domains let you distribute your
+	// instances so that they are not on the same physical hardware within a single availability domain.
+	// A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
+	// instances in other fault domains.
+	// If you do not specify the fault domain, the system selects one for you. To change the fault
+	// domain for an instance, terminate it and launch a new instance in the preferred fault domain.
+	// To get a list of fault domains, use the
+	// ListFaultDomains operation in the
+	// Identity and Access Management Service API.
+	// Example: `FAULT-DOMAIN-1`
+	FaultDomain *string `mandatory:"false" json:"faultDomain"`
 }
 
 func (m InstanceConfigurationLaunchInstanceDetails) String() string {
@@ -145,6 +157,7 @@ func (m *InstanceConfigurationLaunchInstanceDetails) UnmarshalJSON(data []byte) 
 		Metadata           map[string]string                          `json:"metadata"`
 		Shape              *string                                    `json:"shape"`
 		SourceDetails      instanceconfigurationinstancesourcedetails `json:"sourceDetails"`
+		FaultDomain        *string                                    `json:"faultDomain"`
 	}{}
 
 	e = json.Unmarshal(data, &model)
@@ -170,5 +183,6 @@ func (m *InstanceConfigurationLaunchInstanceDetails) UnmarshalJSON(data []byte) 
 	} else {
 		m.SourceDetails = nil
 	}
+	m.FaultDomain = model.FaultDomain
 	return
 }

--- a/core/instance_configuration_summary.go
+++ b/core/instance_configuration_summary.go
@@ -32,14 +32,13 @@ type InstanceConfigurationSummary struct {
 	// A user-friendly name for the instance configuration
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/instance_console_connection.go
+++ b/core/instance_console_connection.go
@@ -28,8 +28,8 @@ type InstanceConsoleConnection struct {
 	// The SSH connection string for the console connection.
 	ConnectionString *string `mandatory:"false" json:"connectionString"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -37,8 +37,7 @@ type InstanceConsoleConnection struct {
 	Fingerprint *string `mandatory:"false" json:"fingerprint"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/instance_pool.go
+++ b/core/instance_pool.go
@@ -41,8 +41,8 @@ type InstancePool struct {
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -50,8 +50,7 @@ type InstancePool struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/instance_pool_summary.go
+++ b/core/instance_pool_summary.go
@@ -44,14 +44,13 @@ type InstancePoolSummary struct {
 	// The user-friendly name.  Does not have to be unique.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/internet_gateway.go
+++ b/core/internet_gateway.go
@@ -38,8 +38,8 @@ type InternetGateway struct {
 	// The OCID of the VCN the internet gateway belongs to.
 	VcnId *string `mandatory:"true" json:"vcnId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -48,8 +48,7 @@ type InternetGateway struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/ip_sec_connection.go
+++ b/core/ip_sec_connection.go
@@ -63,8 +63,8 @@ type IpSecConnection struct {
 	// Example: `10.0.1.0/24`
 	StaticRoutes []string `mandatory:"true" json:"staticRoutes"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -73,8 +73,7 @@ type IpSecConnection struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 
@@ -83,6 +82,8 @@ type IpSecConnection struct {
 	// to the value for `cpeLocalIdentifierType`.
 	// If you don't provide a value when creating the IPSec connection, the `ipAddress` attribute
 	// for the Cpe object specified by `cpeId` is used as the `cpeLocalIdentifier`.
+	// For information about why you'd provide this value, see
+	// If Your CPE Is Behind a NAT Device (https://docs.cloud.oracle.com/Content/Network/Tasks/overviewIPsec.htm#nat).
 	// Example IP address: `10.0.3.3`
 	// Example hostname: `cpe.example.com`
 	CpeLocalIdentifier *string `mandatory:"false" json:"cpeLocalIdentifier"`

--- a/core/ip_sec_connection_tunnel_shared_secret.go
+++ b/core/ip_sec_connection_tunnel_shared_secret.go
@@ -20,7 +20,7 @@ import (
 type IpSecConnectionTunnelSharedSecret struct {
 
 	// The tunnel's shared secret (pre-shared key).
-	// Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
+	// Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
 	SharedSecret *string `mandatory:"true" json:"sharedSecret"`
 }
 

--- a/core/launch_instance_configuration_request_response.go
+++ b/core/launch_instance_configuration_request_response.go
@@ -59,8 +59,8 @@ type LaunchInstanceConfigurationResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/launch_instance_details.go
+++ b/core/launch_instance_details.go
@@ -37,8 +37,8 @@ type LaunchInstanceDetails struct {
 	// the instance is launched.
 	CreateVnicDetails *CreateVnicDetails `mandatory:"false" json:"createVnicDetails"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -65,8 +65,7 @@ type LaunchInstanceDetails struct {
 	FaultDomain *string `mandatory:"false" json:"faultDomain"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/launch_instance_request_response.go
+++ b/core/launch_instance_request_response.go
@@ -56,8 +56,8 @@ type LaunchInstanceResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 
 	// The OCID of the work request. Use GetWorkRequest

--- a/core/list_allowed_peer_regions_for_remote_peering_request_response.go
+++ b/core/list_allowed_peer_regions_for_remote_peering_request_response.go
@@ -43,8 +43,8 @@ type ListAllowedPeerRegionsForRemotePeeringResponse struct {
 	// The []PeerRegionForRemotePeering instance
 	Items []PeerRegionForRemotePeering `presentIn:"body"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_app_catalog_listing_resource_versions_request_response.go
+++ b/core/list_app_catalog_listing_resource_versions_request_response.go
@@ -64,13 +64,13 @@ type ListAppCatalogListingResourceVersionsResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_app_catalog_listings_request_response.go
+++ b/core/list_app_catalog_listings_request_response.go
@@ -67,13 +67,13 @@ type ListAppCatalogListingsResponse struct {
 	// A list of []AppCatalogListingSummary instances
 	Items []AppCatalogListingSummary `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_app_catalog_subscriptions_request_response.go
+++ b/core/list_app_catalog_subscriptions_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListAppCatalogSubscriptionsRequest wrapper for the ListAppCatalogSubscriptions operation
 type ListAppCatalogSubscriptionsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -73,13 +73,13 @@ type ListAppCatalogSubscriptionsResponse struct {
 	// A list of []AppCatalogSubscriptionSummary instances
 	Items []AppCatalogSubscriptionSummary `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_boot_volume_attachments_request_response.go
+++ b/core/list_boot_volume_attachments_request_response.go
@@ -15,7 +15,7 @@ type ListBootVolumeAttachmentsRequest struct {
 	// Example: `Uocm:PHX-AD-1`
 	AvailabilityDomain *string `mandatory:"true" contributesTo:"query" name:"availabilityDomain"`
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -67,13 +67,13 @@ type ListBootVolumeAttachmentsResponse struct {
 	// A list of []BootVolumeAttachment instances
 	Items []BootVolumeAttachment `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_boot_volume_backups_request_response.go
+++ b/core/list_boot_volume_backups_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListBootVolumeBackupsRequest wrapper for the ListBootVolumeBackups operation
 type ListBootVolumeBackupsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// The OCID of the boot volume.
@@ -79,13 +79,13 @@ type ListBootVolumeBackupsResponse struct {
 	// A list of []BootVolumeBackup instances
 	Items []BootVolumeBackup `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_boot_volumes_request_response.go
+++ b/core/list_boot_volumes_request_response.go
@@ -15,7 +15,7 @@ type ListBootVolumesRequest struct {
 	// Example: `Uocm:PHX-AD-1`
 	AvailabilityDomain *string `mandatory:"true" contributesTo:"query" name:"availabilityDomain"`
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -64,13 +64,13 @@ type ListBootVolumesResponse struct {
 	// A list of []BootVolume instances
 	Items []BootVolume `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_console_histories_request_response.go
+++ b/core/list_console_histories_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListConsoleHistoriesRequest wrapper for the ListConsoleHistories operation
 type ListConsoleHistoriesRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// The name of the availability domain.
@@ -80,13 +80,13 @@ type ListConsoleHistoriesResponse struct {
 	// A list of []ConsoleHistory instances
 	Items []ConsoleHistory `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_cpes_request_response.go
+++ b/core/list_cpes_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListCpesRequest wrapper for the ListCpes operation
 type ListCpesRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -57,13 +57,13 @@ type ListCpesResponse struct {
 	// A list of []Cpe instances
 	Items []Cpe `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_cross_connect_groups_request_response.go
+++ b/core/list_cross_connect_groups_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListCrossConnectGroupsRequest wrapper for the ListCrossConnectGroups operation
 type ListCrossConnectGroupsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -76,13 +76,13 @@ type ListCrossConnectGroupsResponse struct {
 	// A list of []CrossConnectGroup instances
 	Items []CrossConnectGroup `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_cross_connect_locations_request_response.go
+++ b/core/list_cross_connect_locations_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListCrossConnectLocationsRequest wrapper for the ListCrossConnectLocations operation
 type ListCrossConnectLocationsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -57,13 +57,13 @@ type ListCrossConnectLocationsResponse struct {
 	// A list of []CrossConnectLocation instances
 	Items []CrossConnectLocation `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_cross_connects_request_response.go
+++ b/core/list_cross_connects_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListCrossConnectsRequest wrapper for the ListCrossConnects operation
 type ListCrossConnectsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// The OCID of the cross-connect group.
@@ -79,13 +79,13 @@ type ListCrossConnectsResponse struct {
 	// A list of []CrossConnect instances
 	Items []CrossConnect `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_crossconnect_port_speed_shapes_request_response.go
+++ b/core/list_crossconnect_port_speed_shapes_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListCrossconnectPortSpeedShapesRequest wrapper for the ListCrossconnectPortSpeedShapes operation
 type ListCrossconnectPortSpeedShapesRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -57,13 +57,13 @@ type ListCrossconnectPortSpeedShapesResponse struct {
 	// A list of []CrossConnectPortSpeedShape instances
 	Items []CrossConnectPortSpeedShape `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_dhcp_options_request_response.go
+++ b/core/list_dhcp_options_request_response.go
@@ -11,10 +11,10 @@ import (
 // ListDhcpOptionsRequest wrapper for the ListDhcpOptions operation
 type ListDhcpOptionsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
-	// The OCID of the VCN.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
 	VcnId *string `mandatory:"true" contributesTo:"query" name:"vcnId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -79,13 +79,13 @@ type ListDhcpOptionsResponse struct {
 	// A list of []DhcpOptions instances
 	Items []DhcpOptions `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_drg_attachments_request_response.go
+++ b/core/list_drg_attachments_request_response.go
@@ -11,10 +11,10 @@ import (
 // ListDrgAttachmentsRequest wrapper for the ListDrgAttachments operation
 type ListDrgAttachmentsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
-	// The OCID of the VCN.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
 	VcnId *string `mandatory:"false" contributesTo:"query" name:"vcnId"`
 
 	// The OCID of the DRG.
@@ -63,13 +63,13 @@ type ListDrgAttachmentsResponse struct {
 	// A list of []DrgAttachment instances
 	Items []DrgAttachment `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_drgs_request_response.go
+++ b/core/list_drgs_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListDrgsRequest wrapper for the ListDrgs operation
 type ListDrgsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -57,13 +57,13 @@ type ListDrgsResponse struct {
 	// A list of []Drg instances
 	Items []Drg `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_fast_connect_provider_services_request_response.go
+++ b/core/list_fast_connect_provider_services_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListFastConnectProviderServicesRequest wrapper for the ListFastConnectProviderServices operation
 type ListFastConnectProviderServicesRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -57,13 +57,13 @@ type ListFastConnectProviderServicesResponse struct {
 	// A list of []FastConnectProviderService instances
 	Items []FastConnectProviderService `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_fast_connect_provider_virtual_circuit_bandwidth_shapes_request_response.go
+++ b/core/list_fast_connect_provider_virtual_circuit_bandwidth_shapes_request_response.go
@@ -57,13 +57,13 @@ type ListFastConnectProviderVirtualCircuitBandwidthShapesResponse struct {
 	// A list of []VirtualCircuitBandwidthShape instances
 	Items []VirtualCircuitBandwidthShape `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_i_p_sec_connection_tunnels_request_response.go
+++ b/core/list_i_p_sec_connection_tunnels_request_response.go
@@ -57,13 +57,13 @@ type ListIPSecConnectionTunnelsResponse struct {
 	// A list of []IpSecConnectionTunnel instances
 	Items []IpSecConnectionTunnel `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_i_p_sec_connections_request_response.go
+++ b/core/list_i_p_sec_connections_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListIPSecConnectionsRequest wrapper for the ListIPSecConnections operation
 type ListIPSecConnectionsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// The OCID of the DRG.
@@ -63,13 +63,13 @@ type ListIPSecConnectionsResponse struct {
 	// A list of []IpSecConnection instances
 	Items []IpSecConnection `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_images_request_response.go
+++ b/core/list_images_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListImagesRequest wrapper for the ListImages operation
 type ListImagesRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// A filter to return only resources that match the given display name exactly.
@@ -87,13 +87,13 @@ type ListImagesResponse struct {
 	// A list of []Image instances
 	Items []Image `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_instance_configurations_request_response.go
+++ b/core/list_instance_configurations_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListInstanceConfigurationsRequest wrapper for the ListInstanceConfigurations operation
 type ListInstanceConfigurationsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -70,13 +70,13 @@ type ListInstanceConfigurationsResponse struct {
 	// A list of []InstanceConfigurationSummary instances
 	Items []InstanceConfigurationSummary `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_instance_console_connections_request_response.go
+++ b/core/list_instance_console_connections_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListInstanceConsoleConnectionsRequest wrapper for the ListInstanceConsoleConnections operation
 type ListInstanceConsoleConnectionsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// The OCID of the instance.
@@ -60,13 +60,13 @@ type ListInstanceConsoleConnectionsResponse struct {
 	// A list of []InstanceConsoleConnection instances
 	Items []InstanceConsoleConnection `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_instance_devices_request_response.go
+++ b/core/list_instance_devices_request_response.go
@@ -76,13 +76,13 @@ type ListInstanceDevicesResponse struct {
 	// A list of []Device instances
 	Items []Device `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_instance_pool_instances_request_response.go
+++ b/core/list_instance_pool_instances_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListInstancePoolInstancesRequest wrapper for the ListInstancePoolInstances operation
 type ListInstancePoolInstancesRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// The OCID of the instance pool.
@@ -76,13 +76,13 @@ type ListInstancePoolInstancesResponse struct {
 	// A list of []InstanceSummary instances
 	Items []InstanceSummary `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_instance_pools_request_response.go
+++ b/core/list_instance_pools_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListInstancePoolsRequest wrapper for the ListInstancePools operation
 type ListInstancePoolsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// A filter to return only resources that match the given display name exactly.
@@ -76,13 +76,13 @@ type ListInstancePoolsResponse struct {
 	// A list of []InstancePoolSummary instances
 	Items []InstancePoolSummary `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_instances_request_response.go
+++ b/core/list_instances_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListInstancesRequest wrapper for the ListInstances operation
 type ListInstancesRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// The name of the availability domain.
@@ -80,13 +80,13 @@ type ListInstancesResponse struct {
 	// A list of []Instance instances
 	Items []Instance `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_internet_gateways_request_response.go
+++ b/core/list_internet_gateways_request_response.go
@@ -11,10 +11,10 @@ import (
 // ListInternetGatewaysRequest wrapper for the ListInternetGateways operation
 type ListInternetGatewaysRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
-	// The OCID of the VCN.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
 	VcnId *string `mandatory:"true" contributesTo:"query" name:"vcnId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -79,13 +79,13 @@ type ListInternetGatewaysResponse struct {
 	// A list of []InternetGateway instances
 	Items []InternetGateway `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_local_peering_gateways_request_response.go
+++ b/core/list_local_peering_gateways_request_response.go
@@ -11,10 +11,10 @@ import (
 // ListLocalPeeringGatewaysRequest wrapper for the ListLocalPeeringGateways operation
 type ListLocalPeeringGatewaysRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
-	// The OCID of the VCN.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
 	VcnId *string `mandatory:"true" contributesTo:"query" name:"vcnId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -60,13 +60,13 @@ type ListLocalPeeringGatewaysResponse struct {
 	// A list of []LocalPeeringGateway instances
 	Items []LocalPeeringGateway `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_nat_gateways_request_response.go
+++ b/core/list_nat_gateways_request_response.go
@@ -11,10 +11,10 @@ import (
 // ListNatGatewaysRequest wrapper for the ListNatGateways operation
 type ListNatGatewaysRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
-	// The OCID of the VCN.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
 	VcnId *string `mandatory:"false" contributesTo:"query" name:"vcnId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -79,13 +79,13 @@ type ListNatGatewaysResponse struct {
 	// A list of []NatGateway instances
 	Items []NatGateway `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_private_ips_request_response.go
+++ b/core/list_private_ips_request_response.go
@@ -64,13 +64,13 @@ type ListPrivateIpsResponse struct {
 	// A list of []PrivateIp instances
 	Items []PrivateIp `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_public_ips_request_response.go
+++ b/core/list_public_ips_request_response.go
@@ -21,7 +21,7 @@ type ListPublicIpsRequest struct {
 	// Ephemeral public IPs that are assigned to private IPs have `scope` = `AVAILABILITY_DOMAIN`.
 	Scope ListPublicIpsScopeEnum `mandatory:"true" contributesTo:"query" name:"scope" omitEmpty:"true"`
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -74,13 +74,13 @@ type ListPublicIpsResponse struct {
 	// A list of []PublicIp instances
 	Items []PublicIp `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_remote_peering_connections_request_response.go
+++ b/core/list_remote_peering_connections_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListRemotePeeringConnectionsRequest wrapper for the ListRemotePeeringConnections operation
 type ListRemotePeeringConnectionsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// The OCID of the DRG.
@@ -60,13 +60,13 @@ type ListRemotePeeringConnectionsResponse struct {
 	// A list of []RemotePeeringConnection instances
 	Items []RemotePeeringConnection `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_route_tables_request_response.go
+++ b/core/list_route_tables_request_response.go
@@ -11,10 +11,10 @@ import (
 // ListRouteTablesRequest wrapper for the ListRouteTables operation
 type ListRouteTablesRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
-	// The OCID of the VCN.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
 	VcnId *string `mandatory:"true" contributesTo:"query" name:"vcnId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -79,13 +79,13 @@ type ListRouteTablesResponse struct {
 	// A list of []RouteTable instances
 	Items []RouteTable `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_security_lists_request_response.go
+++ b/core/list_security_lists_request_response.go
@@ -11,10 +11,10 @@ import (
 // ListSecurityListsRequest wrapper for the ListSecurityLists operation
 type ListSecurityListsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
-	// The OCID of the VCN.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
 	VcnId *string `mandatory:"true" contributesTo:"query" name:"vcnId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -79,13 +79,13 @@ type ListSecurityListsResponse struct {
 	// A list of []SecurityList instances
 	Items []SecurityList `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_service_gateways_request_response.go
+++ b/core/list_service_gateways_request_response.go
@@ -11,10 +11,10 @@ import (
 // ListServiceGatewaysRequest wrapper for the ListServiceGateways operation
 type ListServiceGatewaysRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
-	// The OCID of the VCN.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
 	VcnId *string `mandatory:"false" contributesTo:"query" name:"vcnId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -76,13 +76,13 @@ type ListServiceGatewaysResponse struct {
 	// A list of []ServiceGateway instances
 	Items []ServiceGateway `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_services_request_response.go
+++ b/core/list_services_request_response.go
@@ -54,13 +54,13 @@ type ListServicesResponse struct {
 	// A list of []Service instances
 	Items []Service `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_shapes_request_response.go
+++ b/core/list_shapes_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListShapesRequest wrapper for the ListShapes operation
 type ListShapesRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// The name of the availability domain.
@@ -64,13 +64,13 @@ type ListShapesResponse struct {
 	// A list of []Shape instances
 	Items []Shape `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_subnets_request_response.go
+++ b/core/list_subnets_request_response.go
@@ -11,10 +11,10 @@ import (
 // ListSubnetsRequest wrapper for the ListSubnets operation
 type ListSubnetsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
-	// The OCID of the VCN.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
 	VcnId *string `mandatory:"true" contributesTo:"query" name:"vcnId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -79,13 +79,13 @@ type ListSubnetsResponse struct {
 	// A list of []Subnet instances
 	Items []Subnet `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_vcns_request_response.go
+++ b/core/list_vcns_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListVcnsRequest wrapper for the ListVcns operation
 type ListVcnsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -76,13 +76,13 @@ type ListVcnsResponse struct {
 	// A list of []Vcn instances
 	Items []Vcn `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_virtual_circuit_bandwidth_shapes_request_response.go
+++ b/core/list_virtual_circuit_bandwidth_shapes_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListVirtualCircuitBandwidthShapesRequest wrapper for the ListVirtualCircuitBandwidthShapes operation
 type ListVirtualCircuitBandwidthShapesRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -57,13 +57,13 @@ type ListVirtualCircuitBandwidthShapesResponse struct {
 	// A list of []VirtualCircuitBandwidthShape instances
 	Items []VirtualCircuitBandwidthShape `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_virtual_circuit_public_prefixes_request_response.go
+++ b/core/list_virtual_circuit_public_prefixes_request_response.go
@@ -50,8 +50,8 @@ type ListVirtualCircuitPublicPrefixesResponse struct {
 	// The []VirtualCircuitPublicPrefix instance
 	Items []VirtualCircuitPublicPrefix `presentIn:"body"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_virtual_circuits_request_response.go
+++ b/core/list_virtual_circuits_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListVirtualCircuitsRequest wrapper for the ListVirtualCircuits operation
 type ListVirtualCircuitsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
@@ -76,13 +76,13 @@ type ListVirtualCircuitsResponse struct {
 	// A list of []VirtualCircuit instances
 	Items []VirtualCircuit `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_vnic_attachments_request_response.go
+++ b/core/list_vnic_attachments_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListVnicAttachmentsRequest wrapper for the ListVnicAttachments operation
 type ListVnicAttachmentsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// The name of the availability domain.
@@ -67,13 +67,13 @@ type ListVnicAttachmentsResponse struct {
 	// A list of []VnicAttachment instances
 	Items []VnicAttachment `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_volume_attachments_request_response.go
+++ b/core/list_volume_attachments_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListVolumeAttachmentsRequest wrapper for the ListVolumeAttachments operation
 type ListVolumeAttachmentsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// The name of the availability domain.
@@ -67,13 +67,13 @@ type ListVolumeAttachmentsResponse struct {
 	// A list of []VolumeAttachment instances
 	Items []VolumeAttachment `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_volume_backup_policies_request_response.go
+++ b/core/list_volume_backup_policies_request_response.go
@@ -54,13 +54,13 @@ type ListVolumeBackupPoliciesResponse struct {
 	// A list of []VolumeBackupPolicy instances
 	Items []VolumeBackupPolicy `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_volume_backups_request_response.go
+++ b/core/list_volume_backups_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListVolumeBackupsRequest wrapper for the ListVolumeBackups operation
 type ListVolumeBackupsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// The OCID of the volume.
@@ -82,13 +82,13 @@ type ListVolumeBackupsResponse struct {
 	// A list of []VolumeBackup instances
 	Items []VolumeBackup `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_volume_group_backups_request_response.go
+++ b/core/list_volume_group_backups_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListVolumeGroupBackupsRequest wrapper for the ListVolumeGroupBackups operation
 type ListVolumeGroupBackupsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// The OCID of the volume group.
@@ -76,13 +76,13 @@ type ListVolumeGroupBackupsResponse struct {
 	// A list of []VolumeGroupBackup instances
 	Items []VolumeGroupBackup `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_volume_groups_request_response.go
+++ b/core/list_volume_groups_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListVolumeGroupsRequest wrapper for the ListVolumeGroups operation
 type ListVolumeGroupsRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// The name of the availability domain.
@@ -80,13 +80,13 @@ type ListVolumeGroupsResponse struct {
 	// A list of []VolumeGroup instances
 	Items []VolumeGroup `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/list_volumes_request_response.go
+++ b/core/list_volumes_request_response.go
@@ -11,7 +11,7 @@ import (
 // ListVolumesRequest wrapper for the ListVolumes operation
 type ListVolumesRequest struct {
 
-	// The OCID of the compartment.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// The name of the availability domain.
@@ -83,13 +83,13 @@ type ListVolumesResponse struct {
 	// A list of []Volume instances
 	Items []Volume `presentIn:"body"`
 
-	// For list pagination. When this header appears in the response, additional pages of
-	// results remain. For important details about how pagination works, see
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/local_peering_gateway.go
+++ b/core/local_peering_gateway.go
@@ -57,14 +57,13 @@ type LocalPeeringGateway struct {
 	// The OCID of the VCN the LPG belongs to.
 	VcnId *string `mandatory:"true" json:"vcnId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/nat_gateway.go
+++ b/core/nat_gateway.go
@@ -54,8 +54,8 @@ type NatGateway struct {
 	// belongs to.
 	VcnId *string `mandatory:"true" json:"vcnId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -64,8 +64,7 @@ type NatGateway struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/private_ip.go
+++ b/core/private_ip.go
@@ -52,8 +52,8 @@ type PrivateIp struct {
 	// The OCID of the compartment containing the private IP.
 	CompartmentId *string `mandatory:"false" json:"compartmentId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -62,8 +62,7 @@ type PrivateIp struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/public_ip.go
+++ b/core/public_ip.go
@@ -47,8 +47,8 @@ type PublicIp struct {
 	// its compartment can be different from the assigned private IP's.
 	CompartmentId *string `mandatory:"false" json:"compartmentId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -57,8 +57,7 @@ type PublicIp struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/reset_instance_pool_request_response.go
+++ b/core/reset_instance_pool_request_response.go
@@ -61,8 +61,8 @@ type ResetInstancePoolResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/route_table.go
+++ b/core/route_table.go
@@ -41,8 +41,8 @@ type RouteTable struct {
 	// The OCID of the VCN the route table list belongs to.
 	VcnId *string `mandatory:"true" json:"vcnId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -51,8 +51,7 @@ type RouteTable struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/security_list.go
+++ b/core/security_list.go
@@ -57,14 +57,13 @@ type SecurityList struct {
 	// The OCID of the VCN the security list belongs to.
 	VcnId *string `mandatory:"true" json:"vcnId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/service_gateway.go
+++ b/core/service_gateway.go
@@ -55,8 +55,8 @@ type ServiceGateway struct {
 	// belongs to.
 	VcnId *string `mandatory:"true" json:"vcnId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -65,8 +65,7 @@ type ServiceGateway struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/softreset_instance_pool_request_response.go
+++ b/core/softreset_instance_pool_request_response.go
@@ -61,8 +61,8 @@ type SoftresetInstancePoolResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/start_instance_pool_request_response.go
+++ b/core/start_instance_pool_request_response.go
@@ -61,8 +61,8 @@ type StartInstancePoolResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/stop_instance_pool_request_response.go
+++ b/core/stop_instance_pool_request_response.go
@@ -61,8 +61,8 @@ type StopInstancePoolResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/subnet.go
+++ b/core/subnet.go
@@ -60,8 +60,8 @@ type Subnet struct {
 	// Example: `Uocm:PHX-AD-1`
 	AvailabilityDomain *string `mandatory:"false" json:"availabilityDomain"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -85,8 +85,7 @@ type Subnet struct {
 	DnsLabel *string `mandatory:"false" json:"dnsLabel"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/terminate_instance_pool_request_response.go
+++ b/core/terminate_instance_pool_request_response.go
@@ -48,8 +48,8 @@ type TerminateInstancePoolResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/terminate_instance_request_response.go
+++ b/core/terminate_instance_request_response.go
@@ -52,8 +52,8 @@ type TerminateInstanceResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/tunnel_config.go
+++ b/core/tunnel_config.go
@@ -26,7 +26,7 @@ type TunnelConfig struct {
 	IpAddress *string `mandatory:"true" json:"ipAddress"`
 
 	// The shared secret of the IPSec tunnel.
-	// Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
+	// Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
 	SharedSecret *string `mandatory:"true" json:"sharedSecret"`
 
 	// The date and time the IPSec connection was created, in the format defined by RFC3339.

--- a/core/update_boot_volume_backup_details.go
+++ b/core/update_boot_volume_backup_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateBootVolumeBackupDetails The representation of UpdateBootVolumeBackupDetails
 type UpdateBootVolumeBackupDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -29,8 +29,7 @@ type UpdateBootVolumeBackupDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/update_boot_volume_details.go
+++ b/core/update_boot_volume_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateBootVolumeDetails The representation of UpdateBootVolumeDetails
 type UpdateBootVolumeDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -29,8 +29,7 @@ type UpdateBootVolumeDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/update_boot_volume_kms_key_request_response.go
+++ b/core/update_boot_volume_kms_key_request_response.go
@@ -57,8 +57,8 @@ type UpdateBootVolumeKmsKeyResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_boot_volume_request_response.go
+++ b/core/update_boot_volume_request_response.go
@@ -57,8 +57,8 @@ type UpdateBootVolumeResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_console_history_details.go
+++ b/core/update_console_history_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateConsoleHistoryDetails The representation of UpdateConsoleHistoryDetails
 type UpdateConsoleHistoryDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -28,8 +28,7 @@ type UpdateConsoleHistoryDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/update_console_history_request_response.go
+++ b/core/update_console_history_request_response.go
@@ -57,8 +57,8 @@ type UpdateConsoleHistoryResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_cpe_details.go
+++ b/core/update_cpe_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateCpeDetails The representation of UpdateCpeDetails
 type UpdateCpeDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -29,8 +29,7 @@ type UpdateCpeDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/update_cpe_request_response.go
+++ b/core/update_cpe_request_response.go
@@ -57,8 +57,8 @@ type UpdateCpeResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_cross_connect_group_request_response.go
+++ b/core/update_cross_connect_group_request_response.go
@@ -57,8 +57,8 @@ type UpdateCrossConnectGroupResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_cross_connect_request_response.go
+++ b/core/update_cross_connect_request_response.go
@@ -57,8 +57,8 @@ type UpdateCrossConnectResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_dhcp_details.go
+++ b/core/update_dhcp_details.go
@@ -20,8 +20,8 @@ import (
 // UpdateDhcpDetails The representation of UpdateDhcpDetails
 type UpdateDhcpDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -30,8 +30,7 @@ type UpdateDhcpDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/update_dhcp_options_request_response.go
+++ b/core/update_dhcp_options_request_response.go
@@ -57,8 +57,8 @@ type UpdateDhcpOptionsResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_drg_attachment_request_response.go
+++ b/core/update_drg_attachment_request_response.go
@@ -57,8 +57,8 @@ type UpdateDrgAttachmentResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_drg_details.go
+++ b/core/update_drg_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateDrgDetails The representation of UpdateDrgDetails
 type UpdateDrgDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -29,8 +29,7 @@ type UpdateDrgDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/update_drg_request_response.go
+++ b/core/update_drg_request_response.go
@@ -57,8 +57,8 @@ type UpdateDrgResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_i_p_sec_connection_request_response.go
+++ b/core/update_i_p_sec_connection_request_response.go
@@ -57,8 +57,8 @@ type UpdateIPSecConnectionResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_i_p_sec_connection_tunnel_request_response.go
+++ b/core/update_i_p_sec_connection_tunnel_request_response.go
@@ -60,8 +60,8 @@ type UpdateIPSecConnectionTunnelResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_i_p_sec_connection_tunnel_shared_secret_request_response.go
+++ b/core/update_i_p_sec_connection_tunnel_shared_secret_request_response.go
@@ -60,8 +60,8 @@ type UpdateIPSecConnectionTunnelSharedSecretResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_image_details.go
+++ b/core/update_image_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateImageDetails The representation of UpdateImageDetails
 type UpdateImageDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -30,10 +30,17 @@ type UpdateImageDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Operating system
+	// Example: `Oracle Linux`
+	OperatingSystem *string `mandatory:"false" json:"operatingSystem"`
+
+	// Operating system version
+	// Example: `7.4`
+	OperatingSystemVersion *string `mandatory:"false" json:"operatingSystemVersion"`
 }
 
 func (m UpdateImageDetails) String() string {

--- a/core/update_image_request_response.go
+++ b/core/update_image_request_response.go
@@ -64,8 +64,8 @@ type UpdateImageResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_instance_configuration_details.go
+++ b/core/update_instance_configuration_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateInstanceConfigurationDetails The representation of UpdateInstanceConfigurationDetails
 type UpdateInstanceConfigurationDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -30,8 +30,7 @@ type UpdateInstanceConfigurationDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/update_instance_configuration_request_response.go
+++ b/core/update_instance_configuration_request_response.go
@@ -64,8 +64,8 @@ type UpdateInstanceConfigurationResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_instance_details.go
+++ b/core/update_instance_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateInstanceDetails The representation of UpdateInstanceDetails
 type UpdateInstanceDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -30,8 +30,7 @@ type UpdateInstanceDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/update_instance_pool_details.go
+++ b/core/update_instance_pool_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateInstancePoolDetails The data to update an instance pool.
 type UpdateInstancePoolDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -28,8 +28,7 @@ type UpdateInstancePoolDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/update_instance_pool_request_response.go
+++ b/core/update_instance_pool_request_response.go
@@ -64,8 +64,8 @@ type UpdateInstancePoolResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_instance_request_response.go
+++ b/core/update_instance_request_response.go
@@ -64,8 +64,8 @@ type UpdateInstanceResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_internet_gateway_details.go
+++ b/core/update_internet_gateway_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateInternetGatewayDetails The representation of UpdateInternetGatewayDetails
 type UpdateInternetGatewayDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -29,8 +29,7 @@ type UpdateInternetGatewayDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/update_internet_gateway_request_response.go
+++ b/core/update_internet_gateway_request_response.go
@@ -57,8 +57,8 @@ type UpdateInternetGatewayResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_ip_sec_connection_details.go
+++ b/core/update_ip_sec_connection_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateIpSecConnectionDetails The representation of UpdateIpSecConnectionDetails
 type UpdateIpSecConnectionDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -29,14 +29,15 @@ type UpdateIpSecConnectionDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 
 	// Your identifier for your CPE device. Can be either an IP address or a hostname (specifically, the
 	// fully qualified domain name (FQDN)). The type of identifier you provide here must correspond
 	// to the value for `cpeLocalIdentifierType`.
+	// For information about why you'd provide this value, see
+	// If Your CPE Is Behind a NAT Device (https://docs.cloud.oracle.com/Content/Network/Tasks/overviewIPsec.htm#nat).
 	// Example IP address: `10.0.3.3`
 	// Example hostname: `cpe.example.com`
 	CpeLocalIdentifier *string `mandatory:"false" json:"cpeLocalIdentifier"`

--- a/core/update_ip_sec_connection_tunnel_shared_secret_details.go
+++ b/core/update_ip_sec_connection_tunnel_shared_secret_details.go
@@ -19,8 +19,9 @@ import (
 // UpdateIpSecConnectionTunnelSharedSecretDetails The representation of UpdateIpSecConnectionTunnelSharedSecretDetails
 type UpdateIpSecConnectionTunnelSharedSecretDetails struct {
 
-	// The shared secret (pre-shared key) to use for the tunnel.
-	// Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
+	// The shared secret (pre-shared key) to use for the tunnel. Only numbers, letters, and spaces
+	// are allowed.
+	// Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
 	SharedSecret *string `mandatory:"false" json:"sharedSecret"`
 }
 

--- a/core/update_local_peering_gateway_details.go
+++ b/core/update_local_peering_gateway_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateLocalPeeringGatewayDetails The representation of UpdateLocalPeeringGatewayDetails
 type UpdateLocalPeeringGatewayDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -29,8 +29,7 @@ type UpdateLocalPeeringGatewayDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/update_local_peering_gateway_request_response.go
+++ b/core/update_local_peering_gateway_request_response.go
@@ -57,8 +57,8 @@ type UpdateLocalPeeringGatewayResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_nat_gateway_details.go
+++ b/core/update_nat_gateway_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateNatGatewayDetails The representation of UpdateNatGatewayDetails
 type UpdateNatGatewayDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -29,8 +29,7 @@ type UpdateNatGatewayDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/update_nat_gateway_request_response.go
+++ b/core/update_nat_gateway_request_response.go
@@ -57,8 +57,8 @@ type UpdateNatGatewayResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_private_ip_details.go
+++ b/core/update_private_ip_details.go
@@ -19,8 +19,8 @@ import (
 // UpdatePrivateIpDetails The representation of UpdatePrivateIpDetails
 type UpdatePrivateIpDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -29,8 +29,7 @@ type UpdatePrivateIpDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/update_private_ip_request_response.go
+++ b/core/update_private_ip_request_response.go
@@ -57,8 +57,8 @@ type UpdatePrivateIpResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_public_ip_details.go
+++ b/core/update_public_ip_details.go
@@ -19,8 +19,8 @@ import (
 // UpdatePublicIpDetails The representation of UpdatePublicIpDetails
 type UpdatePublicIpDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -29,8 +29,7 @@ type UpdatePublicIpDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/update_public_ip_request_response.go
+++ b/core/update_public_ip_request_response.go
@@ -57,8 +57,8 @@ type UpdatePublicIpResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_remote_peering_connection_request_response.go
+++ b/core/update_remote_peering_connection_request_response.go
@@ -57,8 +57,8 @@ type UpdateRemotePeeringConnectionResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_route_table_details.go
+++ b/core/update_route_table_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateRouteTableDetails The representation of UpdateRouteTableDetails
 type UpdateRouteTableDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -29,8 +29,7 @@ type UpdateRouteTableDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/update_route_table_request_response.go
+++ b/core/update_route_table_request_response.go
@@ -57,8 +57,8 @@ type UpdateRouteTableResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_security_list_details.go
+++ b/core/update_security_list_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateSecurityListDetails The representation of UpdateSecurityListDetails
 type UpdateSecurityListDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -32,8 +32,7 @@ type UpdateSecurityListDetails struct {
 	EgressSecurityRules []EgressSecurityRule `mandatory:"false" json:"egressSecurityRules"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/update_security_list_request_response.go
+++ b/core/update_security_list_request_response.go
@@ -57,8 +57,8 @@ type UpdateSecurityListResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_service_gateway_details.go
+++ b/core/update_service_gateway_details.go
@@ -24,8 +24,8 @@ type UpdateServiceGatewayDetails struct {
 	// Example: `true`
 	BlockTraffic *bool `mandatory:"false" json:"blockTraffic"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -34,8 +34,7 @@ type UpdateServiceGatewayDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/update_service_gateway_request_response.go
+++ b/core/update_service_gateway_request_response.go
@@ -57,8 +57,8 @@ type UpdateServiceGatewayResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_subnet_details.go
+++ b/core/update_subnet_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateSubnetDetails The representation of UpdateSubnetDetails
 type UpdateSubnetDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -32,8 +32,7 @@ type UpdateSubnetDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/update_subnet_request_response.go
+++ b/core/update_subnet_request_response.go
@@ -57,8 +57,8 @@ type UpdateSubnetResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_vcn_details.go
+++ b/core/update_vcn_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateVcnDetails The representation of UpdateVcnDetails
 type UpdateVcnDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -29,8 +29,7 @@ type UpdateVcnDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/update_vcn_request_response.go
+++ b/core/update_vcn_request_response.go
@@ -11,7 +11,7 @@ import (
 // UpdateVcnRequest wrapper for the UpdateVcn operation
 type UpdateVcnRequest struct {
 
-	// The OCID of the VCN.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
 	VcnId *string `mandatory:"true" contributesTo:"path" name:"vcnId"`
 
 	// Details object for updating a VCN.
@@ -57,8 +57,8 @@ type UpdateVcnResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_virtual_circuit_request_response.go
+++ b/core/update_virtual_circuit_request_response.go
@@ -57,8 +57,8 @@ type UpdateVirtualCircuitResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_vnic_details.go
+++ b/core/update_vnic_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateVnicDetails The representation of UpdateVnicDetails
 type UpdateVnicDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -28,8 +28,7 @@ type UpdateVnicDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/update_vnic_request_response.go
+++ b/core/update_vnic_request_response.go
@@ -57,8 +57,8 @@ type UpdateVnicResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_volume_backup_details.go
+++ b/core/update_volume_backup_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateVolumeBackupDetails The representation of UpdateVolumeBackupDetails
 type UpdateVolumeBackupDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -29,8 +29,7 @@ type UpdateVolumeBackupDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/update_volume_details.go
+++ b/core/update_volume_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateVolumeDetails The representation of UpdateVolumeDetails
 type UpdateVolumeDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -29,8 +29,7 @@ type UpdateVolumeDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/update_volume_group_backup_details.go
+++ b/core/update_volume_group_backup_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateVolumeGroupBackupDetails The representation of UpdateVolumeGroupBackupDetails
 type UpdateVolumeGroupBackupDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -28,8 +28,7 @@ type UpdateVolumeGroupBackupDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 }

--- a/core/update_volume_group_details.go
+++ b/core/update_volume_group_details.go
@@ -19,8 +19,8 @@ import (
 // UpdateVolumeGroupDetails The representation of UpdateVolumeGroupDetails
 type UpdateVolumeGroupDetails struct {
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -28,8 +28,7 @@ type UpdateVolumeGroupDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/update_volume_group_request_response.go
+++ b/core/update_volume_group_request_response.go
@@ -57,8 +57,8 @@ type UpdateVolumeGroupResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_volume_kms_key_request_response.go
+++ b/core/update_volume_kms_key_request_response.go
@@ -57,8 +57,8 @@ type UpdateVolumeKmsKeyResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/update_volume_request_response.go
+++ b/core/update_volume_request_response.go
@@ -57,8 +57,8 @@ type UpdateVolumeResponse struct {
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-	// a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 

--- a/core/vcn.go
+++ b/core/vcn.go
@@ -47,8 +47,8 @@ type Vcn struct {
 	// The OCID for the VCN's default security list.
 	DefaultSecurityListId *string `mandatory:"false" json:"defaultSecurityListId"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -69,8 +69,7 @@ type Vcn struct {
 	DnsLabel *string `mandatory:"false" json:"dnsLabel"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/vnic.go
+++ b/core/vnic.go
@@ -53,8 +53,8 @@ type Vnic struct {
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -63,8 +63,7 @@ type Vnic struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/volume.go
+++ b/core/volume.go
@@ -50,14 +50,13 @@ type Volume struct {
 	// The date and time the volume was created. Format defined by RFC3339.
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/volume_backup.go
+++ b/core/volume_backup.go
@@ -46,8 +46,8 @@ type VolumeBackup struct {
 	// The type of a volume backup.
 	Type VolumeBackupTypeEnum `mandatory:"true" json:"type"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
@@ -59,8 +59,7 @@ type VolumeBackup struct {
 	ExpirationTime *common.SDKTime `mandatory:"false" json:"expirationTime"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/volume_group.go
+++ b/core/volume_group.go
@@ -44,14 +44,13 @@ type VolumeGroup struct {
 	// OCIDs for the volumes in this volume group.
 	VolumeIds []string `mandatory:"true" json:"volumeIds"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/core/volume_group_backup.go
+++ b/core/volume_group_backup.go
@@ -47,14 +47,13 @@ type VolumeGroupBackup struct {
 	// OCIDs for the volume backups in this volume group backup.
 	VolumeBackupIds []string `mandatory:"true" json:"volumeBackupIds"`
 
-	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
-	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
-	// predefined name, type, or namespace. For more information, see
-	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 

--- a/database/autonomous_database.go
+++ b/database/autonomous_database.go
@@ -72,6 +72,9 @@ type AutonomousDatabase struct {
 
 	// The client IP access control list (ACL). Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet.
 	WhitelistedIps []string `mandatory:"false" json:"whitelistedIps"`
+
+	// Indicates if auto scaling is enabled for the Autonomous Database CPU core count.
+	IsAutoScalingEnabled *bool `mandatory:"false" json:"isAutoScalingEnabled"`
 }
 
 func (m AutonomousDatabase) String() string {

--- a/database/autonomous_database_summary.go
+++ b/database/autonomous_database_summary.go
@@ -73,6 +73,9 @@ type AutonomousDatabaseSummary struct {
 
 	// The client IP access control list (ACL). Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet.
 	WhitelistedIps []string `mandatory:"false" json:"whitelistedIps"`
+
+	// Indicates if auto scaling is enabled for the Autonomous Database CPU core count.
+	IsAutoScalingEnabled *bool `mandatory:"false" json:"isAutoScalingEnabled"`
 }
 
 func (m AutonomousDatabaseSummary) String() string {

--- a/database/create_autonomous_database_base.go
+++ b/database/create_autonomous_database_base.go
@@ -41,6 +41,9 @@ type CreateAutonomousDatabaseBase interface {
 	// The Oracle license model that applies to the Oracle Autonomous Database. The default is BRING_YOUR_OWN_LICENSE.
 	GetLicenseModel() CreateAutonomousDatabaseBaseLicenseModelEnum
 
+	// Indicates if auto scaling is enabled for the Autonomous Database CPU core count. The default value is false.
+	GetIsAutoScalingEnabled() *bool
+
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
@@ -62,6 +65,7 @@ type createautonomousdatabasebase struct {
 	DbWorkload           CreateAutonomousDatabaseBaseDbWorkloadEnum   `mandatory:"false" json:"dbWorkload,omitempty"`
 	DisplayName          *string                                      `mandatory:"false" json:"displayName"`
 	LicenseModel         CreateAutonomousDatabaseBaseLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
+	IsAutoScalingEnabled *bool                                        `mandatory:"false" json:"isAutoScalingEnabled"`
 	FreeformTags         map[string]string                            `mandatory:"false" json:"freeformTags"`
 	DefinedTags          map[string]map[string]interface{}            `mandatory:"false" json:"definedTags"`
 	Source               string                                       `json:"source"`
@@ -86,6 +90,7 @@ func (m *createautonomousdatabasebase) UnmarshalJSON(data []byte) error {
 	m.DbWorkload = s.Model.DbWorkload
 	m.DisplayName = s.Model.DisplayName
 	m.LicenseModel = s.Model.LicenseModel
+	m.IsAutoScalingEnabled = s.Model.IsAutoScalingEnabled
 	m.FreeformTags = s.Model.FreeformTags
 	m.DefinedTags = s.Model.DefinedTags
 	m.Source = s.Model.Source
@@ -153,6 +158,11 @@ func (m createautonomousdatabasebase) GetDisplayName() *string {
 //GetLicenseModel returns LicenseModel
 func (m createautonomousdatabasebase) GetLicenseModel() CreateAutonomousDatabaseBaseLicenseModelEnum {
 	return m.LicenseModel
+}
+
+//GetIsAutoScalingEnabled returns IsAutoScalingEnabled
+func (m createautonomousdatabasebase) GetIsAutoScalingEnabled() *bool {
+	return m.IsAutoScalingEnabled
 }
 
 //GetFreeformTags returns FreeformTags

--- a/database/create_autonomous_database_clone_details.go
+++ b/database/create_autonomous_database_clone_details.go
@@ -37,6 +37,9 @@ type CreateAutonomousDatabaseCloneDetails struct {
 	// The user-friendly name for the Autonomous Database. The name does not have to be unique.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
+	// Indicates if auto scaling is enabled for the Autonomous Database CPU core count. The default value is false.
+	IsAutoScalingEnabled *bool `mandatory:"false" json:"isAutoScalingEnabled"`
+
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
@@ -95,6 +98,11 @@ func (m CreateAutonomousDatabaseCloneDetails) GetDisplayName() *string {
 //GetLicenseModel returns LicenseModel
 func (m CreateAutonomousDatabaseCloneDetails) GetLicenseModel() CreateAutonomousDatabaseBaseLicenseModelEnum {
 	return m.LicenseModel
+}
+
+//GetIsAutoScalingEnabled returns IsAutoScalingEnabled
+func (m CreateAutonomousDatabaseCloneDetails) GetIsAutoScalingEnabled() *bool {
+	return m.IsAutoScalingEnabled
 }
 
 //GetFreeformTags returns FreeformTags

--- a/database/create_autonomous_database_details.go
+++ b/database/create_autonomous_database_details.go
@@ -34,6 +34,9 @@ type CreateAutonomousDatabaseDetails struct {
 	// The user-friendly name for the Autonomous Database. The name does not have to be unique.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
+	// Indicates if auto scaling is enabled for the Autonomous Database CPU core count. The default value is false.
+	IsAutoScalingEnabled *bool `mandatory:"false" json:"isAutoScalingEnabled"`
+
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
@@ -89,6 +92,11 @@ func (m CreateAutonomousDatabaseDetails) GetDisplayName() *string {
 //GetLicenseModel returns LicenseModel
 func (m CreateAutonomousDatabaseDetails) GetLicenseModel() CreateAutonomousDatabaseBaseLicenseModelEnum {
 	return m.LicenseModel
+}
+
+//GetIsAutoScalingEnabled returns IsAutoScalingEnabled
+func (m CreateAutonomousDatabaseDetails) GetIsAutoScalingEnabled() *bool {
+	return m.IsAutoScalingEnabled
 }
 
 //GetFreeformTags returns FreeformTags

--- a/database/update_autonomous_database_details.go
+++ b/database/update_autonomous_database_details.go
@@ -43,6 +43,9 @@ type UpdateAutonomousDatabaseDetails struct {
 
 	// The client IP access control list (ACL). Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet. To delete all the existing white listed IP’s, use an array with a single empty string entry.
 	WhitelistedIps []string `mandatory:"false" json:"whitelistedIps"`
+
+	// Indicates if auto scaling is enabled for the Autonomous Database CPU core count. The default value is false.
+	IsAutoScalingEnabled *bool `mandatory:"false" json:"isAutoScalingEnabled"`
 }
 
 func (m UpdateAutonomousDatabaseDetails) String() string {

--- a/example/example_database_test.go
+++ b/example/example_database_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+//
+// Example code for Database API
+//
+package example
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/oracle/oci-go-sdk/common"
+	"github.com/oracle/oci-go-sdk/database"
+	"github.com/oracle/oci-go-sdk/example/helpers"
+)
+
+func ExampleCreateAdb() {
+	c, clerr := database.NewDatabaseClientWithConfigurationProvider(common.DefaultConfigProvider())
+	helpers.FatalIfError(clerr)
+
+	req := database.CreateAutonomousDatabaseDetails{
+		CompartmentId:        helpers.CompartmentID(),
+		DbName:               common.String("gosdkdb"),
+		CpuCoreCount:         common.Int(1),
+		DataStorageSizeInTBs: common.Int(1),
+		AdminPassword:        common.String("DBaaS12345_#"),
+		IsAutoScalingEnabled: common.Bool(true),
+	}
+
+	createadbReq := database.CreateAutonomousDatabaseRequest{
+		CreateAutonomousDatabaseDetails: req,
+	}
+
+	_, err := c.CreateAutonomousDatabase(context.Background(), createadbReq)
+	helpers.FatalIfError(err)
+
+	fmt.Println("create adb successful")
+
+	// Output:
+	// create adb successful
+}
+
+func ExampleUpdateAdb() {
+	c, clerr := database.NewDatabaseClientWithConfigurationProvider(common.DefaultConfigProvider())
+	helpers.FatalIfError(clerr)
+
+	req := database.UpdateAutonomousDatabaseDetails{
+		CpuCoreCount:         common.Int(2),
+		DataStorageSizeInTBs: common.Int(2),
+		IsAutoScalingEnabled: common.Bool(false),
+	}
+
+	updateReq := database.UpdateAutonomousDatabaseRequest{
+		AutonomousDatabaseId:            common.String("replacewithvalidocid"),
+		UpdateAutonomousDatabaseDetails: req,
+	}
+	_, err := c.UpdateAutonomousDatabase(context.Background(), updateReq)
+	helpers.FatalIfError(err)
+
+	fmt.Println("update adb successful")
+
+	// Output:
+	// update adb successful
+}

--- a/identity/create_tag_request_response.go
+++ b/identity/create_tag_request_response.go
@@ -59,6 +59,9 @@ type CreateTagResponse struct {
 	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
 	// particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
 }
 
 func (response CreateTagResponse) String() string {

--- a/identity/delete_tag_namespace_request_response.go
+++ b/identity/delete_tag_namespace_request_response.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package identity
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteTagNamespaceRequest wrapper for the DeleteTagNamespace operation
+type DeleteTagNamespaceRequest struct {
+
+	// The OCID of the tag namespace.
+	TagNamespaceId *string `mandatory:"true" contributesTo:"path" name:"tagNamespaceId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteTagNamespaceRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteTagNamespaceRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteTagNamespaceRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteTagNamespaceResponse wrapper for the DeleteTagNamespace operation
+type DeleteTagNamespaceResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteTagNamespaceResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteTagNamespaceResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/identity/delete_tag_request_response.go
+++ b/identity/delete_tag_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package identity
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteTagRequest wrapper for the DeleteTag operation
+type DeleteTagRequest struct {
+
+	// The OCID of the tag namespace.
+	TagNamespaceId *string `mandatory:"true" contributesTo:"path" name:"tagNamespaceId"`
+
+	// The name of the tag.
+	TagName *string `mandatory:"true" contributesTo:"path" name:"tagName"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteTagRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteTagRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteTagRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteTagResponse wrapper for the DeleteTag operation
+type DeleteTagResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+}
+
+func (response DeleteTagResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteTagResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/identity/get_tag_request_response.go
+++ b/identity/get_tag_request_response.go
@@ -52,6 +52,9 @@ type GetTagResponse struct {
 	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
 	// particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
 }
 
 func (response GetTagResponse) String() string {

--- a/identity/identity_client.go
+++ b/identity/identity_client.go
@@ -1661,6 +1661,48 @@ func (client IdentityClient) deleteSwiftPassword(ctx context.Context, request co
 	return response, err
 }
 
+// DeleteTag Deletes the the specified tag definition.
+func (client IdentityClient) DeleteTag(ctx context.Context, request DeleteTagRequest) (response DeleteTagResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteTag, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = DeleteTagResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteTagResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteTagResponse")
+	}
+	return
+}
+
+// deleteTag implements the OCIOperation interface (enables retrying operations)
+func (client IdentityClient) deleteTag(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/tagNamespaces/{tagNamespaceId}/tags/{tagName}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteTagResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // DeleteTagDefault Deletes the the specified tag default.
 func (client IdentityClient) DeleteTagDefault(ctx context.Context, request DeleteTagDefaultRequest) (response DeleteTagDefaultResponse, err error) {
 	var ociResponse common.OCIResponse
@@ -1691,6 +1733,49 @@ func (client IdentityClient) deleteTagDefault(ctx context.Context, request commo
 	}
 
 	var response DeleteTagDefaultResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteTagNamespace Delete the specified tag namespace. Only an empty tagnamespace can be deleted.
+// If the tag namespace you are trying to delete is not empty, please remove tag definitions from it first.
+func (client IdentityClient) DeleteTagNamespace(ctx context.Context, request DeleteTagNamespaceRequest) (response DeleteTagNamespaceResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteTagNamespace, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = DeleteTagNamespaceResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteTagNamespaceResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteTagNamespaceResponse")
+	}
+	return
+}
+
+// deleteTagNamespace implements the OCIOperation interface (enables retrying operations)
+func (client IdentityClient) deleteTagNamespace(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/tagNamespaces/{tagNamespaceId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteTagNamespaceResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -4127,7 +4212,7 @@ func (client IdentityClient) updateTag(ctx context.Context, request common.OCIRe
 	return response, err
 }
 
-// UpdateTagDefault Updates the the specified tag default. You can update the following field: `value`.
+// UpdateTagDefault Updates the specified tag default. You can update the following field: `value`.
 func (client IdentityClient) UpdateTagDefault(ctx context.Context, request UpdateTagDefaultRequest) (response UpdateTagDefaultResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()

--- a/identity/list_tag_namespaces_request_response.go
+++ b/identity/list_tag_namespaces_request_response.go
@@ -24,6 +24,9 @@ type ListTagNamespacesRequest struct {
 	// parameter is not specified, only the tag namespaces defined in the specified compartment are retrieved.
 	IncludeSubcompartments *bool `mandatory:"false" contributesTo:"query" name:"includeSubcompartments"`
 
+	// A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+	LifecycleState TagNamespaceLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+
 	// Unique Oracle-assigned identifier for the request.
 	// If you need to contact Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`

--- a/identity/list_tags_request_response.go
+++ b/identity/list_tags_request_response.go
@@ -20,6 +20,9 @@ type ListTagsRequest struct {
 	// The maximum number of items to return in a paginated "List" call.
 	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
 
+	// A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+	LifecycleState TagLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+
 	// Unique Oracle-assigned identifier for the request.
 	// If you need to contact Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`

--- a/identity/tag.go
+++ b/identity/tag.go
@@ -53,10 +53,40 @@ type Tag struct {
 	// Example: `{"Operations": {"CostCenter": "42"}}``
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
+	// The tag's current state. After creating a tag, make sure its `lifecycleState` is ACTIVE before using it. After retiring a tag, make sure its `lifecycleState` is INACTIVE before using it.
+	LifecycleState TagLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
 	// Indicates whether the tag is enabled for cost tracking.
 	IsCostTracking *bool `mandatory:"false" json:"isCostTracking"`
 }
 
 func (m Tag) String() string {
 	return common.PointerString(m)
+}
+
+// TagLifecycleStateEnum Enum with underlying type: string
+type TagLifecycleStateEnum string
+
+// Set of constants representing the allowable values for TagLifecycleStateEnum
+const (
+	TagLifecycleStateActive   TagLifecycleStateEnum = "ACTIVE"
+	TagLifecycleStateInactive TagLifecycleStateEnum = "INACTIVE"
+	TagLifecycleStateDeleting TagLifecycleStateEnum = "DELETING"
+	TagLifecycleStateDeleted  TagLifecycleStateEnum = "DELETED"
+)
+
+var mappingTagLifecycleState = map[string]TagLifecycleStateEnum{
+	"ACTIVE":   TagLifecycleStateActive,
+	"INACTIVE": TagLifecycleStateInactive,
+	"DELETING": TagLifecycleStateDeleting,
+	"DELETED":  TagLifecycleStateDeleted,
+}
+
+// GetTagLifecycleStateEnumValues Enumerates the set of values for TagLifecycleStateEnum
+func GetTagLifecycleStateEnumValues() []TagLifecycleStateEnum {
+	values := make([]TagLifecycleStateEnum, 0)
+	for _, v := range mappingTagLifecycleState {
+		values = append(values, v)
+	}
+	return values
 }

--- a/identity/tag_namespace.go
+++ b/identity/tag_namespace.go
@@ -45,8 +45,38 @@ type TagNamespace struct {
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// The tagnamespace's current state. After creating a tagnamespace, make sure its `lifecycleState` is ACTIVE before using it. After retiring a tagnamespace, make sure its `lifecycleState` is INACTIVE before using it.
+	LifecycleState TagNamespaceLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
 }
 
 func (m TagNamespace) String() string {
 	return common.PointerString(m)
+}
+
+// TagNamespaceLifecycleStateEnum Enum with underlying type: string
+type TagNamespaceLifecycleStateEnum string
+
+// Set of constants representing the allowable values for TagNamespaceLifecycleStateEnum
+const (
+	TagNamespaceLifecycleStateActive   TagNamespaceLifecycleStateEnum = "ACTIVE"
+	TagNamespaceLifecycleStateInactive TagNamespaceLifecycleStateEnum = "INACTIVE"
+	TagNamespaceLifecycleStateDeleting TagNamespaceLifecycleStateEnum = "DELETING"
+	TagNamespaceLifecycleStateDeleted  TagNamespaceLifecycleStateEnum = "DELETED"
+)
+
+var mappingTagNamespaceLifecycleState = map[string]TagNamespaceLifecycleStateEnum{
+	"ACTIVE":   TagNamespaceLifecycleStateActive,
+	"INACTIVE": TagNamespaceLifecycleStateInactive,
+	"DELETING": TagNamespaceLifecycleStateDeleting,
+	"DELETED":  TagNamespaceLifecycleStateDeleted,
+}
+
+// GetTagNamespaceLifecycleStateEnumValues Enumerates the set of values for TagNamespaceLifecycleStateEnum
+func GetTagNamespaceLifecycleStateEnumValues() []TagNamespaceLifecycleStateEnum {
+	values := make([]TagNamespaceLifecycleStateEnum, 0)
+	for _, v := range mappingTagNamespaceLifecycleState {
+		values = append(values, v)
+	}
+	return values
 }

--- a/identity/tag_namespace_summary.go
+++ b/identity/tag_namespace_summary.go
@@ -41,6 +41,9 @@ type TagNamespaceSummary struct {
 	// For more information, see Retiring Key Definitions and Namespace Definitions (https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm#Retiring).
 	IsRetired *bool `mandatory:"false" json:"isRetired"`
 
+	// The tagnamespace's current state. After creating a tagnamespace, make sure its `lifecycleState` is ACTIVE before using it. After retiring a tagnamespace, make sure its `lifecycleState` is INACTIVE before using it.
+	LifecycleState TagNamespaceLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
 	// Date and time the tag namespace was created, in the format defined by RFC3339.
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`

--- a/identity/tag_summary.go
+++ b/identity/tag_summary.go
@@ -41,6 +41,9 @@ type TagSummary struct {
 	// See Retiring Key Definitions and Namespace Definitions (https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm#Retiring).
 	IsRetired *bool `mandatory:"false" json:"isRetired"`
 
+	// The tag's current state. After creating a tag, make sure its `lifecycleState` is ACTIVE before using it. After retiring a tag, make sure its `lifecycleState` is INACTIVE before using it.
+	LifecycleState TagLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
 	// Date and time the tag was created, in the format defined by RFC3339.
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`

--- a/identity/update_tag_request_response.go
+++ b/identity/update_tag_request_response.go
@@ -20,6 +20,11 @@ type UpdateTagRequest struct {
 	// Request object for updating a tag.
 	UpdateTagDetails `contributesTo:"body"`
 
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
 	// Unique Oracle-assigned identifier for the request.
 	// If you need to contact Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
@@ -55,6 +60,9 @@ type UpdateTagResponse struct {
 	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
 	// particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
 }
 
 func (response UpdateTagResponse) String() string {

--- a/identity/work_request.go
+++ b/identity/work_request.go
@@ -62,11 +62,13 @@ type WorkRequestOperationTypeEnum string
 
 // Set of constants representing the allowable values for WorkRequestOperationTypeEnum
 const (
-	WorkRequestOperationTypeCompartment WorkRequestOperationTypeEnum = "DELETE_COMPARTMENT"
+	WorkRequestOperationTypeCompartment   WorkRequestOperationTypeEnum = "DELETE_COMPARTMENT"
+	WorkRequestOperationTypeTagDefinition WorkRequestOperationTypeEnum = "DELETE_TAG_DEFINITION"
 )
 
 var mappingWorkRequestOperationType = map[string]WorkRequestOperationTypeEnum{
-	"DELETE_COMPARTMENT": WorkRequestOperationTypeCompartment,
+	"DELETE_COMPARTMENT":    WorkRequestOperationTypeCompartment,
+	"DELETE_TAG_DEFINITION": WorkRequestOperationTypeTagDefinition,
 }
 
 // GetWorkRequestOperationTypeEnumValues Enumerates the set of values for WorkRequestOperationTypeEnum

--- a/identity/work_request_summary.go
+++ b/identity/work_request_summary.go
@@ -58,11 +58,13 @@ type WorkRequestSummaryOperationTypeEnum string
 
 // Set of constants representing the allowable values for WorkRequestSummaryOperationTypeEnum
 const (
-	WorkRequestSummaryOperationTypeCompartment WorkRequestSummaryOperationTypeEnum = "DELETE_COMPARTMENT"
+	WorkRequestSummaryOperationTypeCompartment   WorkRequestSummaryOperationTypeEnum = "DELETE_COMPARTMENT"
+	WorkRequestSummaryOperationTypeTagDefinition WorkRequestSummaryOperationTypeEnum = "DELETE_TAG_DEFINITION"
 )
 
 var mappingWorkRequestSummaryOperationType = map[string]WorkRequestSummaryOperationTypeEnum{
-	"DELETE_COMPARTMENT": WorkRequestSummaryOperationTypeCompartment,
+	"DELETE_COMPARTMENT":    WorkRequestSummaryOperationTypeCompartment,
+	"DELETE_TAG_DEFINITION": WorkRequestSummaryOperationTypeTagDefinition,
 }
 
 // GetWorkRequestSummaryOperationTypeEnumValues Enumerates the set of values for WorkRequestSummaryOperationTypeEnum

--- a/loadbalancer/loadbalancer_client.go
+++ b/loadbalancer/loadbalancer_client.go
@@ -38,7 +38,7 @@ func NewLoadBalancerClientWithConfigurationProvider(configProvider common.Config
 
 // SetRegion overrides the region of this client.
 func (client *LoadBalancerClient) SetRegion(region string) {
-	client.Host = common.StringToRegion(region).EndpointForTemplate("iaas", "https://iaas.{region}.oraclecloud.com")
+	client.Host = common.StringToRegion(region).EndpointForTemplate("iaas", "https://iaas.{region}.{secondLevelDomain}")
 }
 
 // SetConfigurationProvider sets the configuration provider including the region, returns an error if is not valid

--- a/loadbalancer/session_persistence_configuration_details.go
+++ b/loadbalancer/session_persistence_configuration_details.go
@@ -16,6 +16,7 @@ import (
 // SessionPersistenceConfigurationDetails The configuration details for implementing session persistence. Session persistence enables the Load Balancing
 // Service to direct any number of requests that originate from a single logical client to a single backend web server.
 // For more information, see Session Persistence (https://docs.cloud.oracle.com/Content/Balance/Reference/sessionpersistence.htm).
+//
 // To disable session persistence on a running load balancer, use the
 // UpdateBackendSet operation and specify "null" for the
 // `SessionPersistenceConfigurationDetails` object.


### PR DESCRIPTION
### Added
- Support for autoscaling autonomous databases and autonomous data warehouses in the Database service
- Support for specifying fault domains as part of instance configurations in the Compute Autoscaling service
- Support for deleting tag definitions and tag namespaces in the Identity service

### Fixed
- Support for regions in realms other than oraclecloud.com in the Load Balancing service
