### PR TITLE
Releasing version 5.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## 5.13.0 - 2019-07-02
+### Added
+- Support for moving images, instance configurations, and instance pools across compartments in Core Services
+- Support for moving autoscaling configurations across compartments in the Compute Autoscaling service
+
+### Fixed
+- Fixed a bug where the Streaming service's endpoints in Tokyo, Seoul, and future regions were not reachable from the SDK
+
 ## 5.12.0 - 2019-06-25
 ### Added
 - Support for moving senders across compartments in the Email service

--- a/autoscaling/autoscaling_client.go
+++ b/autoscaling/autoscaling_client.go
@@ -59,6 +59,57 @@ func (client *AutoScalingClient) ConfigurationProvider() *common.ConfigurationPr
 	return client.config
 }
 
+// ChangeAutoScalingConfigurationCompartment Moves an autoscaling configuration into a different compartment within the same tenancy. For information
+// about moving resources between compartments, see
+// Moving Resources to a Different Compartment (https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+// When you move an autoscaling configuration to a different compartment, associated resources such as instance
+// pools are not moved.
+func (client AutoScalingClient) ChangeAutoScalingConfigurationCompartment(ctx context.Context, request ChangeAutoScalingConfigurationCompartmentRequest) (response ChangeAutoScalingConfigurationCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.changeAutoScalingConfigurationCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ChangeAutoScalingConfigurationCompartmentResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeAutoScalingConfigurationCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeAutoScalingConfigurationCompartmentResponse")
+	}
+	return
+}
+
+// changeAutoScalingConfigurationCompartment implements the OCIOperation interface (enables retrying operations)
+func (client AutoScalingClient) changeAutoScalingConfigurationCompartment(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/autoScalingConfigurations/{autoScalingConfigurationId}/actions/changeCompartment")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeAutoScalingConfigurationCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // CreateAutoScalingConfiguration Creates an autoscaling configuration.
 func (client AutoScalingClient) CreateAutoScalingConfiguration(ctx context.Context, request CreateAutoScalingConfigurationRequest) (response CreateAutoScalingConfigurationResponse, err error) {
 	var ociResponse common.OCIResponse

--- a/autoscaling/change_auto_scaling_compartment_details.go
+++ b/autoscaling/change_auto_scaling_compartment_details.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Autoscaling API
+//
+// APIs for dynamically scaling Compute resources to meet application requirements.
+// For information about the Compute service, see Overview of the Compute Service (https://docs.cloud.oracle.com/Content/Compute/Concepts/computeoverview.htm).
+//
+
+package autoscaling
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ChangeAutoScalingCompartmentDetails The configuration details for the move operation.
+type ChangeAutoScalingCompartmentDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the autoscaling configuration to.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+}
+
+func (m ChangeAutoScalingCompartmentDetails) String() string {
+	return common.PointerString(m)
+}

--- a/autoscaling/change_auto_scaling_configuration_compartment_request_response.go
+++ b/autoscaling/change_auto_scaling_configuration_compartment_request_response.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package autoscaling
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ChangeAutoScalingConfigurationCompartmentRequest wrapper for the ChangeAutoScalingConfigurationCompartment operation
+type ChangeAutoScalingConfigurationCompartmentRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the autoscaling configuration.
+	AutoScalingConfigurationId *string `mandatory:"true" contributesTo:"path" name:"autoScalingConfigurationId"`
+
+	// Request to change the compartment of given autoscaling configuration.
+	ChangeCompartmentDetails ChangeAutoScalingCompartmentDetails `contributesTo:"body"`
+
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ChangeAutoScalingConfigurationCompartmentRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ChangeAutoScalingConfigurationCompartmentRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ChangeAutoScalingConfigurationCompartmentRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ChangeAutoScalingConfigurationCompartmentResponse wrapper for the ChangeAutoScalingConfigurationCompartment operation
+type ChangeAutoScalingConfigurationCompartmentResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The resulting etag of the autoscaling configuration affected by this operation.
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ChangeAutoScalingConfigurationCompartmentResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ChangeAutoScalingConfigurationCompartmentResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/autoscaling/create_auto_scaling_configuration_details.go
+++ b/autoscaling/create_auto_scaling_configuration_details.go
@@ -18,7 +18,6 @@ import (
 type CreateAutoScalingConfigurationDetails struct {
 
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment containing the autoscaling configuration.
-	// The autoscaling configuration and the instance pool that it manages must be in the same compartment.
 	CompartmentId *string `mandatory:"true" json:"compartmentId"`
 
 	Policies []CreateAutoScalingPolicyDetails `mandatory:"true" json:"policies"`

--- a/common/version.go
+++ b/common/version.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	major = "5"
-	minor = "12"
+	minor = "13"
 	patch = "0"
 	tag   = ""
 )

--- a/core/change_image_compartment_details.go
+++ b/core/change_image_compartment_details.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ChangeImageCompartmentDetails The configuration details for the move operation.
+type ChangeImageCompartmentDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the image to.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+}
+
+func (m ChangeImageCompartmentDetails) String() string {
+	return common.PointerString(m)
+}

--- a/core/change_image_compartment_request_response.go
+++ b/core/change_image_compartment_request_response.go
@@ -8,14 +8,23 @@ import (
 	"net/http"
 )
 
-// ExportImageRequest wrapper for the ExportImage operation
-type ExportImageRequest struct {
+// ChangeImageCompartmentRequest wrapper for the ChangeImageCompartment operation
+type ChangeImageCompartmentRequest struct {
 
 	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the image.
 	ImageId *string `mandatory:"true" contributesTo:"path" name:"imageId"`
 
-	// Details for the image export.
-	ExportImageDetails `contributesTo:"body"`
+	// Request to change the compartment of a given image.
+	ChangeImageCompartmentDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
 
 	// A token that uniquely identifies a request so it can be retried in case of a timeout or
 	// server error without risk of executing that same action again. Retry tokens expire after 24
@@ -24,42 +33,30 @@ type ExportImageRequest struct {
 	// may be rejected).
 	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
 
-	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
-	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
-	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
-
-	// Unique Oracle-assigned identifier for the request.
-	// If you need to contact Oracle about a particular request, please provide the request ID.
-	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
-
 	// Metadata about the request. This information will not be transmitted to the service, but
 	// represents information that the SDK will consume to drive retry behavior.
 	RequestMetadata common.RequestMetadata
 }
 
-func (request ExportImageRequest) String() string {
+func (request ChangeImageCompartmentRequest) String() string {
 	return common.PointerString(request)
 }
 
 // HTTPRequest implements the OCIRequest interface
-func (request ExportImageRequest) HTTPRequest(method, path string) (http.Request, error) {
+func (request ChangeImageCompartmentRequest) HTTPRequest(method, path string) (http.Request, error) {
 	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
 }
 
 // RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
-func (request ExportImageRequest) RetryPolicy() *common.RetryPolicy {
+func (request ChangeImageCompartmentRequest) RetryPolicy() *common.RetryPolicy {
 	return request.RequestMetadata.RetryPolicy
 }
 
-// ExportImageResponse wrapper for the ExportImage operation
-type ExportImageResponse struct {
+// ChangeImageCompartmentResponse wrapper for the ChangeImageCompartment operation
+type ChangeImageCompartmentResponse struct {
 
 	// The underlying http response
 	RawResponse *http.Response
-
-	// The Image instance
-	Image `presentIn:"body"`
 
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
@@ -67,17 +64,13 @@ type ExportImageResponse struct {
 	// Unique Oracle-assigned identifier for the request. If you need to contact
 	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
-
-	// The OCID of the work request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
-	// with this ID to track the status of the request.
-	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
 }
 
-func (response ExportImageResponse) String() string {
+func (response ChangeImageCompartmentResponse) String() string {
 	return common.PointerString(response)
 }
 
 // HTTPResponse implements the OCIResponse interface
-func (response ExportImageResponse) HTTPResponse() *http.Response {
+func (response ChangeImageCompartmentResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
 }

--- a/core/change_instance_configuration_compartment_details.go
+++ b/core/change_instance_configuration_compartment_details.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ChangeInstanceConfigurationCompartmentDetails The configuration details for the move operation.
+type ChangeInstanceConfigurationCompartmentDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to
+	// move the instance configuration to.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+}
+
+func (m ChangeInstanceConfigurationCompartmentDetails) String() string {
+	return common.PointerString(m)
+}

--- a/core/change_instance_configuration_compartment_request_response.go
+++ b/core/change_instance_configuration_compartment_request_response.go
@@ -8,14 +8,23 @@ import (
 	"net/http"
 )
 
-// ExportImageRequest wrapper for the ExportImage operation
-type ExportImageRequest struct {
+// ChangeInstanceConfigurationCompartmentRequest wrapper for the ChangeInstanceConfigurationCompartment operation
+type ChangeInstanceConfigurationCompartmentRequest struct {
 
-	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the image.
-	ImageId *string `mandatory:"true" contributesTo:"path" name:"imageId"`
+	// The OCID of the instance configuration.
+	InstanceConfigurationId *string `mandatory:"true" contributesTo:"path" name:"instanceConfigurationId"`
 
-	// Details for the image export.
-	ExportImageDetails `contributesTo:"body"`
+	// Request to change the compartment of given instance configuration.
+	ChangeInstanceConfigurationCompartmentDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
 
 	// A token that uniquely identifies a request so it can be retried in case of a timeout or
 	// server error without risk of executing that same action again. Retry tokens expire after 24
@@ -24,42 +33,30 @@ type ExportImageRequest struct {
 	// may be rejected).
 	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
 
-	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
-	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
-	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
-
-	// Unique Oracle-assigned identifier for the request.
-	// If you need to contact Oracle about a particular request, please provide the request ID.
-	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
-
 	// Metadata about the request. This information will not be transmitted to the service, but
 	// represents information that the SDK will consume to drive retry behavior.
 	RequestMetadata common.RequestMetadata
 }
 
-func (request ExportImageRequest) String() string {
+func (request ChangeInstanceConfigurationCompartmentRequest) String() string {
 	return common.PointerString(request)
 }
 
 // HTTPRequest implements the OCIRequest interface
-func (request ExportImageRequest) HTTPRequest(method, path string) (http.Request, error) {
+func (request ChangeInstanceConfigurationCompartmentRequest) HTTPRequest(method, path string) (http.Request, error) {
 	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
 }
 
 // RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
-func (request ExportImageRequest) RetryPolicy() *common.RetryPolicy {
+func (request ChangeInstanceConfigurationCompartmentRequest) RetryPolicy() *common.RetryPolicy {
 	return request.RequestMetadata.RetryPolicy
 }
 
-// ExportImageResponse wrapper for the ExportImage operation
-type ExportImageResponse struct {
+// ChangeInstanceConfigurationCompartmentResponse wrapper for the ChangeInstanceConfigurationCompartment operation
+type ChangeInstanceConfigurationCompartmentResponse struct {
 
 	// The underlying http response
 	RawResponse *http.Response
-
-	// The Image instance
-	Image `presentIn:"body"`
 
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
@@ -67,17 +64,13 @@ type ExportImageResponse struct {
 	// Unique Oracle-assigned identifier for the request. If you need to contact
 	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
-
-	// The OCID of the work request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
-	// with this ID to track the status of the request.
-	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
 }
 
-func (response ExportImageResponse) String() string {
+func (response ChangeInstanceConfigurationCompartmentResponse) String() string {
 	return common.PointerString(response)
 }
 
 // HTTPResponse implements the OCIResponse interface
-func (response ExportImageResponse) HTTPResponse() *http.Response {
+func (response ChangeInstanceConfigurationCompartmentResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
 }

--- a/core/change_instance_pool_compartment_details.go
+++ b/core/change_instance_pool_compartment_details.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ChangeInstancePoolCompartmentDetails The configuration details for the move operation.
+type ChangeInstancePoolCompartmentDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to
+	// move the instance pool to.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+}
+
+func (m ChangeInstancePoolCompartmentDetails) String() string {
+	return common.PointerString(m)
+}

--- a/core/change_instance_pool_compartment_request_response.go
+++ b/core/change_instance_pool_compartment_request_response.go
@@ -8,14 +8,23 @@ import (
 	"net/http"
 )
 
-// ExportImageRequest wrapper for the ExportImage operation
-type ExportImageRequest struct {
+// ChangeInstancePoolCompartmentRequest wrapper for the ChangeInstancePoolCompartment operation
+type ChangeInstancePoolCompartmentRequest struct {
 
-	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the image.
-	ImageId *string `mandatory:"true" contributesTo:"path" name:"imageId"`
+	// The OCID of the instance pool.
+	InstancePoolId *string `mandatory:"true" contributesTo:"path" name:"instancePoolId"`
 
-	// Details for the image export.
-	ExportImageDetails `contributesTo:"body"`
+	// Request to change the compartment of given instance pool.
+	ChangeInstancePoolCompartmentDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
 
 	// A token that uniquely identifies a request so it can be retried in case of a timeout or
 	// server error without risk of executing that same action again. Retry tokens expire after 24
@@ -24,42 +33,30 @@ type ExportImageRequest struct {
 	// may be rejected).
 	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
 
-	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
-	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
-	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
-
-	// Unique Oracle-assigned identifier for the request.
-	// If you need to contact Oracle about a particular request, please provide the request ID.
-	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
-
 	// Metadata about the request. This information will not be transmitted to the service, but
 	// represents information that the SDK will consume to drive retry behavior.
 	RequestMetadata common.RequestMetadata
 }
 
-func (request ExportImageRequest) String() string {
+func (request ChangeInstancePoolCompartmentRequest) String() string {
 	return common.PointerString(request)
 }
 
 // HTTPRequest implements the OCIRequest interface
-func (request ExportImageRequest) HTTPRequest(method, path string) (http.Request, error) {
+func (request ChangeInstancePoolCompartmentRequest) HTTPRequest(method, path string) (http.Request, error) {
 	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
 }
 
 // RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
-func (request ExportImageRequest) RetryPolicy() *common.RetryPolicy {
+func (request ChangeInstancePoolCompartmentRequest) RetryPolicy() *common.RetryPolicy {
 	return request.RequestMetadata.RetryPolicy
 }
 
-// ExportImageResponse wrapper for the ExportImage operation
-type ExportImageResponse struct {
+// ChangeInstancePoolCompartmentResponse wrapper for the ChangeInstancePoolCompartment operation
+type ChangeInstancePoolCompartmentResponse struct {
 
 	// The underlying http response
 	RawResponse *http.Response
-
-	// The Image instance
-	Image `presentIn:"body"`
 
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
@@ -67,17 +64,13 @@ type ExportImageResponse struct {
 	// Unique Oracle-assigned identifier for the request. If you need to contact
 	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
-
-	// The OCID of the work request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
-	// with this ID to track the status of the request.
-	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
 }
 
-func (response ExportImageResponse) String() string {
+func (response ChangeInstancePoolCompartmentResponse) String() string {
 	return common.PointerString(response)
 }
 
 // HTTPResponse implements the OCIResponse interface
-func (response ExportImageResponse) HTTPResponse() *http.Response {
+func (response ChangeInstancePoolCompartmentResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
 }

--- a/core/core_compute_client.go
+++ b/core/core_compute_client.go
@@ -266,6 +266,55 @@ func (client ComputeClient) captureConsoleHistory(ctx context.Context, request c
 	return response, err
 }
 
+// ChangeImageCompartment Moves an image into a different compartment within the same tenancy. For information about moving
+// resources between compartments, see
+// Moving Resources to a Different Compartment (https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+func (client ComputeClient) ChangeImageCompartment(ctx context.Context, request ChangeImageCompartmentRequest) (response ChangeImageCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.changeImageCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ChangeImageCompartmentResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeImageCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeImageCompartmentResponse")
+	}
+	return
+}
+
+// changeImageCompartment implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) changeImageCompartment(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/images/{imageId}/actions/changeCompartment")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeImageCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // CreateAppCatalogSubscription Create a subscription for listing resource version for a compartment. It will take some time to propagate to all regions.
 func (client ComputeClient) CreateAppCatalogSubscription(ctx context.Context, request CreateAppCatalogSubscriptionRequest) (response CreateAppCatalogSubscriptionResponse, err error) {
 	var ociResponse common.OCIResponse

--- a/core/core_computemanagement_client.go
+++ b/core/core_computemanagement_client.go
@@ -109,6 +109,112 @@ func (client ComputeManagementClient) attachLoadBalancer(ctx context.Context, re
 	return response, err
 }
 
+// ChangeInstanceConfigurationCompartment Moves an instance configuration into a different compartment within the same tenancy.
+// For information about moving resources between compartments, see
+// Moving Resources to a Different Compartment (https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+// **Important:** Most of the properties for an existing instance configuration, including the compartment,
+// cannot be modified after you create the instance configuration. Although you can move an instance configuration
+// to a different compartment, you will not be able to use the instance configuration to manage instance pools
+// in the new compartment. If you want to update an instance configuration to point to a different compartment,
+// you should instead create a new instance configuration in the target compartment using
+// CreateInstanceConfiguration (https://docs.cloud.oracle.com/iaas/api/#/en/iaas/20160918/InstanceConfiguration/CreateInstanceConfiguration).
+func (client ComputeManagementClient) ChangeInstanceConfigurationCompartment(ctx context.Context, request ChangeInstanceConfigurationCompartmentRequest) (response ChangeInstanceConfigurationCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.changeInstanceConfigurationCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ChangeInstanceConfigurationCompartmentResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeInstanceConfigurationCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeInstanceConfigurationCompartmentResponse")
+	}
+	return
+}
+
+// changeInstanceConfigurationCompartment implements the OCIOperation interface (enables retrying operations)
+func (client ComputeManagementClient) changeInstanceConfigurationCompartment(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/instanceConfigurations/{instanceConfigurationId}/actions/changeCompartment")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeInstanceConfigurationCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ChangeInstancePoolCompartment Moves an instance pool into a different compartment within the same tenancy. For
+// information about moving resources between compartments, see
+// Moving Resources to a Different Compartment (https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+// When you move an instance pool to a different compartment, associated resources such as the instances in
+// the pool, boot volumes, VNICs, and autoscaling configurations are not moved.
+func (client ComputeManagementClient) ChangeInstancePoolCompartment(ctx context.Context, request ChangeInstancePoolCompartmentRequest) (response ChangeInstancePoolCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.changeInstancePoolCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ChangeInstancePoolCompartmentResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeInstancePoolCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeInstancePoolCompartmentResponse")
+	}
+	return
+}
+
+// changeInstancePoolCompartment implements the OCIOperation interface (enables retrying operations)
+func (client ComputeManagementClient) changeInstancePoolCompartment(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/instancePools/{instancePoolId}/actions/changeCompartment")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeInstancePoolCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // CreateInstanceConfiguration Creates an instance configuration
 func (client ComputeManagementClient) CreateInstanceConfiguration(ctx context.Context, request CreateInstanceConfigurationRequest) (response CreateInstanceConfigurationResponse, err error) {
 	var ociResponse common.OCIResponse

--- a/core/core_virtualnetwork_client.go
+++ b/core/core_virtualnetwork_client.go
@@ -178,6 +178,55 @@ func (client VirtualNetworkClient) bulkDeleteVirtualCircuitPublicPrefixes(ctx co
 	return response, err
 }
 
+// ChangeNatGatewayCompartment Moves a NAT gateway into a different compartment within the same tenancy. For information
+// about moving resources between compartments, see
+// Moving Resources to a Different Compartment (https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+func (client VirtualNetworkClient) ChangeNatGatewayCompartment(ctx context.Context, request ChangeNatGatewayCompartmentRequest) (response ChangeNatGatewayCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.changeNatGatewayCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ChangeNatGatewayCompartmentResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeNatGatewayCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeNatGatewayCompartmentResponse")
+	}
+	return
+}
+
+// changeNatGatewayCompartment implements the OCIOperation interface (enables retrying operations)
+func (client VirtualNetworkClient) changeNatGatewayCompartment(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/natGateways/{natGatewayId}/actions/changeCompartment")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeNatGatewayCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // ChangeServiceGatewayCompartment Moves a service gateway into a different compartment within the same tenancy. For information
 // about moving resources between compartments, see
 // Moving Resources to a Different Compartment (https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
@@ -210,62 +259,11 @@ func (client VirtualNetworkClient) ChangeServiceGatewayCompartment(ctx context.C
 // changeServiceGatewayCompartment implements the OCIOperation interface (enables retrying operations)
 func (client VirtualNetworkClient) changeServiceGatewayCompartment(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
 	httpRequest, err := request.HTTPRequest(http.MethodPost, "/serviceGateways/{serviceGatewayId}/actions/changeCompartment")
-
 	if err != nil {
 		return nil, err
 	}
 
 	var response ChangeServiceGatewayCompartmentResponse
-	var httpResponse *http.Response
-	httpResponse, err = client.Call(ctx, &httpRequest)
-	defer common.CloseBodyIfValid(httpResponse)
-	response.RawResponse = httpResponse
-	if err != nil {
-		return response, err
-	}
-
-	err = common.UnmarshalResponse(httpResponse, &response)
-	return response, err
-}
-
-// ChangeNatGatewayCompartment Moves a NAT gateway into a different compartment within the same tenancy. For information
-// about moving resources between compartments, see
-// Moving Resources to a Different Compartment (https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
-func (client VirtualNetworkClient) ChangeNatGatewayCompartment(ctx context.Context, request ChangeNatGatewayCompartmentRequest) (response ChangeNatGatewayCompartmentResponse, err error) {
-	var ociResponse common.OCIResponse
-	policy := common.NoRetryPolicy()
-	if request.RetryPolicy() != nil {
-		policy = *request.RetryPolicy()
-	}
-
-	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
-		request.OpcRetryToken = common.String(common.RetryToken())
-	}
-
-	ociResponse, err = common.Retry(ctx, request, client.changeNatGatewayCompartment, policy)
-	if err != nil {
-		if ociResponse != nil {
-			response = ChangeNatGatewayCompartmentResponse{RawResponse: ociResponse.HTTPResponse()}
-		}
-		return
-	}
-	if convertedResponse, ok := ociResponse.(ChangeNatGatewayCompartmentResponse); ok {
-		response = convertedResponse
-	} else {
-		err = fmt.Errorf("failed to convert OCIResponse into ChangeNatGatewayCompartmentResponse")
-	}
-	return
-}
-
-
-// changeNatGatewayCompartment implements the OCIOperation interface (enables retrying operations)
-func (client VirtualNetworkClient) changeNatGatewayCompartment(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
-	httpRequest, err := request.HTTPRequest(http.MethodPost, "/natGateways/{natGatewayId}/actions/changeCompartment")
-	if err != nil {
-		return nil, err
-	}
-
-	var response ChangeNatGatewayCompartmentResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)

--- a/core/create_image_request_response.go
+++ b/core/create_image_request_response.go
@@ -60,7 +60,7 @@ type CreateImageResponse struct {
 	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 
-	// The OCID of the work request. Use GetWorkRequest
+	// The OCID of the work request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
 	// with this ID to track the status of the request.
 	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
 }

--- a/core/delete_image_request_response.go
+++ b/core/delete_image_request_response.go
@@ -11,7 +11,7 @@ import (
 // DeleteImageRequest wrapper for the DeleteImage operation
 type DeleteImageRequest struct {
 
-	// The OCID of the image.
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the image.
 	ImageId *string `mandatory:"true" contributesTo:"path" name:"imageId"`
 
 	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`

--- a/core/get_image_request_response.go
+++ b/core/get_image_request_response.go
@@ -11,7 +11,7 @@ import (
 // GetImageRequest wrapper for the GetImage operation
 type GetImageRequest struct {
 
-	// The OCID of the image.
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the image.
 	ImageId *string `mandatory:"true" contributesTo:"path" name:"imageId"`
 
 	// Unique Oracle-assigned identifier for the request.

--- a/core/image.go
+++ b/core/image.go
@@ -80,7 +80,8 @@ type Image struct {
 
 	AgentFeatures *InstanceAgentFeatures `mandatory:"false" json:"agentFeatures"`
 
-	// Image size (1 MB = 1048576 bytes)
+	// The boot volume size for an instance launched from this image, (1 MB = 1048576 bytes).
+	// Note this is not the same as the size of the image when it was exported or the actual size of the image.
 	// Example: `47694`
 	SizeInMBs *int64 `mandatory:"false" json:"sizeInMBs"`
 }

--- a/core/instance_configuration.go
+++ b/core/instance_configuration.go
@@ -17,7 +17,9 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// InstanceConfiguration Instance Configuration
+// InstanceConfiguration An instance configuration is a template that defines the settings to use when creating Compute instances
+// as part of an instance pool. For more information about instance pools and instance configurations, see
+// Managing Compute Instances (https://docs.cloud.oracle.com/Content/Compute/Concepts/instancemanagement.htm).
 type InstanceConfiguration struct {
 
 	// The OCID of the compartment containing the instance configuration.

--- a/core/instance_configuration_instance_source_via_image_details.go
+++ b/core/instance_configuration_instance_source_via_image_details.go
@@ -20,7 +20,7 @@ import (
 // InstanceConfigurationInstanceSourceViaImageDetails The representation of InstanceConfigurationInstanceSourceViaImageDetails
 type InstanceConfigurationInstanceSourceViaImageDetails struct {
 
-	// The size of the boot volume in GBs. Minimum value is 50 GB and maximum value is 16384 GB (16TB).
+	// The size of the boot volume in GBs. The minimum value is 50 GB and the maximum value is 16384 GB (16TB).
 	BootVolumeSizeInGBs *int64 `mandatory:"false" json:"bootVolumeSizeInGBs"`
 
 	// The OCID of the image used to boot the instance.

--- a/core/instance_configuration_summary.go
+++ b/core/instance_configuration_summary.go
@@ -16,20 +16,20 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// InstanceConfigurationSummary Instance Configuration Summary
+// InstanceConfigurationSummary Summary information for an instance configuration.
 type InstanceConfigurationSummary struct {
 
 	// The OCID of the compartment containing the instance configuration.
 	CompartmentId *string `mandatory:"true" json:"compartmentId"`
 
-	// The OCID of the instance configuration
+	// The OCID of the instance configuration.
 	Id *string `mandatory:"true" json:"id"`
 
 	// The date and time the instance configuration was created, in the format defined by RFC3339.
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
-	// A user-friendly name for the instance configuration
+	// A user-friendly name for the instance configuration.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
 	// Defined tags for this resource. Each key is predefined and scoped to a

--- a/core/instance_pool.go
+++ b/core/instance_pool.go
@@ -16,7 +16,9 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// InstancePool Instance Pool
+// InstancePool An instance pool is a group of instances within the same region that are created based off of the same
+// instance configuration. For more information about instance pools and instance configurations, see
+// Managing Compute Instances (https://docs.cloud.oracle.com/Content/Compute/Concepts/instancemanagement.htm).
 type InstancePool struct {
 
 	// The OCID of the instance pool.

--- a/core/instance_pool_summary.go
+++ b/core/instance_pool_summary.go
@@ -16,13 +16,13 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// InstancePoolSummary Condensed InstancePool data when listing instance pools.
+// InstancePoolSummary Summary information for an instance pool.
 type InstancePoolSummary struct {
 
-	// The OCID of the instance pool
+	// The OCID of the instance pool.
 	Id *string `mandatory:"true" json:"id"`
 
-	// The OCID of the compartment containing the instance pool
+	// The OCID of the compartment containing the instance pool.
 	CompartmentId *string `mandatory:"true" json:"compartmentId"`
 
 	// The OCID of the instance configuration associated with the instance pool.

--- a/core/launch_instance_request_response.go
+++ b/core/launch_instance_request_response.go
@@ -60,7 +60,7 @@ type LaunchInstanceResponse struct {
 	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 
-	// The OCID of the work request. Use GetWorkRequest
+	// The OCID of the work request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
 	// with this ID to track the status of the request.
 	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
 }

--- a/core/list_shapes_request_response.go
+++ b/core/list_shapes_request_response.go
@@ -29,7 +29,7 @@ type ListShapesRequest struct {
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
 
-	// The OCID of an image.
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of an image.
 	ImageId *string `mandatory:"false" contributesTo:"query" name:"imageId"`
 
 	// Unique Oracle-assigned identifier for the request.

--- a/core/update_image_request_response.go
+++ b/core/update_image_request_response.go
@@ -11,7 +11,7 @@ import (
 // UpdateImageRequest wrapper for the UpdateImage operation
 type UpdateImageRequest struct {
 
-	// The OCID of the image.
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the image.
 	ImageId *string `mandatory:"true" contributesTo:"path" name:"imageId"`
 
 	// Updates the image display name field. Avoid entering confidential information.

--- a/example/example_database_test.go
+++ b/example/example_database_test.go
@@ -61,3 +61,45 @@ func ExampleUpdateAdb() {
 	// Output:
 	// update adb successful
 }
+
+func ExampleUpdateAdbAcl() {
+	c, clerr := database.NewDatabaseClientWithConfigurationProvider(common.DefaultConfigProvider())
+	helpers.FatalIfError(clerr)
+
+	updateDbDetails := database.UpdateAutonomousDatabaseDetails{
+		WhitelistedIps: []string{"1.1.1.1/28", "3.3.3.3"},
+	}
+
+	updateReq := database.UpdateAutonomousDatabaseRequest{
+		AutonomousDatabaseId:            common.String("replacewithvalidocid"),
+		UpdateAutonomousDatabaseDetails: updateDbDetails,
+	}
+	_, err := c.UpdateAutonomousDatabase(context.Background(), updateReq)
+	helpers.FatalIfError(err)
+
+	fmt.Println("update adb acl successful")
+
+	// Output:
+	// update adb acl successful
+}
+
+func ExampleUpdateAdbLisenceType() {
+	c, clerr := database.NewDatabaseClientWithConfigurationProvider(common.DefaultConfigProvider())
+	helpers.FatalIfError(clerr)
+
+	updateDbDetails := database.UpdateAutonomousDatabaseDetails{
+		LicenseModel: database.UpdateAutonomousDatabaseDetailsLicenseModelLicenseIncluded,
+	}
+
+	updateReq := database.UpdateAutonomousDatabaseRequest{
+		AutonomousDatabaseId:            common.String("replacewithvalidocid"),
+		UpdateAutonomousDatabaseDetails: updateDbDetails,
+	}
+	_, err := c.UpdateAutonomousDatabase(context.Background(), updateReq)
+	helpers.FatalIfError(err)
+
+	fmt.Println("update adb license type successful")
+
+	// Output:
+	// update adb license type successful
+}

--- a/streaming/list_streams_request_response.go
+++ b/streaming/list_streams_request_response.go
@@ -67,10 +67,10 @@ type ListStreamsResponse struct {
 	// A list of []StreamSummary instances
 	Items []StreamSummary `presentIn:"body"`
 
-	// Pagination token
+	// For list pagination. When this header appears in the response, additional pages of results remain. For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
-	// Pagination token
+	// For list pagination. When this header appears in the response, previous pages of results exist. For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
 
 	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about

--- a/streaming/streaming_stream_client.go
+++ b/streaming/streaming_stream_client.go
@@ -37,7 +37,7 @@ func NewStreamClientWithConfigurationProvider(configProvider common.Configuratio
 
 // SetRegion overrides the region of this client.
 func (client *StreamClient) SetRegion(region string) {
-	client.Host = common.StringToRegion(region).EndpointForTemplate("streams", "https://streams.{region}.streaming.oci.{secondLevelDomain}")
+	client.Host = common.StringToRegion(region).EndpointForTemplate("streams", "https://streaming.{region}.oci.{secondLevelDomain}")
 }
 
 // SetConfigurationProvider sets the configuration provider including the region, returns an error if is not valid

--- a/streaming/streaming_streamadmin_client.go
+++ b/streaming/streaming_streamadmin_client.go
@@ -37,7 +37,7 @@ func NewStreamAdminClientWithConfigurationProvider(configProvider common.Configu
 
 // SetRegion overrides the region of this client.
 func (client *StreamAdminClient) SetRegion(region string) {
-	client.Host = common.StringToRegion(region).EndpointForTemplate("streams", "https://streams.{region}.streaming.oci.{secondLevelDomain}")
+	client.Host = common.StringToRegion(region).EndpointForTemplate("streams", "https://streaming.{region}.oci.{secondLevelDomain}")
 }
 
 // SetConfigurationProvider sets the configuration provider including the region, returns an error if is not valid
@@ -103,7 +103,7 @@ func (client StreamAdminClient) createStream(ctx context.Context, request common
 }
 
 // DeleteStream Deletes a stream and its content. Stream contents are deleted immediately. The service retains records of the stream itself for 90 days after deletion.
-// The `lifeCycleState` parameter of the `Stream` object changes to `DELETING` and the stream becomes inaccessible for read or write operations.
+// The `lifecycleState` parameter of the `Stream` object changes to `DELETING` and the stream becomes inaccessible for read or write operations.
 // To verify that a stream has been deleted, make a GetStream request. If the call returns the stream's
 // lifecycle state as `DELETED`, then the stream has been deleted. If the call returns a "404 Not Found" error, that means all records of the
 // stream have been deleted.


### PR DESCRIPTION
### Added

- Support for moving images, instance configurations, and instance pools across compartments in Core Services

- Support for moving autoscaling configurations across compartments in the Compute Autoscaling service



### Fixed

- Fixed a bug where the Streaming service's endpoints in Tokyo, Seoul, and future regions were not reachable from the SDK
