### PR TITLE
Releasing version 9.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## 9.0.0 - 2019-09-10
+### Added
+- Support for specifying the autoBackupWindow field for scheduling backups in the Database service
+- Support for network security groups on autonomous Exadata infrastructure in the Database service
+- Support for Kubernetes secrets encryption in customer clusters, regional subnets, and cluster authentication for instance principals in the Container Engine for Kubernetes service
+- Support for the Oracle Content and Experience service
+
+### Breaking
+- The etag field has been removed from the ChangeSubscriptionCompartmentResponse and ChangeTopicCompartmentResponse structs of the Notifications service
+
 ## 8.1.0 - 2019-09-03
 ### Added
 - Support for the Sydney (SYD) region

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOC_SERVER_URL=https:\/\/docs.cloud.oracle.com
 
-GEN_TARGETS = identity core objectstorage loadbalancer database audit dns filestorage email containerengine resourcesearch keymanagement announcementsservice healthchecks waas autoscaling streaming ons monitoring resourcemanager budget workrequests functions limits events dts ##SPECNAME##
+GEN_TARGETS = identity core objectstorage loadbalancer database audit dns filestorage email containerengine resourcesearch keymanagement announcementsservice healthchecks waas autoscaling streaming ons monitoring resourcemanager budget workrequests functions limits events dts oce ##SPECNAME##
 NON_GEN_TARGETS = common common/auth objectstorage/transfer example
 TARGETS = $(NON_GEN_TARGETS) $(GEN_TARGETS)
 

--- a/common/common.go
+++ b/common/common.go
@@ -114,7 +114,7 @@ func StringToRegion(stringRegion string) (r Region) {
 	switch strings.ToLower(stringRegion) {
 	case "sea":
 		r = RegionSEA
-	case "ca-toronto-1":
+	case "yyz", "ca-toronto-1":
 		r = RegionCAToronto1
 	case "phx", "us-phoenix-1":
 		r = RegionPHX
@@ -124,15 +124,15 @@ func StringToRegion(stringRegion string) (r Region) {
 		r = RegionFRA
 	case "lhr", "uk-london-1":
 		r = RegionLHR
-	case "ap-tokyo-1":
+	case "nrt", "ap-tokyo-1":
 		r = RegionAPTokyo1
-	case "ap-seoul-1":
+	case "icn", "ap-seoul-1":
 		r = RegionAPSeoul1
-	case "ap-mumbai-1":
+	case "bom", "ap-mumbai-1":
 		r = RegionAPMumbai1
-	case "eu-zurich-1":
+	case "zrh", "eu-zurich-1":
 		r = RegionEUZurich1
-	case "sa-saopaulo-1":
+	case "gru", "sa-saopaulo-1":
 		r = RegionSASaopaulo1
 	case "us-langley-1":
 		r = RegionUSLangley1

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -76,3 +76,14 @@ func TestEndpointForTemplate(t *testing.T) {
 		assert.Equal(t, testData.expected, endpoint)
 	}
 }
+
+func TestStringToRegion(t *testing.T) {
+	region := StringToRegion("yyz")
+	assert.Equal(t, RegionCAToronto1, region)
+
+	region = StringToRegion("nrt")
+	assert.Equal(t, RegionAPTokyo1, region)
+
+	region = StringToRegion("gru")
+	assert.Equal(t, RegionSASaopaulo1, region)
+}

--- a/common/version.go
+++ b/common/version.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	major = "8"
-	minor = "1"
+	major = "9"
+	minor = "0"
 	patch = "0"
 	tag   = ""
 )

--- a/containerengine/cluster.go
+++ b/containerengine/cluster.go
@@ -32,6 +32,9 @@ type Cluster struct {
 	// The version of Kubernetes running on the cluster masters.
 	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
 
+	// The OCID of the KMS key to be used as the master encryption key for Kubernetes secret encryption.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
 	// Optional attributes for the cluster.
 	Options *ClusterCreateOptions `mandatory:"false" json:"options"`
 

--- a/containerengine/create_cluster_details.go
+++ b/containerengine/create_cluster_details.go
@@ -29,6 +29,10 @@ type CreateClusterDetails struct {
 	// The version of Kubernetes to install into the cluster masters.
 	KubernetesVersion *string `mandatory:"true" json:"kubernetesVersion"`
 
+	// The OCID of the KMS key to be used as the master encryption key for Kubernetes secret encryption.
+	// When used, `kubernetesVersion` must be at least `v1.13.0`.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
 	// Optional attributes for the cluster.
 	Options *ClusterCreateOptions `mandatory:"false" json:"options"`
 }

--- a/containerengine/create_cluster_kubeconfig_content_details.go
+++ b/containerengine/create_cluster_kubeconfig_content_details.go
@@ -17,10 +17,11 @@ import (
 // CreateClusterKubeconfigContentDetails The properties that define a request to create a cluster kubeconfig.
 type CreateClusterKubeconfigContentDetails struct {
 
-	// The version of the kubeconfig token.
+	// The version of the kubeconfig token. Supported values 1.0.0 and 2.0.0
 	TokenVersion *string `mandatory:"false" json:"tokenVersion"`
 
 	// The desired expiration, in seconds, to use for the kubeconfig token.
+	// Important Note, expiration field is only honored for token version 1.0.0
 	Expiration *int `mandatory:"false" json:"expiration"`
 }
 

--- a/containerengine/create_node_pool_details.go
+++ b/containerengine/create_node_pool_details.go
@@ -35,9 +35,6 @@ type CreateNodePoolDetails struct {
 	// The name of the node shape of the nodes in the node pool.
 	NodeShape *string `mandatory:"true" json:"nodeShape"`
 
-	// The OCIDs of the subnets in which to place nodes for this node pool.
-	SubnetIds []string `mandatory:"true" json:"subnetIds"`
-
 	// A list of key/value pairs to add to each underlying OCI instance in the node pool.
 	NodeMetadata map[string]string `mandatory:"false" json:"nodeMetadata"`
 
@@ -47,8 +44,18 @@ type CreateNodePoolDetails struct {
 	// The SSH public key to add to each node in the node pool.
 	SshPublicKey *string `mandatory:"false" json:"sshPublicKey"`
 
-	// The number of nodes to create in each subnet.
+	// Optional, default to 1. The number of nodes to create in each subnet specified in subnetIds property.
+	// When used, subnetIds is required. This property is deprecated, use nodeConfigDetails instead.
 	QuantityPerSubnet *int `mandatory:"false" json:"quantityPerSubnet"`
+
+	// The OCIDs of the subnets in which to place nodes for this node pool. When used, quantityPerSubnet
+	// can be provided. This property is deprecated, use nodeConfigDetails. Exactly one of the
+	// subnetIds or nodeConfigDetails properties must be specified.
+	SubnetIds []string `mandatory:"false" json:"subnetIds"`
+
+	// The configuration of nodes in the node pool. Exactly one of the
+	// subnetIds or nodeConfigDetails properties must be specified.
+	NodeConfigDetails *CreateNodePoolNodeConfigDetails `mandatory:"false" json:"nodeConfigDetails"`
 }
 
 func (m CreateNodePoolDetails) String() string {

--- a/containerengine/create_node_pool_node_config_details.go
+++ b/containerengine/create_node_pool_node_config_details.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateNodePoolNodeConfigDetails The size and placement configuration of nodes in the node pool.
+type CreateNodePoolNodeConfigDetails struct {
+
+	// The number of nodes that should be in the node pool.
+	Size *int `mandatory:"true" json:"size"`
+
+	// The placement configurations for the node pool. Provide one placement
+	// configuration for each availability domain in which you intend to launch a node.
+	// To use the node pool with a regional subnet, provide a placement configuration for
+	// each availability domain, and include the regional subnet in each placement
+	// configuration.
+	PlacementConfigs []NodePoolPlacementConfigDetails `mandatory:"true" json:"placementConfigs"`
+}
+
+func (m CreateNodePoolNodeConfigDetails) String() string {
+	return common.PointerString(m)
+}

--- a/containerengine/node_pool.go
+++ b/containerengine/node_pool.go
@@ -58,6 +58,9 @@ type NodePool struct {
 
 	// The nodes in the node pool.
 	Nodes []Node `mandatory:"false" json:"nodes"`
+
+	// The configuration of nodes in the node pool.
+	NodeConfigDetails *NodePoolNodeConfigDetails `mandatory:"false" json:"nodeConfigDetails"`
 }
 
 func (m NodePool) String() string {

--- a/containerengine/node_pool_node_config_details.go
+++ b/containerengine/node_pool_node_config_details.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// NodePoolNodeConfigDetails The size and placement configuration of nodes in the node pool.
+type NodePoolNodeConfigDetails struct {
+
+	// The number of nodes in the node pool.
+	Size *int `mandatory:"false" json:"size"`
+
+	// The placement configurations for the node pool. Provide one placement
+	// configuration for each availability domain in which you intend to launch a node.
+	// To use the node pool with a regional subnet, provide a placement configuration for
+	// each availability domain, and include the regional subnet in each placement
+	// configuration.
+	PlacementConfigs []NodePoolPlacementConfigDetails `mandatory:"false" json:"placementConfigs"`
+}
+
+func (m NodePoolNodeConfigDetails) String() string {
+	return common.PointerString(m)
+}

--- a/containerengine/node_pool_options.go
+++ b/containerengine/node_pool_options.go
@@ -20,7 +20,7 @@ type NodePoolOptions struct {
 	// Available Kubernetes versions.
 	KubernetesVersions []string `mandatory:"false" json:"kubernetesVersions"`
 
-	// Available Kubernetes versions.
+	// Available image names.
 	Images []string `mandatory:"false" json:"images"`
 
 	// Available shapes for nodes.

--- a/containerengine/node_pool_placement_config_details.go
+++ b/containerengine/node_pool_placement_config_details.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// NodePoolPlacementConfigDetails The location where a node pool will place nodes.
+type NodePoolPlacementConfigDetails struct {
+
+	// The availability domain in which to place nodes.
+	// Example: `Uocm:PHX-AD-1`
+	AvailabilityDomain *string `mandatory:"true" json:"availabilityDomain"`
+
+	// The OCID of the subnet in which to place nodes.
+	SubnetId *string `mandatory:"true" json:"subnetId"`
+}
+
+func (m NodePoolPlacementConfigDetails) String() string {
+	return common.PointerString(m)
+}

--- a/containerengine/node_pool_summary.go
+++ b/containerengine/node_pool_summary.go
@@ -52,6 +52,9 @@ type NodePoolSummary struct {
 
 	// The OCIDs of the subnets in which to place nodes for this node pool.
 	SubnetIds []string `mandatory:"false" json:"subnetIds"`
+
+	// The configuration of nodes in the node pool.
+	NodeConfigDetails *NodePoolNodeConfigDetails `mandatory:"false" json:"nodeConfigDetails"`
 }
 
 func (m NodePoolSummary) String() string {

--- a/containerengine/update_node_pool_details.go
+++ b/containerengine/update_node_pool_details.go
@@ -23,14 +23,26 @@ type UpdateNodePoolDetails struct {
 	// The version of Kubernetes to which the nodes in the node pool should be upgraded.
 	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
 
-	// The number of nodes to ensure in each subnet.
-	QuantityPerSubnet *int `mandatory:"false" json:"quantityPerSubnet"`
-
 	// A list of key/value pairs to add to nodes after they join the Kubernetes cluster.
 	InitialNodeLabels []KeyValue `mandatory:"false" json:"initialNodeLabels"`
 
-	// The OCIDs of the subnets in which to place nodes for this node pool.
+	// The number of nodes to have in each subnet specified in the subnetIds property. This property is deprecated,
+	// use nodeConfigDetails instead. If the current value of quantityPerSubnet is greater than 0, you can only
+	// use quantityPerSubnet to scale the node pool. If the current value of quantityPerSubnet is equal to 0 and
+	// the current value of size in nodeConfigDetails is greater than 0, before you can use quantityPerSubnet,
+	// you must first scale the node pool to 0 nodes using nodeConfigDetails.
+	QuantityPerSubnet *int `mandatory:"false" json:"quantityPerSubnet"`
+
+	// The OCIDs of the subnets in which to place nodes for this node pool. This property is deprecated,
+	// use nodeConfigDetails instead. Only one of the subnetIds or nodeConfigDetails
+	// properties can be specified.
 	SubnetIds []string `mandatory:"false" json:"subnetIds"`
+
+	// The configuration of nodes in the node pool. Only one of the subnetIds or nodeConfigDetails
+	// properties should be specified. If the current value of quantityPerSubnet is greater than 0, the node
+	// pool may still be scaled using quantityPerSubnet. Before you can use nodeConfigDetails,
+	// you must first scale the node pool to 0 nodes using quantityPerSubnet.
+	NodeConfigDetails *UpdateNodePoolNodeConfigDetails `mandatory:"false" json:"nodeConfigDetails"`
 }
 
 func (m UpdateNodePoolDetails) String() string {

--- a/containerengine/update_node_pool_node_config_details.go
+++ b/containerengine/update_node_pool_node_config_details.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateNodePoolNodeConfigDetails The size and placement configuration of nodes in the node pool.
+type UpdateNodePoolNodeConfigDetails struct {
+
+	// The number of nodes in the node pool.
+	Size *int `mandatory:"false" json:"size"`
+
+	// The placement configurations for the node pool. Provide one placement
+	// configuration for each availability domain in which you intend to launch a node.
+	// To use the node pool with a regional subnet, provide a placement configuration for
+	// each availability domain, and include the regional subnet in each placement
+	// configuration.
+	PlacementConfigs []NodePoolPlacementConfigDetails `mandatory:"false" json:"placementConfigs"`
+}
+
+func (m UpdateNodePoolNodeConfigDetails) String() string {
+	return common.PointerString(m)
+}

--- a/core/boot_volume.go
+++ b/core/boot_volume.go
@@ -51,6 +51,10 @@ type BootVolume struct {
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
+	// System tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
 	// A user-friendly name. Does not have to be unique, and it's changeable.
 	// Avoid entering confidential information.
 	DisplayName *string `mandatory:"false" json:"displayName"`
@@ -88,6 +92,7 @@ func (m BootVolume) String() string {
 func (m *BootVolume) UnmarshalJSON(data []byte) (e error) {
 	model := struct {
 		DefinedTags        map[string]map[string]interface{} `json:"definedTags"`
+		SystemTags         map[string]map[string]interface{} `json:"systemTags"`
 		DisplayName        *string                           `json:"displayName"`
 		FreeformTags       map[string]string                 `json:"freeformTags"`
 		ImageId            *string                           `json:"imageId"`
@@ -109,6 +114,7 @@ func (m *BootVolume) UnmarshalJSON(data []byte) (e error) {
 		return
 	}
 	m.DefinedTags = model.DefinedTags
+	m.SystemTags = model.SystemTags
 	m.DisplayName = model.DisplayName
 	m.FreeformTags = model.FreeformTags
 	m.ImageId = model.ImageId

--- a/core/boot_volume_backup.go
+++ b/core/boot_volume_backup.go
@@ -52,6 +52,10 @@ type BootVolumeBackup struct {
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
+	// System tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
 	// The date and time the volume backup will expire and be automatically deleted.
 	// Format defined by RFC3339. This parameter will always be present for backups that
 	// were created automatically by a scheduled-backup policy. For manually created backups,

--- a/core/instance.go
+++ b/core/instance.go
@@ -127,6 +127,10 @@ type Instance struct {
 	// Details for creating an instance
 	SourceDetails InstanceSourceDetails `mandatory:"false" json:"sourceDetails"`
 
+	// System tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
 	AgentConfig *InstanceAgentConfig `mandatory:"false" json:"agentConfig"`
 
 	// The date and time the instance is expected to be stopped / started,  in the format defined by RFC3339.
@@ -155,6 +159,7 @@ func (m *Instance) UnmarshalJSON(data []byte) (e error) {
 		LaunchOptions            *LaunchOptions                    `json:"launchOptions"`
 		Metadata                 map[string]string                 `json:"metadata"`
 		SourceDetails            instancesourcedetails             `json:"sourceDetails"`
+		SystemTags               map[string]map[string]interface{} `json:"systemTags"`
 		AgentConfig              *InstanceAgentConfig              `json:"agentConfig"`
 		TimeMaintenanceRebootDue *common.SDKTime                   `json:"timeMaintenanceRebootDue"`
 		AvailabilityDomain       *string                           `json:"availabilityDomain"`
@@ -190,6 +195,7 @@ func (m *Instance) UnmarshalJSON(data []byte) (e error) {
 	} else {
 		m.SourceDetails = nil
 	}
+	m.SystemTags = model.SystemTags
 	m.AgentConfig = model.AgentConfig
 	m.TimeMaintenanceRebootDue = model.TimeMaintenanceRebootDue
 	m.AvailabilityDomain = model.AvailabilityDomain

--- a/core/volume.go
+++ b/core/volume.go
@@ -60,6 +60,10 @@ type Volume struct {
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 
+	// System tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
 	// Specifies whether the cloned volume's data has finished copying from the source volume or backup.
 	IsHydrated *bool `mandatory:"false" json:"isHydrated"`
 
@@ -86,6 +90,7 @@ func (m *Volume) UnmarshalJSON(data []byte) (e error) {
 	model := struct {
 		DefinedTags        map[string]map[string]interface{} `json:"definedTags"`
 		FreeformTags       map[string]string                 `json:"freeformTags"`
+		SystemTags         map[string]map[string]interface{} `json:"systemTags"`
 		IsHydrated         *bool                             `json:"isHydrated"`
 		KmsKeyId           *string                           `json:"kmsKeyId"`
 		SizeInGBs          *int64                            `json:"sizeInGBs"`
@@ -106,6 +111,7 @@ func (m *Volume) UnmarshalJSON(data []byte) (e error) {
 	}
 	m.DefinedTags = model.DefinedTags
 	m.FreeformTags = model.FreeformTags
+	m.SystemTags = model.SystemTags
 	m.IsHydrated = model.IsHydrated
 	m.KmsKeyId = model.KmsKeyId
 	m.SizeInGBs = model.SizeInGBs

--- a/core/volume_backup.go
+++ b/core/volume_backup.go
@@ -51,6 +51,10 @@ type VolumeBackup struct {
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
+	// System tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
 	// The date and time the volume backup will expire and be automatically deleted.
 	// Format defined by RFC3339. This parameter will always be present for backups that
 	// were created automatically by a scheduled-backup policy. For manually created backups,

--- a/database/autonomous_container_database.go
+++ b/database/autonomous_container_database.go
@@ -55,7 +55,6 @@ type AutonomousContainerDatabase struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// The availability domain of the Autonomous Container Database.

--- a/database/autonomous_container_database_summary.go
+++ b/database/autonomous_container_database_summary.go
@@ -55,7 +55,6 @@ type AutonomousContainerDatabaseSummary struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// The availability domain of the Autonomous Container Database.

--- a/database/autonomous_data_warehouse.go
+++ b/database/autonomous_data_warehouse.go
@@ -58,7 +58,6 @@ type AutonomousDataWarehouse struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// A valid Oracle Database version for Autonomous Data Warehouse.

--- a/database/autonomous_data_warehouse_summary.go
+++ b/database/autonomous_data_warehouse_summary.go
@@ -59,7 +59,6 @@ type AutonomousDataWarehouseSummary struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// A valid Oracle Database version for Autonomous Data Warehouse.

--- a/database/autonomous_database.go
+++ b/database/autonomous_database.go
@@ -36,6 +36,19 @@ type AutonomousDatabase struct {
 	// Information about the current lifecycle state.
 	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
 
+	// Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB memory. For Always Free databases, memory and CPU cannot be scaled.
+	IsFreeTier *bool `mandatory:"false" json:"isFreeTier"`
+
+	// System tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	// The date and time the Always Free database will be stopped because of inactivity. If this time is reached without any database activity, the database will automatically be put into the STOPPED state.
+	TimeReclamationOfFreeAutonomousDatabase *common.SDKTime `mandatory:"false" json:"timeReclamationOfFreeAutonomousDatabase"`
+
+	// The date and time the Always Free database will be automatically deleted because of inactivity. If the database is in the STOPPED state and without activity until this time, it will be deleted.
+	TimeDeletionOfFreeAutonomousDatabase *common.SDKTime `mandatory:"false" json:"timeDeletionOfFreeAutonomousDatabase"`
+
 	// True if the database uses the dedicated deployment (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm) option.
 	IsDedicated *bool `mandatory:"false" json:"isDedicated"`
 
@@ -56,7 +69,7 @@ type AutonomousDatabase struct {
 
 	ConnectionUrls *AutonomousDatabaseConnectionUrls `mandatory:"false" json:"connectionUrls"`
 
-	// The Oracle license model that applies to the Oracle Autonomous Database. The default is BRING_YOUR_OWN_LICENSE.
+	// The Oracle license model that applies to the Oracle Autonomous Database. The default for Autonomous Database using the shared deployment is BRING_YOUR_OWN_LICENSE. Note that when provisioning an Autonomous Database using the dedicated deployment (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm) option, this attribute must be null because the attribute is already set on Autonomous Exadata Infrastructure level.
 	LicenseModel AutonomousDatabaseLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
 
 	// The amount of storage that has been used, in terabytes.
@@ -69,7 +82,6 @@ type AutonomousDatabase struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// A valid Oracle Database version for Autonomous Database.

--- a/database/autonomous_database_summary.go
+++ b/database/autonomous_database_summary.go
@@ -37,6 +37,19 @@ type AutonomousDatabaseSummary struct {
 	// Information about the current lifecycle state.
 	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
 
+	// Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB memory. For Always Free databases, memory and CPU cannot be scaled.
+	IsFreeTier *bool `mandatory:"false" json:"isFreeTier"`
+
+	// System tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	// The date and time the Always Free database will be stopped because of inactivity. If this time is reached without any database activity, the database will automatically be put into the STOPPED state.
+	TimeReclamationOfFreeAutonomousDatabase *common.SDKTime `mandatory:"false" json:"timeReclamationOfFreeAutonomousDatabase"`
+
+	// The date and time the Always Free database will be automatically deleted because of inactivity. If the database is in the STOPPED state and without activity until this time, it will be deleted.
+	TimeDeletionOfFreeAutonomousDatabase *common.SDKTime `mandatory:"false" json:"timeDeletionOfFreeAutonomousDatabase"`
+
 	// True if the database uses the dedicated deployment (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm) option.
 	IsDedicated *bool `mandatory:"false" json:"isDedicated"`
 
@@ -57,7 +70,7 @@ type AutonomousDatabaseSummary struct {
 
 	ConnectionUrls *AutonomousDatabaseConnectionUrls `mandatory:"false" json:"connectionUrls"`
 
-	// The Oracle license model that applies to the Oracle Autonomous Database. The default is BRING_YOUR_OWN_LICENSE.
+	// The Oracle license model that applies to the Oracle Autonomous Database. The default for Autonomous Database using the shared deployment is BRING_YOUR_OWN_LICENSE. Note that when provisioning an Autonomous Database using the dedicated deployment (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm) option, this attribute must be null because the attribute is already set on Autonomous Exadata Infrastructure level.
 	LicenseModel AutonomousDatabaseSummaryLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
 
 	// The amount of storage that has been used, in terabytes.
@@ -70,7 +83,6 @@ type AutonomousDatabaseSummary struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// A valid Oracle Database version for Autonomous Database.

--- a/database/autonomous_exadata_infrastructure.go
+++ b/database/autonomous_exadata_infrastructure.go
@@ -49,6 +49,9 @@ type AutonomousExadataInfrastructure struct {
 
 	MaintenanceWindow *MaintenanceWindow `mandatory:"true" json:"maintenanceWindow"`
 
+	// A list of the OCIDs (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see Security Rules (https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
 	// Additional information about the current lifecycle state of the Autonomous Exadata Infrastructure.
 	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
 
@@ -71,7 +74,6 @@ type AutonomousExadataInfrastructure struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 }
 

--- a/database/autonomous_exadata_infrastructure_summary.go
+++ b/database/autonomous_exadata_infrastructure_summary.go
@@ -58,6 +58,9 @@ type AutonomousExadataInfrastructureSummary struct {
 
 	MaintenanceWindow *MaintenanceWindow `mandatory:"true" json:"maintenanceWindow"`
 
+	// A list of the OCIDs (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see Security Rules (https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
 	// Additional information about the current lifecycle state of the Autonomous Exadata Infrastructure.
 	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
 
@@ -80,7 +83,6 @@ type AutonomousExadataInfrastructureSummary struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 }
 

--- a/database/create_autonomous_container_database_details.go
+++ b/database/create_autonomous_container_database_details.go
@@ -37,7 +37,6 @@ type CreateAutonomousContainerDatabaseDetails struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	BackupConfig *AutonomousContainerDatabaseBackupConfig `mandatory:"false" json:"backupConfig"`

--- a/database/create_autonomous_data_warehouse_details.go
+++ b/database/create_autonomous_data_warehouse_details.go
@@ -44,7 +44,6 @@ type CreateAutonomousDataWarehouseDetails struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 }
 

--- a/database/create_autonomous_database_base.go
+++ b/database/create_autonomous_database_base.go
@@ -35,10 +35,13 @@ type CreateAutonomousDatabaseBase interface {
 	// The autonomous database workload type. OLTP indicates an Autonomous Transaction Processing database and DW indicates an Autonomous Data Warehouse. The default is OLTP.
 	GetDbWorkload() CreateAutonomousDatabaseBaseDbWorkloadEnum
 
+	// Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB memory. For Always Free databases, memory and CPU cannot be scaled.
+	GetIsFreeTier() *bool
+
 	// The user-friendly name for the Autonomous Database. The name does not have to be unique.
 	GetDisplayName() *string
 
-	// The Oracle license model that applies to the Oracle Autonomous Database. The default is BRING_YOUR_OWN_LICENSE. Note that when provisioning an Autonomous Database using the dedicated deployment (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm) option, this attribute must be null.
+	// The Oracle license model that applies to the Oracle Autonomous Database. The default for Autonomous Database using the shared deployment is BRING_YOUR_OWN_LICENSE. Note that when provisioning an Autonomous Database using the dedicated deployment (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm) option, this attribute must be null because the attribute is already set on Autonomous Exadata Infrastructure level.
 	GetLicenseModel() CreateAutonomousDatabaseBaseLicenseModelEnum
 
 	// If set to true, indicates that an Autonomous Database preview version is being provisioned, and that the preview version's terms of service have been accepted. Note that preview version software is only available for serverless deployments (https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI).
@@ -60,7 +63,6 @@ type CreateAutonomousDatabaseBase interface {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	GetDefinedTags() map[string]map[string]interface{}
 }
 
@@ -72,6 +74,7 @@ type createautonomousdatabasebase struct {
 	DataStorageSizeInTBs                     *int                                         `mandatory:"true" json:"dataStorageSizeInTBs"`
 	AdminPassword                            *string                                      `mandatory:"true" json:"adminPassword"`
 	DbWorkload                               CreateAutonomousDatabaseBaseDbWorkloadEnum   `mandatory:"false" json:"dbWorkload,omitempty"`
+	IsFreeTier                               *bool                                        `mandatory:"false" json:"isFreeTier"`
 	DisplayName                              *string                                      `mandatory:"false" json:"displayName"`
 	LicenseModel                             CreateAutonomousDatabaseBaseLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
 	IsPreviewVersionWithServiceTermsAccepted *bool                                        `mandatory:"false" json:"isPreviewVersionWithServiceTermsAccepted"`
@@ -100,6 +103,7 @@ func (m *createautonomousdatabasebase) UnmarshalJSON(data []byte) error {
 	m.DataStorageSizeInTBs = s.Model.DataStorageSizeInTBs
 	m.AdminPassword = s.Model.AdminPassword
 	m.DbWorkload = s.Model.DbWorkload
+	m.IsFreeTier = s.Model.IsFreeTier
 	m.DisplayName = s.Model.DisplayName
 	m.LicenseModel = s.Model.LicenseModel
 	m.IsPreviewVersionWithServiceTermsAccepted = s.Model.IsPreviewVersionWithServiceTermsAccepted
@@ -163,6 +167,11 @@ func (m createautonomousdatabasebase) GetAdminPassword() *string {
 //GetDbWorkload returns DbWorkload
 func (m createautonomousdatabasebase) GetDbWorkload() CreateAutonomousDatabaseBaseDbWorkloadEnum {
 	return m.DbWorkload
+}
+
+//GetIsFreeTier returns IsFreeTier
+func (m createautonomousdatabasebase) GetIsFreeTier() *bool {
+	return m.IsFreeTier
 }
 
 //GetDisplayName returns DisplayName

--- a/database/create_autonomous_database_clone_details.go
+++ b/database/create_autonomous_database_clone_details.go
@@ -34,6 +34,9 @@ type CreateAutonomousDatabaseCloneDetails struct {
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the source Autonomous Database that you will clone to create a new Autonomous Database.
 	SourceId *string `mandatory:"true" json:"sourceId"`
 
+	// Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB memory. For Always Free databases, memory and CPU cannot be scaled.
+	IsFreeTier *bool `mandatory:"false" json:"isFreeTier"`
+
 	// The user-friendly name for the Autonomous Database. The name does not have to be unique.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
@@ -56,7 +59,6 @@ type CreateAutonomousDatabaseCloneDetails struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// The Autonomous Database clone type.
@@ -65,7 +67,7 @@ type CreateAutonomousDatabaseCloneDetails struct {
 	// The autonomous database workload type. OLTP indicates an Autonomous Transaction Processing database and DW indicates an Autonomous Data Warehouse. The default is OLTP.
 	DbWorkload CreateAutonomousDatabaseBaseDbWorkloadEnum `mandatory:"false" json:"dbWorkload,omitempty"`
 
-	// The Oracle license model that applies to the Oracle Autonomous Database. The default is BRING_YOUR_OWN_LICENSE. Note that when provisioning an Autonomous Database using the dedicated deployment (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm) option, this attribute must be null.
+	// The Oracle license model that applies to the Oracle Autonomous Database. The default for Autonomous Database using the shared deployment is BRING_YOUR_OWN_LICENSE. Note that when provisioning an Autonomous Database using the dedicated deployment (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm) option, this attribute must be null because the attribute is already set on Autonomous Exadata Infrastructure level.
 	LicenseModel CreateAutonomousDatabaseBaseLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
 }
 
@@ -92,6 +94,11 @@ func (m CreateAutonomousDatabaseCloneDetails) GetDbWorkload() CreateAutonomousDa
 //GetDataStorageSizeInTBs returns DataStorageSizeInTBs
 func (m CreateAutonomousDatabaseCloneDetails) GetDataStorageSizeInTBs() *int {
 	return m.DataStorageSizeInTBs
+}
+
+//GetIsFreeTier returns IsFreeTier
+func (m CreateAutonomousDatabaseCloneDetails) GetIsFreeTier() *bool {
+	return m.IsFreeTier
 }
 
 //GetAdminPassword returns AdminPassword

--- a/database/create_autonomous_database_details.go
+++ b/database/create_autonomous_database_details.go
@@ -31,6 +31,9 @@ type CreateAutonomousDatabaseDetails struct {
 	// The password must be between 12 and 30 characters long, and must contain at least 1 uppercase, 1 lowercase, and 1 numeric character. It cannot contain the double quote symbol (") or the username "admin", regardless of casing.
 	AdminPassword *string `mandatory:"true" json:"adminPassword"`
 
+	// Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB memory. For Always Free databases, memory and CPU cannot be scaled.
+	IsFreeTier *bool `mandatory:"false" json:"isFreeTier"`
+
 	// The user-friendly name for the Autonomous Database. The name does not have to be unique.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
@@ -53,13 +56,12 @@ type CreateAutonomousDatabaseDetails struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// The autonomous database workload type. OLTP indicates an Autonomous Transaction Processing database and DW indicates an Autonomous Data Warehouse. The default is OLTP.
 	DbWorkload CreateAutonomousDatabaseBaseDbWorkloadEnum `mandatory:"false" json:"dbWorkload,omitempty"`
 
-	// The Oracle license model that applies to the Oracle Autonomous Database. The default is BRING_YOUR_OWN_LICENSE. Note that when provisioning an Autonomous Database using the dedicated deployment (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm) option, this attribute must be null.
+	// The Oracle license model that applies to the Oracle Autonomous Database. The default for Autonomous Database using the shared deployment is BRING_YOUR_OWN_LICENSE. Note that when provisioning an Autonomous Database using the dedicated deployment (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm) option, this attribute must be null because the attribute is already set on Autonomous Exadata Infrastructure level.
 	LicenseModel CreateAutonomousDatabaseBaseLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
 }
 
@@ -86,6 +88,11 @@ func (m CreateAutonomousDatabaseDetails) GetDbWorkload() CreateAutonomousDatabas
 //GetDataStorageSizeInTBs returns DataStorageSizeInTBs
 func (m CreateAutonomousDatabaseDetails) GetDataStorageSizeInTBs() *int {
 	return m.DataStorageSizeInTBs
+}
+
+//GetIsFreeTier returns IsFreeTier
+func (m CreateAutonomousDatabaseDetails) GetIsFreeTier() *bool {
+	return m.IsFreeTier
 }
 
 //GetAdminPassword returns AdminPassword

--- a/database/create_database_details.go
+++ b/database/create_database_details.go
@@ -45,7 +45,6 @@ type CreateDatabaseDetails struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 }
 

--- a/database/create_db_home_with_db_system_id_base.go
+++ b/database/create_db_home_with_db_system_id_base.go
@@ -26,7 +26,7 @@ type CreateDbHomeWithDbSystemIdBase interface {
 
 type createdbhomewithdbsystemidbase struct {
 	JsonData    []byte
-	DbSystemId  *string `mandatory:"false" json:"dbSystemId"`
+	DbSystemId  *string `mandatory:"true" json:"dbSystemId"`
 	DisplayName *string `mandatory:"false" json:"displayName"`
 	Source      string  `json:"source"`
 }

--- a/database/create_db_home_with_db_system_id_details.go
+++ b/database/create_db_home_with_db_system_id_details.go
@@ -16,13 +16,13 @@ import (
 // CreateDbHomeWithDbSystemIdDetails Note that a valid `dbSystemId` value must be supplied for the `CreateDbHomeWithDbSystemId` API operation to successfully complete.
 type CreateDbHomeWithDbSystemIdDetails struct {
 
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the DB system.
+	DbSystemId *string `mandatory:"true" json:"dbSystemId"`
+
 	// A valid Oracle Database version. To get a list of supported versions, use the ListDbVersions operation.
 	DbVersion *string `mandatory:"true" json:"dbVersion"`
 
 	Database *CreateDatabaseDetails `mandatory:"true" json:"database"`
-
-	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the DB system.
-	DbSystemId *string `mandatory:"false" json:"dbSystemId"`
 
 	// The user-provided name of the database home.
 	DisplayName *string `mandatory:"false" json:"displayName"`

--- a/database/create_db_home_with_db_system_id_from_backup_details.go
+++ b/database/create_db_home_with_db_system_id_from_backup_details.go
@@ -15,10 +15,11 @@ import (
 
 // CreateDbHomeWithDbSystemIdFromBackupDetails Note that a valid `dbSystemId` value must be supplied for the `CreateDbHomeWithDbSystemIdFromBackup` API operation to successfully complete.
 type CreateDbHomeWithDbSystemIdFromBackupDetails struct {
-	Database *CreateDatabaseFromBackupDetails `mandatory:"true" json:"database"`
 
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the DB system.
-	DbSystemId *string `mandatory:"false" json:"dbSystemId"`
+	DbSystemId *string `mandatory:"true" json:"dbSystemId"`
+
+	Database *CreateDatabaseFromBackupDetails `mandatory:"true" json:"database"`
 
 	// The user-provided name of the database home.
 	DisplayName *string `mandatory:"false" json:"displayName"`

--- a/database/database.go
+++ b/database/database.go
@@ -60,7 +60,6 @@ type Database struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// The Connection strings used to connect to the Oracle Database.

--- a/database/database_summary.go
+++ b/database/database_summary.go
@@ -62,7 +62,6 @@ type DatabaseSummary struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// The Connection strings used to connect to the Oracle Database.

--- a/database/db_backup_config.go
+++ b/database/db_backup_config.go
@@ -23,8 +23,55 @@ type DbBackupConfig struct {
 	// This value applies to automatic backups only. After a new automatic backup has been created, Oracle removes old automatic backups that are created before the window.
 	// When the value is updated, it is applied to all existing automatic backups.
 	RecoveryWindowInDays *int `mandatory:"false" json:"recoveryWindowInDays"`
+
+	// Time window selected for initiating automatic backup for the database system. There are twelve available two-hour time windows. If no option is selected, a start time between 12:00 AM to 7:00 AM in the region of the database is automatically chosen. For example, if the user selects SLOT_TWO from the enum list, the automatic backup job will start in between 2:00 AM (inclusive) to 4:00 AM (exclusive).
+	// Example: `SLOT_TWO`
+	AutoBackupWindow DbBackupConfigAutoBackupWindowEnum `mandatory:"false" json:"autoBackupWindow,omitempty"`
 }
 
 func (m DbBackupConfig) String() string {
 	return common.PointerString(m)
+}
+
+// DbBackupConfigAutoBackupWindowEnum Enum with underlying type: string
+type DbBackupConfigAutoBackupWindowEnum string
+
+// Set of constants representing the allowable values for DbBackupConfigAutoBackupWindowEnum
+const (
+	DbBackupConfigAutoBackupWindowOne    DbBackupConfigAutoBackupWindowEnum = "SLOT_ONE"
+	DbBackupConfigAutoBackupWindowTwo    DbBackupConfigAutoBackupWindowEnum = "SLOT_TWO"
+	DbBackupConfigAutoBackupWindowThree  DbBackupConfigAutoBackupWindowEnum = "SLOT_THREE"
+	DbBackupConfigAutoBackupWindowFour   DbBackupConfigAutoBackupWindowEnum = "SLOT_FOUR"
+	DbBackupConfigAutoBackupWindowFive   DbBackupConfigAutoBackupWindowEnum = "SLOT_FIVE"
+	DbBackupConfigAutoBackupWindowSix    DbBackupConfigAutoBackupWindowEnum = "SLOT_SIX"
+	DbBackupConfigAutoBackupWindowSeven  DbBackupConfigAutoBackupWindowEnum = "SLOT_SEVEN"
+	DbBackupConfigAutoBackupWindowEight  DbBackupConfigAutoBackupWindowEnum = "SLOT_EIGHT"
+	DbBackupConfigAutoBackupWindowNine   DbBackupConfigAutoBackupWindowEnum = "SLOT_NINE"
+	DbBackupConfigAutoBackupWindowTen    DbBackupConfigAutoBackupWindowEnum = "SLOT_TEN"
+	DbBackupConfigAutoBackupWindowEleven DbBackupConfigAutoBackupWindowEnum = "SLOT_ELEVEN"
+	DbBackupConfigAutoBackupWindowTwelve DbBackupConfigAutoBackupWindowEnum = "SLOT_TWELVE"
+)
+
+var mappingDbBackupConfigAutoBackupWindow = map[string]DbBackupConfigAutoBackupWindowEnum{
+	"SLOT_ONE":    DbBackupConfigAutoBackupWindowOne,
+	"SLOT_TWO":    DbBackupConfigAutoBackupWindowTwo,
+	"SLOT_THREE":  DbBackupConfigAutoBackupWindowThree,
+	"SLOT_FOUR":   DbBackupConfigAutoBackupWindowFour,
+	"SLOT_FIVE":   DbBackupConfigAutoBackupWindowFive,
+	"SLOT_SIX":    DbBackupConfigAutoBackupWindowSix,
+	"SLOT_SEVEN":  DbBackupConfigAutoBackupWindowSeven,
+	"SLOT_EIGHT":  DbBackupConfigAutoBackupWindowEight,
+	"SLOT_NINE":   DbBackupConfigAutoBackupWindowNine,
+	"SLOT_TEN":    DbBackupConfigAutoBackupWindowTen,
+	"SLOT_ELEVEN": DbBackupConfigAutoBackupWindowEleven,
+	"SLOT_TWELVE": DbBackupConfigAutoBackupWindowTwelve,
+}
+
+// GetDbBackupConfigAutoBackupWindowEnumValues Enumerates the set of values for DbBackupConfigAutoBackupWindowEnum
+func GetDbBackupConfigAutoBackupWindowEnumValues() []DbBackupConfigAutoBackupWindowEnum {
+	values := make([]DbBackupConfigAutoBackupWindowEnum, 0)
+	for _, v := range mappingDbBackupConfigAutoBackupWindow {
+		values = append(values, v)
+	}
+	return values
 }

--- a/database/db_system.go
+++ b/database/db_system.go
@@ -139,7 +139,6 @@ type DbSystem struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	IormConfigCache *ExadataIormConfig `mandatory:"false" json:"iormConfigCache"`

--- a/database/db_system_summary.go
+++ b/database/db_system_summary.go
@@ -150,7 +150,6 @@ type DbSystemSummary struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 }
 

--- a/database/launch_autonomous_exadata_infrastructure_details.go
+++ b/database/launch_autonomous_exadata_infrastructure_details.go
@@ -35,6 +35,9 @@ type LaunchAutonomousExadataInfrastructureDetails struct {
 	// The user-friendly name for the Autonomous Exadata Infrastructure. It does not have to be unique.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
+	// A list of the OCIDs (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see Security Rules (https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
 	// A domain name used for the Autonomous Exadata Infrastructure. If the Oracle-provided Internet and VCN
 	// Resolver is enabled for the specified subnet, the domain name for the subnet is used
 	// (don't provide one). Otherwise, provide a valid DNS domain name. Hyphens (-) are not permitted.
@@ -52,7 +55,6 @@ type LaunchAutonomousExadataInfrastructureDetails struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 }
 

--- a/database/launch_db_system_base.go
+++ b/database/launch_db_system_base.go
@@ -122,7 +122,6 @@ type LaunchDbSystemBase interface {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	GetDefinedTags() map[string]map[string]interface{}
 }
 

--- a/database/launch_db_system_details.go
+++ b/database/launch_db_system_details.go
@@ -123,7 +123,6 @@ type LaunchDbSystemDetails struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// The Oracle Database Edition that applies to all the databases on the DB system.

--- a/database/launch_db_system_from_backup_details.go
+++ b/database/launch_db_system_from_backup_details.go
@@ -123,7 +123,6 @@ type LaunchDbSystemFromBackupDetails struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// The Oracle Database Edition that applies to all the databases on the DB system.

--- a/database/list_autonomous_databases_request_response.go
+++ b/database/list_autonomous_databases_request_response.go
@@ -36,6 +36,10 @@ type ListAutonomousDatabasesRequest struct {
 	// A filter to return only autonomous database resources that match the specified workload type.
 	DbWorkload AutonomousDatabaseSummaryDbWorkloadEnum `mandatory:"false" contributesTo:"query" name:"dbWorkload" omitEmpty:"true"`
 
+	// Filter on the value of the resource's 'isFreeTier' property. A value of `true` returns only Always Free resources.
+	// A value of `false` excludes Always Free resources from the returned results. Omitting this parameter returns both Always Free and paid resources.
+	IsFreeTier *bool `mandatory:"false" contributesTo:"query" name:"isFreeTier"`
+
 	// A filter to return only resources that match the entire display name given. The match is not case sensitive.
 	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
 

--- a/database/update_autonomous_container_database_details.go
+++ b/database/update_autonomous_container_database_details.go
@@ -28,7 +28,6 @@ type UpdateAutonomousContainerDatabaseDetails struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	BackupConfig *AutonomousContainerDatabaseBackupConfig `mandatory:"false" json:"backupConfig"`

--- a/database/update_autonomous_data_warehouse_details.go
+++ b/database/update_autonomous_data_warehouse_details.go
@@ -35,7 +35,6 @@ type UpdateAutonomousDataWarehouseDetails struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 }
 

--- a/database/update_autonomous_database_details.go
+++ b/database/update_autonomous_database_details.go
@@ -25,6 +25,9 @@ type UpdateAutonomousDatabaseDetails struct {
 	// The user-friendly name for the Autonomous Database. The name does not have to be unique.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
+	// Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB memory. For Always Free databases, memory and CPU cannot be scaled.
+	IsFreeTier *bool `mandatory:"false" json:"isFreeTier"`
+
 	// The password must be between 12 and 30 characters long, and must contain at least 1 uppercase, 1 lowercase, and 1 numeric character. It cannot contain the double quote symbol (") or the username "admin", regardless of casing. It must be different from the last four passwords and it must not be a password used within the last 24 hours.
 	AdminPassword *string `mandatory:"false" json:"adminPassword"`
 
@@ -40,10 +43,9 @@ type UpdateAutonomousDatabaseDetails struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
-	// The new Oracle license model that applies to the Oracle Autonomous Transaction Processing database. Note that when updating an Autonomous Database that uses the dedicated deployment (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm) option, this attribute must be null.
+	// The Oracle license model that applies to the Oracle Autonomous Database. The default for Autonomous Database using the shared deployment is BRING_YOUR_OWN_LICENSE. Note that when provisioning an Autonomous Database using the dedicated deployment (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm) option, this attribute must be null because the attribute is already set on Autonomous Exadata Infrastructure level.
 	LicenseModel UpdateAutonomousDatabaseDetailsLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
 
 	// The client IP access control list (ACL). This feature is available for serverless deployments (https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI) only.

--- a/database/update_autonomous_exadata_infrastructure_details.go
+++ b/database/update_autonomous_exadata_infrastructure_details.go
@@ -20,6 +20,9 @@ type UpdateAutonomousExadataInfrastructureDetails struct {
 
 	MaintenanceWindowDetails *MaintenanceWindow `mandatory:"false" json:"maintenanceWindowDetails"`
 
+	// A list of the OCIDs (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see Security Rules (https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
@@ -27,7 +30,6 @@ type UpdateAutonomousExadataInfrastructureDetails struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 }
 

--- a/database/update_database_details.go
+++ b/database/update_database_details.go
@@ -24,7 +24,6 @@ type UpdateDatabaseDetails struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 }
 

--- a/database/update_db_system_details.go
+++ b/database/update_db_system_details.go
@@ -34,7 +34,6 @@ type UpdateDbSystemDetails struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
-	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// A list of the OCIDs (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see Security Rules (https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).

--- a/example/example_cluster_network_test.go
+++ b/example/example_cluster_network_test.go
@@ -115,11 +115,11 @@ func createClusterNetwork(ctx context.Context, client core.ComputeManagementClie
 
 	req := core.CreateClusterNetworkRequest{
 		CreateClusterNetworkDetails: core.CreateClusterNetworkDetails{
-			CompartmentId:           &compartmentId,
-			DisplayName: 			 &displayName,
-			PlacementConfiguration:  &placementConfigurationDetails,
-			InstancePools: []core.CreateClusterNetworkInstancePoolDetails {
-				core.CreateClusterNetworkInstancePoolDetails {
+			CompartmentId:          &compartmentId,
+			DisplayName:            &displayName,
+			PlacementConfiguration: &placementConfigurationDetails,
+			InstancePools: []core.CreateClusterNetworkInstancePoolDetails{
+				{
 					Size: &size,
 					InstanceConfigurationId: &instanceConfigurationId,
 				},
@@ -170,7 +170,6 @@ func createInstanceConfigurationWithHpcShape(ctx context.Context, client core.Co
 	return
 }
 
-
 // helper method to terminate a cluster network
 func terminateClusterNetwork(ctx context.Context, client core.ComputeManagementClient,
 	clusterNetworkId string) (response core.TerminateClusterNetworkResponse, err error) {
@@ -199,8 +198,8 @@ func pollUntilClusterNetworkInDesiredState(ctx context.Context, computeMgmtClien
 	// create get cluster network request with a retry policy which takes a function
 	// to determine shouldRetry or not
 	pollingGetRequest := core.GetClusterNetworkRequest{
-		ClusterNetworkId:  clusterNetwork.Id,
-		RequestMetadata: helpers.GetRequestMetadataWithCustomizedRetryPolicy(shouldRetryFunc),
+		ClusterNetworkId: clusterNetwork.Id,
+		RequestMetadata:  helpers.GetRequestMetadataWithCustomizedRetryPolicy(shouldRetryFunc),
 	}
 	_, pollError := computeMgmtClient.GetClusterNetwork(ctx, pollingGetRequest)
 	helpers.FatalIfError(pollError)

--- a/example/example_database_test.go
+++ b/example/example_database_test.go
@@ -55,6 +55,32 @@ func ExampleCreateAdb() {
 	// create adb successful
 }
 
+func ExampleCreateFreeAdb() {
+	c, clerr := database.NewDatabaseClientWithConfigurationProvider(common.DefaultConfigProvider())
+	helpers.FatalIfError(clerr)
+
+	createDbDetails := database.CreateAutonomousDatabaseDetails{
+		CompartmentId:        helpers.CompartmentID(),
+		DbName:               common.String("freeadb"),
+		CpuCoreCount:         common.Int(1),
+		DataStorageSizeInTBs: common.Int(1),
+		AdminPassword:        common.String("DBaaS12345_#"),
+		IsFreeTier:           common.Bool(true),
+	}
+
+	createadbReq := database.CreateAutonomousDatabaseRequest{
+		CreateAutonomousDatabaseDetails: createDbDetails,
+	}
+
+	_, err := c.CreateAutonomousDatabase(context.Background(), createadbReq)
+	helpers.FatalIfError(err)
+
+	fmt.Println("create free adb successful")
+
+	// Output:
+	// create free adb successful
+}
+
 func ExampleCreateAdbPreview() {
 	c, clerr := database.NewDatabaseClientWithConfigurationProvider(common.DefaultConfigProvider())
 	helpers.FatalIfError(clerr)

--- a/loadbalancer/backend.go
+++ b/loadbalancer/backend.go
@@ -44,6 +44,7 @@ type Backend struct {
 
 	// Whether the load balancer should treat this server as a backup unit. If `true`, the load balancer forwards no ingress
 	// traffic to this backend server unless all other backend servers not marked as "backup" fail the health check policy.
+	// **Note:** You cannot add a backend server marked as `backup` to a backend set that uses the IP Hash policy.
 	// Example: `false`
 	Backup *bool `mandatory:"true" json:"backup"`
 

--- a/loadbalancer/backend_details.go
+++ b/loadbalancer/backend_details.go
@@ -34,6 +34,7 @@ type BackendDetails struct {
 
 	// Whether the load balancer should treat this server as a backup unit. If `true`, the load balancer forwards no ingress
 	// traffic to this backend server unless all other backend servers not marked as "backup" fail the health check policy.
+	// **Note:** You cannot add a backend server marked as `backup` to a backend set that uses the IP Hash policy.
 	// Example: `false`
 	Backup *bool `mandatory:"false" json:"backup"`
 

--- a/loadbalancer/create_backend_details.go
+++ b/loadbalancer/create_backend_details.go
@@ -36,6 +36,7 @@ type CreateBackendDetails struct {
 
 	// Whether the load balancer should treat this server as a backup unit. If `true`, the load balancer forwards no ingress
 	// traffic to this backend server unless all other backend servers not marked as "backup" fail the health check policy.
+	// **Note:** You cannot add a backend server marked as `backup` to a backend set that uses the IP Hash policy.
 	// Example: `false`
 	Backup *bool `mandatory:"false" json:"backup"`
 

--- a/loadbalancer/create_load_balancer_details.go
+++ b/loadbalancer/create_load_balancer_details.go
@@ -55,7 +55,13 @@ type CreateLoadBalancerDetails struct {
 
 	BackendSets map[string]BackendSetDetails `mandatory:"false" json:"backendSets"`
 
-	// The array of NSG OCIDs (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) to be used by this Load Balancer.
+	// An array of NSG OCIDs (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) associated with this load balancer.
+	// During the load balancer's creation, the service adds the new load balancer to the specified NSGs.
+	// The benefits of using NSGs with the load balancer include:
+	// *  NSGs define network security rules to govern ingress and egress traffic for the load balancer.
+	// *  The network security rules of other resources can reference the NSGs associated with the load balancer
+	//    to ensure access.
+	// Example: `["ocid1.nsg.oc1.phx.unique_ID"]`
 	NetworkSecurityGroupIds []string `mandatory:"false" json:"networkSecurityGroupIds"`
 
 	Certificates map[string]CertificateDetails `mandatory:"false" json:"certificates"`

--- a/loadbalancer/health_checker.go
+++ b/loadbalancer/health_checker.go
@@ -39,7 +39,8 @@ type HealthChecker struct {
 	// Example: `/healthcheck`
 	UrlPath *string `mandatory:"false" json:"urlPath"`
 
-	// The number of retries to attempt before a backend server is considered "unhealthy". Defaults to 3.
+	// The number of retries to attempt before a backend server is considered "unhealthy". This number also applies
+	// when recovering a server to the "healthy" state. Defaults to 3.
 	// Example: `3`
 	Retries *int `mandatory:"false" json:"retries"`
 

--- a/loadbalancer/health_checker_details.go
+++ b/loadbalancer/health_checker_details.go
@@ -33,7 +33,8 @@ type HealthCheckerDetails struct {
 	// Example: `200`
 	ReturnCode *int `mandatory:"false" json:"returnCode"`
 
-	// The number of retries to attempt before a backend server is considered "unhealthy".
+	// The number of retries to attempt before a backend server is considered "unhealthy". This number also applies
+	// when recovering a server to the "healthy" state.
 	// Example: `3`
 	Retries *int `mandatory:"false" json:"retries"`
 

--- a/loadbalancer/lb_cookie_session_persistence_configuration_details.go
+++ b/loadbalancer/lb_cookie_session_persistence_configuration_details.go
@@ -20,7 +20,7 @@ import (
 // When you configure LB cookie stickiness, the load balancer inserts a cookie into the response. The parameters configured
 // in the cookie enable session stickiness. This method is useful when you have applications and Web backend services
 // that cannot generate their own cookies.
-// Path route rules take precedence to determine the target backend server. The load balancer verfies that session stickiness
+// Path route rules take precedence to determine the target backend server. The load balancer verifies that session stickiness
 // is enabled for the backend server and that the cookie configuration (domain, path, and cookie hash) is valid for the
 // target. The system ignores invalid cookies.
 // To disable LB cookie stickiness on a running load balancer, use the
@@ -62,7 +62,7 @@ type LbCookieSessionPersistenceConfigurationDetails struct {
 	//    If the value of the `Domain` attribute is `example.com` in the `Set-cookie` header, the client includes
 	//    the same cookie in the `Cookie` header when making HTTP requests to `example.com`, `www.example.com`, and
 	//    `www.abc.example.com`. If the `Domain` attribute is not present, the client returns the cookie only for
-	//    the domain to which the origianl request was made.
+	//    the domain to which the original request was made.
 	// *  Ensure that this attribute specifies the correct domain value. If the `Domain` attribute in the `Set-cookie`
 	//    header does not include the domain to which the original request was made, the client or browser might reject
 	//    the cookie. As specified in RFC 6265, the client accepts a cookie with the `Domain` attribute value `example.com`

--- a/loadbalancer/load_balancer.go
+++ b/loadbalancer/load_balancer.go
@@ -61,7 +61,14 @@ type LoadBalancer struct {
 	// An array of subnet OCIDs (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
 	SubnetIds []string `mandatory:"false" json:"subnetIds"`
 
-	// The array of NSG OCIDs (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) in use by this Load Balancer.
+	// An array of NSG OCIDs (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) associated with the load
+	// balancer.
+	// During the load balancer's creation, the service adds the new load balancer to the specified NSGs.
+	// The benefits of associating the load balancer with NSGs include:
+	// *  NSGs define network security rules to govern ingress and egress traffic for the load balancer.
+	// *  The network security rules of other resources can reference the NSGs associated with the load balancer
+	//    to ensure access.
+	// Example: ["ocid1.nsg.oc1.phx.unique_ID"]
 	NetworkSecurityGroupIds []string `mandatory:"false" json:"networkSecurityGroupIds"`
 
 	Listeners map[string]Listener `mandatory:"false" json:"listeners"`
@@ -83,6 +90,12 @@ type LoadBalancer struct {
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// System tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// System tags can be viewed by users, but can only be created by the system.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
 
 	RuleSets map[string]RuleSet `mandatory:"false" json:"ruleSets"`
 }

--- a/loadbalancer/loadbalancer_client.go
+++ b/loadbalancer/loadbalancer_client.go
@@ -2133,7 +2133,7 @@ func (client LoadBalancerClient) updateLoadBalancer(ctx context.Context, request
 	return response, err
 }
 
-// UpdateNetworkSecurityGroups Updates the network security groups to be used by a load balancer.
+// UpdateNetworkSecurityGroups Updates the network security groups associated with the specified load balancer.
 func (client LoadBalancerClient) UpdateNetworkSecurityGroups(ctx context.Context, request UpdateNetworkSecurityGroupsRequest) (response UpdateNetworkSecurityGroupsResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()

--- a/loadbalancer/update_backend_details.go
+++ b/loadbalancer/update_backend_details.go
@@ -26,6 +26,7 @@ type UpdateBackendDetails struct {
 
 	// Whether the load balancer should treat this server as a backup unit. If `true`, the load balancer forwards no ingress
 	// traffic to this backend server unless all other backend servers not marked as "backup" fail the health check policy.
+	// **Note:** You cannot add a backend server marked as `backup` to a backend set that uses the IP Hash policy.
 	// Example: `false`
 	Backup *bool `mandatory:"true" json:"backup"`
 

--- a/loadbalancer/update_health_checker_details.go
+++ b/loadbalancer/update_health_checker_details.go
@@ -28,7 +28,8 @@ type UpdateHealthCheckerDetails struct {
 	// Example: `200`
 	ReturnCode *int `mandatory:"true" json:"returnCode"`
 
-	// The number of retries to attempt before a backend server is considered "unhealthy".
+	// The number of retries to attempt before a backend server is considered "unhealthy". This number also applies
+	// when recovering a server to the "healthy" state.
 	// Example: `3`
 	Retries *int `mandatory:"true" json:"retries"`
 

--- a/loadbalancer/update_network_security_groups_details.go
+++ b/loadbalancer/update_network_security_groups_details.go
@@ -13,10 +13,19 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// UpdateNetworkSecurityGroupsDetails An object representing an updated list of NSGs that overwrites the existing list of NSGs. In particular, if the load balancer had no prior NSGs configured, these with be the new NSGs to be used by the load balancer. If the load balancer used to have a list of NSGs configured, and this list contains no entries, then the load balancer will contain no NSGs after this call completes.
+// UpdateNetworkSecurityGroupsDetails An object representing an updated list of network security groups (NSGs) that overwrites the existing list of NSGs.
+// *  If the load balancer has no NSGs configured, it uses the NSGs in this list.
+// *  If the load balancer has a list of NSGs configured, this list replaces the existing list.
+// *  If the load balancer has a list of NSGs configured and this list is empty, the operation removes all of the load balancer's NSG associations.
 type UpdateNetworkSecurityGroupsDetails struct {
 
-	// The array of NSG OCIDs (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) to be used by this Load Balancer.
+	// An array of NSG OCIDs (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) associated with the load
+	// balancer.
+	// During the load balancer's creation, the service adds the new load balancer to the specified NSGs.
+	// The benefits of associating the load balancer with NSGs include:
+	// *  NSGs define network security rules to govern ingress and egress traffic for the load balancer.
+	// *  The network security rules of other resources can reference the NSGs associated with the load balancer
+	//    to ensure access.
 	NetworkSecurityGroupIds []string `mandatory:"false" json:"networkSecurityGroupIds"`
 }
 

--- a/loadbalancer/update_network_security_groups_request_response.go
+++ b/loadbalancer/update_network_security_groups_request_response.go
@@ -11,10 +11,10 @@ import (
 // UpdateNetworkSecurityGroupsRequest wrapper for the UpdateNetworkSecurityGroups operation
 type UpdateNetworkSecurityGroupsRequest struct {
 
-	// The details for updating the NSGs of the load balancer.
+	// The details for updating the NSGs associated with the specified load balancer.
 	UpdateNetworkSecurityGroupsDetails `contributesTo:"body"`
 
-	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the load balancer on which update the NSGs.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the load balancer to update the NSGs for.
 	LoadBalancerId *string `mandatory:"true" contributesTo:"path" name:"loadBalancerId"`
 
 	// The unique Oracle-assigned identifier for the request. If you need to contact Oracle about a

--- a/oce/change_oce_instance_compartment_details.go
+++ b/oce/change_oce_instance_compartment_details.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// OceInstance API
+//
+// Oracle Content and Experience is a cloud-based content hub to drive omni-channel content management and accelerate experience delivery
+//
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ChangeOceInstanceCompartmentDetails The information about compartment details.
+type ChangeOceInstanceCompartmentDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment
+	// into which the OceInstance should be moved.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+}
+
+func (m ChangeOceInstanceCompartmentDetails) String() string {
+	return common.PointerString(m)
+}

--- a/oce/change_oce_instance_compartment_request_response.go
+++ b/oce/change_oce_instance_compartment_request_response.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ChangeOceInstanceCompartmentRequest wrapper for the ChangeOceInstanceCompartment operation
+type ChangeOceInstanceCompartmentRequest struct {
+
+	// unique OceInstance identifier
+	OceInstanceId *string `mandatory:"true" contributesTo:"path" name:"oceInstanceId"`
+
+	// The information about compartment details to be moved.
+	ChangeOceInstanceCompartmentDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call
+	// for a resource, set the `if-match` parameter to the value of the
+	// etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you
+	// provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// might be rejected.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ChangeOceInstanceCompartmentRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ChangeOceInstanceCompartmentRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ChangeOceInstanceCompartmentRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ChangeOceInstanceCompartmentResponse wrapper for the ChangeOceInstanceCompartment operation
+type ChangeOceInstanceCompartmentResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ChangeOceInstanceCompartmentResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ChangeOceInstanceCompartmentResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/oce/create_oce_instance_details.go
+++ b/oce/create_oce_instance_details.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// OceInstance API
+//
+// Oracle Content and Experience is a cloud-based content hub to drive omni-channel content management and accelerate experience delivery
+//
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateOceInstanceDetails The information about new OceInstance.
+type CreateOceInstanceDetails struct {
+
+	// Compartment Identifier
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// OceInstance Name
+	Name *string `mandatory:"true" json:"name"`
+
+	// Tenancy Identifier
+	TenancyId *string `mandatory:"true" json:"tenancyId"`
+
+	// Identity Cloud Service access token identifying a stripe and service administrator user
+	IdcsAccessToken *string `mandatory:"true" json:"idcsAccessToken"`
+
+	// Tenancy Name
+	TenancyName *string `mandatory:"true" json:"tenancyName"`
+
+	// Object Storage Namespace of Tenancy
+	ObjectStorageNamespace *string `mandatory:"true" json:"objectStorageNamespace"`
+
+	// Admin Email for Notification
+	AdminEmail *string `mandatory:"true" json:"adminEmail"`
+
+	// OceInstance description
+	Description *string `mandatory:"false" json:"description"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m CreateOceInstanceDetails) String() string {
+	return common.PointerString(m)
+}

--- a/oce/create_oce_instance_request_response.go
+++ b/oce/create_oce_instance_request_response.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateOceInstanceRequest wrapper for the CreateOceInstance operation
+type CreateOceInstanceRequest struct {
+
+	// Details for the new OceInstance.
+	CreateOceInstanceDetails `contributesTo:"body"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// might be rejected.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateOceInstanceRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateOceInstanceRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateOceInstanceRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateOceInstanceResponse wrapper for the CreateOceInstance operation
+type CreateOceInstanceResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateOceInstanceResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateOceInstanceResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/oce/delete_oce_instance_details.go
+++ b/oce/delete_oce_instance_details.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// OceInstance API
+//
+// Oracle Content and Experience is a cloud-based content hub to drive omni-channel content management and accelerate experience delivery
+//
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DeleteOceInstanceDetails The information about the resource to be deleted.
+type DeleteOceInstanceDetails struct {
+
+	// IDCS access token identifying a stripe and service administrator user
+	IdcsAccessToken *string `mandatory:"true" json:"idcsAccessToken"`
+}
+
+func (m DeleteOceInstanceDetails) String() string {
+	return common.PointerString(m)
+}

--- a/oce/delete_oce_instance_request_response.go
+++ b/oce/delete_oce_instance_request_response.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteOceInstanceRequest wrapper for the DeleteOceInstance operation
+type DeleteOceInstanceRequest struct {
+
+	// unique OceInstance identifier
+	OceInstanceId *string `mandatory:"true" contributesTo:"path" name:"oceInstanceId"`
+
+	// The information about resource to be deleted.
+	DeleteOceInstanceDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call
+	// for a resource, set the `if-match` parameter to the value of the
+	// etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you
+	// provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteOceInstanceRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteOceInstanceRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteOceInstanceRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteOceInstanceResponse wrapper for the DeleteOceInstance operation
+type DeleteOceInstanceResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteOceInstanceResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteOceInstanceResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/oce/get_oce_instance_request_response.go
+++ b/oce/get_oce_instance_request_response.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetOceInstanceRequest wrapper for the GetOceInstance operation
+type GetOceInstanceRequest struct {
+
+	// unique OceInstance identifier
+	OceInstanceId *string `mandatory:"true" contributesTo:"path" name:"oceInstanceId"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetOceInstanceRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetOceInstanceRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetOceInstanceRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetOceInstanceResponse wrapper for the GetOceInstance operation
+type GetOceInstanceResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OceInstance instance
+	OceInstance `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetOceInstanceResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetOceInstanceResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/oce/get_work_request_request_response.go
+++ b/oce/get_work_request_request_response.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetWorkRequestRequest wrapper for the GetWorkRequest operation
+type GetWorkRequestRequest struct {
+
+	// The ID of the asynchronous request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetWorkRequestRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetWorkRequestRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetWorkRequestRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetWorkRequestResponse wrapper for the GetWorkRequest operation
+type GetWorkRequestResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The WorkRequest instance
+	WorkRequest `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// some decimal number representing the number of seconds the client should wait before polling this endpoint again
+	RetryAfter *float32 `presentIn:"header" name:"retry-after"`
+}
+
+func (response GetWorkRequestResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetWorkRequestResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/oce/list_oce_instances_request_response.go
+++ b/oce/list_oce_instances_request_response.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListOceInstancesRequest wrapper for the ListOceInstances operation
+type ListOceInstancesRequest struct {
+
+	// The ID of the compartment in which to list resources.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// A user-friendly name. Does not have to be unique, and it's changeable.
+	// Example: `My new resource`
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The sort order to use, either 'asc' or 'desc'.
+	SortOrder ListOceInstancesSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending. Default order for displayName is ascending. If no value is specified timeCreated is default.
+	SortBy ListOceInstancesSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Filter results on lifecycleState.
+	LifecycleState ListOceInstancesLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListOceInstancesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListOceInstancesRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListOceInstancesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListOceInstancesResponse wrapper for the ListOceInstances operation
+type ListOceInstancesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []OceInstanceSummary instances
+	Items []OceInstanceSummary `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For pagination of a list of `OceInstance`s. If this header appears in the response, then this
+	// is a partial list of OceInstances. Include this value as the `page` parameter in a subsequent
+	// GET request to get the next batch of OceInstances.
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListOceInstancesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListOceInstancesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListOceInstancesSortOrderEnum Enum with underlying type: string
+type ListOceInstancesSortOrderEnum string
+
+// Set of constants representing the allowable values for ListOceInstancesSortOrderEnum
+const (
+	ListOceInstancesSortOrderAsc  ListOceInstancesSortOrderEnum = "ASC"
+	ListOceInstancesSortOrderDesc ListOceInstancesSortOrderEnum = "DESC"
+)
+
+var mappingListOceInstancesSortOrder = map[string]ListOceInstancesSortOrderEnum{
+	"ASC":  ListOceInstancesSortOrderAsc,
+	"DESC": ListOceInstancesSortOrderDesc,
+}
+
+// GetListOceInstancesSortOrderEnumValues Enumerates the set of values for ListOceInstancesSortOrderEnum
+func GetListOceInstancesSortOrderEnumValues() []ListOceInstancesSortOrderEnum {
+	values := make([]ListOceInstancesSortOrderEnum, 0)
+	for _, v := range mappingListOceInstancesSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListOceInstancesSortByEnum Enum with underlying type: string
+type ListOceInstancesSortByEnum string
+
+// Set of constants representing the allowable values for ListOceInstancesSortByEnum
+const (
+	ListOceInstancesSortByTimecreated ListOceInstancesSortByEnum = "timeCreated"
+	ListOceInstancesSortByDisplayname ListOceInstancesSortByEnum = "displayName"
+)
+
+var mappingListOceInstancesSortBy = map[string]ListOceInstancesSortByEnum{
+	"timeCreated": ListOceInstancesSortByTimecreated,
+	"displayName": ListOceInstancesSortByDisplayname,
+}
+
+// GetListOceInstancesSortByEnumValues Enumerates the set of values for ListOceInstancesSortByEnum
+func GetListOceInstancesSortByEnumValues() []ListOceInstancesSortByEnum {
+	values := make([]ListOceInstancesSortByEnum, 0)
+	for _, v := range mappingListOceInstancesSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListOceInstancesLifecycleStateEnum Enum with underlying type: string
+type ListOceInstancesLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListOceInstancesLifecycleStateEnum
+const (
+	ListOceInstancesLifecycleStateCreating ListOceInstancesLifecycleStateEnum = "CREATING"
+	ListOceInstancesLifecycleStateUpdating ListOceInstancesLifecycleStateEnum = "UPDATING"
+	ListOceInstancesLifecycleStateActive   ListOceInstancesLifecycleStateEnum = "ACTIVE"
+	ListOceInstancesLifecycleStateDeleting ListOceInstancesLifecycleStateEnum = "DELETING"
+	ListOceInstancesLifecycleStateDeleted  ListOceInstancesLifecycleStateEnum = "DELETED"
+	ListOceInstancesLifecycleStateFailed   ListOceInstancesLifecycleStateEnum = "FAILED"
+)
+
+var mappingListOceInstancesLifecycleState = map[string]ListOceInstancesLifecycleStateEnum{
+	"CREATING": ListOceInstancesLifecycleStateCreating,
+	"UPDATING": ListOceInstancesLifecycleStateUpdating,
+	"ACTIVE":   ListOceInstancesLifecycleStateActive,
+	"DELETING": ListOceInstancesLifecycleStateDeleting,
+	"DELETED":  ListOceInstancesLifecycleStateDeleted,
+	"FAILED":   ListOceInstancesLifecycleStateFailed,
+}
+
+// GetListOceInstancesLifecycleStateEnumValues Enumerates the set of values for ListOceInstancesLifecycleStateEnum
+func GetListOceInstancesLifecycleStateEnumValues() []ListOceInstancesLifecycleStateEnum {
+	values := make([]ListOceInstancesLifecycleStateEnum, 0)
+	for _, v := range mappingListOceInstancesLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}

--- a/oce/list_work_request_errors_request_response.go
+++ b/oce/list_work_request_errors_request_response.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListWorkRequestErrorsRequest wrapper for the ListWorkRequestErrors operation
+type ListWorkRequestErrorsRequest struct {
+
+	// The ID of the asynchronous request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListWorkRequestErrorsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListWorkRequestErrorsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListWorkRequestErrorsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListWorkRequestErrorsResponse wrapper for the ListWorkRequestErrors operation
+type ListWorkRequestErrorsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []WorkRequestError instances
+	Items []WorkRequestError `presentIn:"body"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then there might be additional items still to get. Include this value as the `page` parameter for the
+	// subsequent GET request.
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListWorkRequestErrorsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListWorkRequestErrorsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/oce/list_work_request_logs_request_response.go
+++ b/oce/list_work_request_logs_request_response.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListWorkRequestLogsRequest wrapper for the ListWorkRequestLogs operation
+type ListWorkRequestLogsRequest struct {
+
+	// The ID of the asynchronous request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListWorkRequestLogsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListWorkRequestLogsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListWorkRequestLogsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListWorkRequestLogsResponse wrapper for the ListWorkRequestLogs operation
+type ListWorkRequestLogsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []WorkRequestLogEntry instances
+	Items []WorkRequestLogEntry `presentIn:"body"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then there might be additional items still to get. Include this value as the `page` parameter for the
+	// subsequent GET request.
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListWorkRequestLogsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListWorkRequestLogsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/oce/list_work_requests_request_response.go
+++ b/oce/list_work_requests_request_response.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListWorkRequestsRequest wrapper for the ListWorkRequests operation
+type ListWorkRequestsRequest struct {
+
+	// The ID of the compartment in which to list resources.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The resource Identifier for which to list resources.
+	ResourceId *string `mandatory:"false" contributesTo:"query" name:"resourceId"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListWorkRequestsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListWorkRequestsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListWorkRequestsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListWorkRequestsResponse wrapper for the ListWorkRequests operation
+type ListWorkRequestsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []WorkRequest instances
+	Items []WorkRequest `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then a partial list might have been returned. Include this value as the `page` parameter for the
+	// subsequent GET request to get the next batch of items.
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListWorkRequestsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListWorkRequestsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/oce/oce_instance.go
+++ b/oce/oce_instance.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// OceInstance API
+//
+// Oracle Content and Experience is a cloud-based content hub to drive omni-channel content management and accelerate experience delivery
+//
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// OceInstance Details of OceInstance.
+type OceInstance struct {
+
+	// Unique identifier that is immutable on creation
+	Id *string `mandatory:"true" json:"id"`
+
+	// Unique GUID identifier that is immutable on creation
+	Guid *string `mandatory:"true" json:"guid"`
+
+	// Compartment Identifier
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// OceInstance Name
+	Name *string `mandatory:"true" json:"name"`
+
+	// Tenancy Identifier
+	TenancyId *string `mandatory:"true" json:"tenancyId"`
+
+	// IDCS Tenancy Identifier
+	IdcsTenancy *string `mandatory:"true" json:"idcsTenancy"`
+
+	// Tenancy Name
+	TenancyName *string `mandatory:"true" json:"tenancyName"`
+
+	// Object Storage Namespace of tenancy
+	ObjectStorageNamespace *string `mandatory:"true" json:"objectStorageNamespace"`
+
+	// Admin Email for Notification
+	AdminEmail *string `mandatory:"true" json:"adminEmail"`
+
+	// OceInstance description, can be updated
+	Description *string `mandatory:"false" json:"description"`
+
+	// The time the the OceInstance was created. An RFC3339 formatted datetime string
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The time the OceInstance was updated. An RFC3339 formatted datetime string
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// The current state of the file system.
+	LifecycleState OceInstanceLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// An message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+	StateMessage *string `mandatory:"false" json:"stateMessage"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// SERVICE data.
+	// Example: `{"service": {"IDCS": "value"}}`
+	Service map[string]interface{} `mandatory:"false" json:"service"`
+}
+
+func (m OceInstance) String() string {
+	return common.PointerString(m)
+}
+
+// OceInstanceLifecycleStateEnum Enum with underlying type: string
+type OceInstanceLifecycleStateEnum string
+
+// Set of constants representing the allowable values for OceInstanceLifecycleStateEnum
+const (
+	OceInstanceLifecycleStateCreating OceInstanceLifecycleStateEnum = "CREATING"
+	OceInstanceLifecycleStateUpdating OceInstanceLifecycleStateEnum = "UPDATING"
+	OceInstanceLifecycleStateActive   OceInstanceLifecycleStateEnum = "ACTIVE"
+	OceInstanceLifecycleStateDeleting OceInstanceLifecycleStateEnum = "DELETING"
+	OceInstanceLifecycleStateDeleted  OceInstanceLifecycleStateEnum = "DELETED"
+	OceInstanceLifecycleStateFailed   OceInstanceLifecycleStateEnum = "FAILED"
+)
+
+var mappingOceInstanceLifecycleState = map[string]OceInstanceLifecycleStateEnum{
+	"CREATING": OceInstanceLifecycleStateCreating,
+	"UPDATING": OceInstanceLifecycleStateUpdating,
+	"ACTIVE":   OceInstanceLifecycleStateActive,
+	"DELETING": OceInstanceLifecycleStateDeleting,
+	"DELETED":  OceInstanceLifecycleStateDeleted,
+	"FAILED":   OceInstanceLifecycleStateFailed,
+}
+
+// GetOceInstanceLifecycleStateEnumValues Enumerates the set of values for OceInstanceLifecycleStateEnum
+func GetOceInstanceLifecycleStateEnumValues() []OceInstanceLifecycleStateEnum {
+	values := make([]OceInstanceLifecycleStateEnum, 0)
+	for _, v := range mappingOceInstanceLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}

--- a/oce/oce_instance_summary.go
+++ b/oce/oce_instance_summary.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// OceInstance API
+//
+// Oracle Content and Experience is a cloud-based content hub to drive omni-channel content management and accelerate experience delivery
+//
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// OceInstanceSummary Summary of the OceInstance.
+type OceInstanceSummary struct {
+
+	// Unique identifier that is immutable on creation
+	Id *string `mandatory:"true" json:"id"`
+
+	// Unique GUID identifier that is immutable on creation
+	Guid *string `mandatory:"true" json:"guid"`
+
+	// Compartment Identifier
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// OceInstance Name
+	Name *string `mandatory:"true" json:"name"`
+
+	// Tenancy Identifier
+	TenancyId *string `mandatory:"true" json:"tenancyId"`
+
+	// IDCS Tenancy Identifier
+	IdcsTenancy *string `mandatory:"true" json:"idcsTenancy"`
+
+	// Tenancy Name
+	TenancyName *string `mandatory:"true" json:"tenancyName"`
+
+	// Object Storage Namespace of tenancy
+	ObjectStorageNamespace *string `mandatory:"true" json:"objectStorageNamespace"`
+
+	// Admin Email for Notification
+	AdminEmail *string `mandatory:"true" json:"adminEmail"`
+
+	// OceInstance description, can be updated
+	Description *string `mandatory:"false" json:"description"`
+
+	// The time the the OceInstance was created. An RFC3339 formatted datetime string
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The time the OceInstance was updated. An RFC3339 formatted datetime string
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// The current state of the file system.
+	LifecycleState OceInstanceSummaryLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// An message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+	StateMessage *string `mandatory:"false" json:"stateMessage"`
+
+	// SERVICE data.
+	// Example: `{"service": {"IDCS": "value"}}`
+	Service map[string]interface{} `mandatory:"false" json:"service"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m OceInstanceSummary) String() string {
+	return common.PointerString(m)
+}
+
+// OceInstanceSummaryLifecycleStateEnum Enum with underlying type: string
+type OceInstanceSummaryLifecycleStateEnum string
+
+// Set of constants representing the allowable values for OceInstanceSummaryLifecycleStateEnum
+const (
+	OceInstanceSummaryLifecycleStateCreating OceInstanceSummaryLifecycleStateEnum = "CREATING"
+	OceInstanceSummaryLifecycleStateUpdating OceInstanceSummaryLifecycleStateEnum = "UPDATING"
+	OceInstanceSummaryLifecycleStateActive   OceInstanceSummaryLifecycleStateEnum = "ACTIVE"
+	OceInstanceSummaryLifecycleStateDeleting OceInstanceSummaryLifecycleStateEnum = "DELETING"
+	OceInstanceSummaryLifecycleStateDeleted  OceInstanceSummaryLifecycleStateEnum = "DELETED"
+	OceInstanceSummaryLifecycleStateFailed   OceInstanceSummaryLifecycleStateEnum = "FAILED"
+)
+
+var mappingOceInstanceSummaryLifecycleState = map[string]OceInstanceSummaryLifecycleStateEnum{
+	"CREATING": OceInstanceSummaryLifecycleStateCreating,
+	"UPDATING": OceInstanceSummaryLifecycleStateUpdating,
+	"ACTIVE":   OceInstanceSummaryLifecycleStateActive,
+	"DELETING": OceInstanceSummaryLifecycleStateDeleting,
+	"DELETED":  OceInstanceSummaryLifecycleStateDeleted,
+	"FAILED":   OceInstanceSummaryLifecycleStateFailed,
+}
+
+// GetOceInstanceSummaryLifecycleStateEnumValues Enumerates the set of values for OceInstanceSummaryLifecycleStateEnum
+func GetOceInstanceSummaryLifecycleStateEnumValues() []OceInstanceSummaryLifecycleStateEnum {
+	values := make([]OceInstanceSummaryLifecycleStateEnum, 0)
+	for _, v := range mappingOceInstanceSummaryLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}

--- a/oce/oce_oceinstance_client.go
+++ b/oce/oce_oceinstance_client.go
@@ -1,0 +1,489 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// OceInstance API
+//
+// Oracle Content and Experience is a cloud-based content hub to drive omni-channel content management and accelerate experience delivery
+//
+
+package oce
+
+import (
+	"context"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+//OceInstanceClient a client for OceInstance
+type OceInstanceClient struct {
+	common.BaseClient
+	config *common.ConfigurationProvider
+}
+
+// NewOceInstanceClientWithConfigurationProvider Creates a new default OceInstance client with the given configuration provider.
+// the configuration provider will be used for the default signer as well as reading the region
+func NewOceInstanceClientWithConfigurationProvider(configProvider common.ConfigurationProvider) (client OceInstanceClient, err error) {
+	baseClient, err := common.NewClientWithConfig(configProvider)
+	if err != nil {
+		return
+	}
+
+	client = OceInstanceClient{BaseClient: baseClient}
+	client.BasePath = "20190912"
+	err = client.setConfigurationProvider(configProvider)
+	return
+}
+
+// SetRegion overrides the region of this client.
+func (client *OceInstanceClient) SetRegion(region string) {
+	client.Host = common.StringToRegion(region).EndpointForTemplate("oce", "https://cp.oce.{region}.ocp.{secondLevelDomain}")
+}
+
+// SetConfigurationProvider sets the configuration provider including the region, returns an error if is not valid
+func (client *OceInstanceClient) setConfigurationProvider(configProvider common.ConfigurationProvider) error {
+	if ok, err := common.IsConfigurationProviderValid(configProvider); !ok {
+		return err
+	}
+
+	// Error has been checked already
+	region, _ := configProvider.Region()
+	client.SetRegion(region)
+	client.config = &configProvider
+	return nil
+}
+
+// ConfigurationProvider the ConfigurationProvider used in this client, or null if none set
+func (client *OceInstanceClient) ConfigurationProvider() *common.ConfigurationProvider {
+	return client.config
+}
+
+// ChangeOceInstanceCompartment Moves a OceInstance into a different compartment
+func (client OceInstanceClient) ChangeOceInstanceCompartment(ctx context.Context, request ChangeOceInstanceCompartmentRequest) (response ChangeOceInstanceCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.changeOceInstanceCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ChangeOceInstanceCompartmentResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeOceInstanceCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeOceInstanceCompartmentResponse")
+	}
+	return
+}
+
+// changeOceInstanceCompartment implements the OCIOperation interface (enables retrying operations)
+func (client OceInstanceClient) changeOceInstanceCompartment(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/oceInstances/{oceInstanceId}/actions/changeCompartment")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeOceInstanceCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateOceInstance Creates a new OceInstance.
+func (client OceInstanceClient) CreateOceInstance(ctx context.Context, request CreateOceInstanceRequest) (response CreateOceInstanceResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createOceInstance, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = CreateOceInstanceResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateOceInstanceResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateOceInstanceResponse")
+	}
+	return
+}
+
+// createOceInstance implements the OCIOperation interface (enables retrying operations)
+func (client OceInstanceClient) createOceInstance(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/oceInstances")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateOceInstanceResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteOceInstance Deletes a OceInstance resource by identifier
+func (client OceInstanceClient) DeleteOceInstance(ctx context.Context, request DeleteOceInstanceRequest) (response DeleteOceInstanceResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteOceInstance, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = DeleteOceInstanceResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteOceInstanceResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteOceInstanceResponse")
+	}
+	return
+}
+
+// deleteOceInstance implements the OCIOperation interface (enables retrying operations)
+func (client OceInstanceClient) deleteOceInstance(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/oceInstances/{oceInstanceId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteOceInstanceResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetOceInstance Gets a OceInstance by identifier
+func (client OceInstanceClient) GetOceInstance(ctx context.Context, request GetOceInstanceRequest) (response GetOceInstanceResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getOceInstance, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = GetOceInstanceResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetOceInstanceResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetOceInstanceResponse")
+	}
+	return
+}
+
+// getOceInstance implements the OCIOperation interface (enables retrying operations)
+func (client OceInstanceClient) getOceInstance(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/oceInstances/{oceInstanceId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetOceInstanceResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetWorkRequest Gets the status of the work request with the given ID.
+func (client OceInstanceClient) GetWorkRequest(ctx context.Context, request GetWorkRequestRequest) (response GetWorkRequestResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getWorkRequest, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = GetWorkRequestResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetWorkRequestResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetWorkRequestResponse")
+	}
+	return
+}
+
+// getWorkRequest implements the OCIOperation interface (enables retrying operations)
+func (client OceInstanceClient) getWorkRequest(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests/{workRequestId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetWorkRequestResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListOceInstances Returns a list of OceInstances.
+func (client OceInstanceClient) ListOceInstances(ctx context.Context, request ListOceInstancesRequest) (response ListOceInstancesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listOceInstances, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ListOceInstancesResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListOceInstancesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListOceInstancesResponse")
+	}
+	return
+}
+
+// listOceInstances implements the OCIOperation interface (enables retrying operations)
+func (client OceInstanceClient) listOceInstances(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/oceInstances")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListOceInstancesResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListWorkRequestErrors Return a (paginated) list of errors for a given work request.
+func (client OceInstanceClient) ListWorkRequestErrors(ctx context.Context, request ListWorkRequestErrorsRequest) (response ListWorkRequestErrorsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listWorkRequestErrors, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ListWorkRequestErrorsResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListWorkRequestErrorsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListWorkRequestErrorsResponse")
+	}
+	return
+}
+
+// listWorkRequestErrors implements the OCIOperation interface (enables retrying operations)
+func (client OceInstanceClient) listWorkRequestErrors(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests/{workRequestId}/errors")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListWorkRequestErrorsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListWorkRequestLogs Return a (paginated) list of logs for a given work request.
+func (client OceInstanceClient) ListWorkRequestLogs(ctx context.Context, request ListWorkRequestLogsRequest) (response ListWorkRequestLogsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listWorkRequestLogs, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ListWorkRequestLogsResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListWorkRequestLogsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListWorkRequestLogsResponse")
+	}
+	return
+}
+
+// listWorkRequestLogs implements the OCIOperation interface (enables retrying operations)
+func (client OceInstanceClient) listWorkRequestLogs(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests/{workRequestId}/logs")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListWorkRequestLogsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListWorkRequests Lists the work requests in a compartment.
+func (client OceInstanceClient) ListWorkRequests(ctx context.Context, request ListWorkRequestsRequest) (response ListWorkRequestsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listWorkRequests, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ListWorkRequestsResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListWorkRequestsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListWorkRequestsResponse")
+	}
+	return
+}
+
+// listWorkRequests implements the OCIOperation interface (enables retrying operations)
+func (client OceInstanceClient) listWorkRequests(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListWorkRequestsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateOceInstance Updates the OceInstance
+func (client OceInstanceClient) UpdateOceInstance(ctx context.Context, request UpdateOceInstanceRequest) (response UpdateOceInstanceResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateOceInstance, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = UpdateOceInstanceResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateOceInstanceResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateOceInstanceResponse")
+	}
+	return
+}
+
+// updateOceInstance implements the OCIOperation interface (enables retrying operations)
+func (client OceInstanceClient) updateOceInstance(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/oceInstances/{oceInstanceId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateOceInstanceResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}

--- a/oce/update_oce_instance_details.go
+++ b/oce/update_oce_instance_details.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// OceInstance API
+//
+// Oracle Content and Experience is a cloud-based content hub to drive omni-channel content management and accelerate experience delivery
+//
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateOceInstanceDetails The information to be updated.
+type UpdateOceInstanceDetails struct {
+
+	// OceInstance description
+	Description *string `mandatory:"false" json:"description"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m UpdateOceInstanceDetails) String() string {
+	return common.PointerString(m)
+}

--- a/oce/update_oce_instance_request_response.go
+++ b/oce/update_oce_instance_request_response.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateOceInstanceRequest wrapper for the UpdateOceInstance operation
+type UpdateOceInstanceRequest struct {
+
+	// unique OceInstance identifier
+	OceInstanceId *string `mandatory:"true" contributesTo:"path" name:"oceInstanceId"`
+
+	// The information to be updated.
+	UpdateOceInstanceDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call
+	// for a resource, set the `if-match` parameter to the value of the
+	// etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you
+	// provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateOceInstanceRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateOceInstanceRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateOceInstanceRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateOceInstanceResponse wrapper for the UpdateOceInstance operation
+type UpdateOceInstanceResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateOceInstanceResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateOceInstanceResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/oce/work_request.go
+++ b/oce/work_request.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// OceInstance API
+//
+// Oracle Content and Experience is a cloud-based content hub to drive omni-channel content management and accelerate experience delivery
+//
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// WorkRequest A description of workrequest status
+type WorkRequest struct {
+
+	// type of the work request
+	OperationType WorkRequestOperationTypeEnum `mandatory:"true" json:"operationType"`
+
+	// status of current work request.
+	Status WorkRequestStatusEnum `mandatory:"true" json:"status"`
+
+	// The id of the work request.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The ocid of the compartment that contains the work request. Work requests should be scoped to
+	// the same compartment as the resource the work request affects. If the work request affects multiple resources,
+	// and those resources are not in the same compartment, it is up to the service team to pick the primary
+	// resource whose compartment should be used
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The resources affected by this work request.
+	Resources []WorkRequestResource `mandatory:"true" json:"resources"`
+
+	// Percentage of the request completed.
+	PercentComplete *float32 `mandatory:"true" json:"percentComplete"`
+
+	// The date and time the request was created, as described in
+	// RFC 3339 (https://tools.ietf.org/rfc/rfc3339), section 14.29.
+	TimeAccepted *common.SDKTime `mandatory:"true" json:"timeAccepted"`
+
+	WorkflowMonitor *WorkflowMonitor `mandatory:"false" json:"workflowMonitor"`
+
+	// The date and time the request was started, as described in RFC 3339 (https://tools.ietf.org/rfc/rfc3339),
+	// section 14.29.
+	TimeStarted *common.SDKTime `mandatory:"false" json:"timeStarted"`
+
+	// The date and time the object was finished, as described in RFC 3339 (https://tools.ietf.org/rfc/rfc3339).
+	TimeFinished *common.SDKTime `mandatory:"false" json:"timeFinished"`
+}
+
+func (m WorkRequest) String() string {
+	return common.PointerString(m)
+}
+
+// WorkRequestOperationTypeEnum Enum with underlying type: string
+type WorkRequestOperationTypeEnum string
+
+// Set of constants representing the allowable values for WorkRequestOperationTypeEnum
+const (
+	WorkRequestOperationTypeCreateOceInstance WorkRequestOperationTypeEnum = "CREATE_OCE_INSTANCE"
+	WorkRequestOperationTypeUpdateOceInstance WorkRequestOperationTypeEnum = "UPDATE_OCE_INSTANCE"
+	WorkRequestOperationTypeDeleteOceInstance WorkRequestOperationTypeEnum = "DELETE_OCE_INSTANCE"
+)
+
+var mappingWorkRequestOperationType = map[string]WorkRequestOperationTypeEnum{
+	"CREATE_OCE_INSTANCE": WorkRequestOperationTypeCreateOceInstance,
+	"UPDATE_OCE_INSTANCE": WorkRequestOperationTypeUpdateOceInstance,
+	"DELETE_OCE_INSTANCE": WorkRequestOperationTypeDeleteOceInstance,
+}
+
+// GetWorkRequestOperationTypeEnumValues Enumerates the set of values for WorkRequestOperationTypeEnum
+func GetWorkRequestOperationTypeEnumValues() []WorkRequestOperationTypeEnum {
+	values := make([]WorkRequestOperationTypeEnum, 0)
+	for _, v := range mappingWorkRequestOperationType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// WorkRequestStatusEnum Enum with underlying type: string
+type WorkRequestStatusEnum string
+
+// Set of constants representing the allowable values for WorkRequestStatusEnum
+const (
+	WorkRequestStatusAccepted   WorkRequestStatusEnum = "ACCEPTED"
+	WorkRequestStatusInProgress WorkRequestStatusEnum = "IN_PROGRESS"
+	WorkRequestStatusFailed     WorkRequestStatusEnum = "FAILED"
+	WorkRequestStatusSucceeded  WorkRequestStatusEnum = "SUCCEEDED"
+	WorkRequestStatusCanceling  WorkRequestStatusEnum = "CANCELING"
+	WorkRequestStatusCanceled   WorkRequestStatusEnum = "CANCELED"
+)
+
+var mappingWorkRequestStatus = map[string]WorkRequestStatusEnum{
+	"ACCEPTED":    WorkRequestStatusAccepted,
+	"IN_PROGRESS": WorkRequestStatusInProgress,
+	"FAILED":      WorkRequestStatusFailed,
+	"SUCCEEDED":   WorkRequestStatusSucceeded,
+	"CANCELING":   WorkRequestStatusCanceling,
+	"CANCELED":    WorkRequestStatusCanceled,
+}
+
+// GetWorkRequestStatusEnumValues Enumerates the set of values for WorkRequestStatusEnum
+func GetWorkRequestStatusEnumValues() []WorkRequestStatusEnum {
+	values := make([]WorkRequestStatusEnum, 0)
+	for _, v := range mappingWorkRequestStatus {
+		values = append(values, v)
+	}
+	return values
+}

--- a/oce/work_request_error.go
+++ b/oce/work_request_error.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// OceInstance API
+//
+// Oracle Content and Experience is a cloud-based content hub to drive omni-channel content management and accelerate experience delivery
+//
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// WorkRequestError An error encountered while executing a work request.
+type WorkRequestError struct {
+
+	// A machine-usable code for the error that occured. Error codes are listed on
+	// (https://docs.cloud.oracle.com/Content/API/References/apierrors.htm)
+	Code *string `mandatory:"true" json:"code"`
+
+	// A human readable description of the issue encountered.
+	Message *string `mandatory:"true" json:"message"`
+
+	// The time the error occured. An RFC3339 formatted datetime string.
+	Timestamp *common.SDKTime `mandatory:"true" json:"timestamp"`
+}
+
+func (m WorkRequestError) String() string {
+	return common.PointerString(m)
+}

--- a/oce/work_request_log_entry.go
+++ b/oce/work_request_log_entry.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// OceInstance API
+//
+// Oracle Content and Experience is a cloud-based content hub to drive omni-channel content management and accelerate experience delivery
+//
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// WorkRequestLogEntry A log message from the execution of a work request.
+type WorkRequestLogEntry struct {
+
+	// Human-readable log message.
+	Message *string `mandatory:"true" json:"message"`
+
+	// The time the log message was written. An RFC3339 formatted datetime string
+	Timestamp *common.SDKTime `mandatory:"true" json:"timestamp"`
+}
+
+func (m WorkRequestLogEntry) String() string {
+	return common.PointerString(m)
+}

--- a/oce/work_request_resource.go
+++ b/oce/work_request_resource.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// OceInstance API
+//
+// Oracle Content and Experience is a cloud-based content hub to drive omni-channel content management and accelerate experience delivery
+//
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// WorkRequestResource A resource created or operated on by a work request.
+type WorkRequestResource struct {
+
+	// The resource type the work request is affects.
+	EntityType *string `mandatory:"true" json:"entityType"`
+
+	// The way in which this resource is affected by the work tracked in the work request.
+	// A resource being created, updated, or deleted will remain in the IN_PROGRESS state until
+	// work is complete for that resource at which point it will transition to CREATED, UPDATED,
+	// or DELETED, respectively.
+	ActionType WorkRequestResourceActionTypeEnum `mandatory:"true" json:"actionType"`
+
+	// The identifier of the resource the work request affects.
+	Identifier *string `mandatory:"true" json:"identifier"`
+
+	// The URI path that the user can do a GET on to access the resource metadata
+	EntityUri *string `mandatory:"false" json:"entityUri"`
+}
+
+func (m WorkRequestResource) String() string {
+	return common.PointerString(m)
+}
+
+// WorkRequestResourceActionTypeEnum Enum with underlying type: string
+type WorkRequestResourceActionTypeEnum string
+
+// Set of constants representing the allowable values for WorkRequestResourceActionTypeEnum
+const (
+	WorkRequestResourceActionTypeCreated    WorkRequestResourceActionTypeEnum = "CREATED"
+	WorkRequestResourceActionTypeUpdated    WorkRequestResourceActionTypeEnum = "UPDATED"
+	WorkRequestResourceActionTypeDeleted    WorkRequestResourceActionTypeEnum = "DELETED"
+	WorkRequestResourceActionTypeInProgress WorkRequestResourceActionTypeEnum = "IN_PROGRESS"
+)
+
+var mappingWorkRequestResourceActionType = map[string]WorkRequestResourceActionTypeEnum{
+	"CREATED":     WorkRequestResourceActionTypeCreated,
+	"UPDATED":     WorkRequestResourceActionTypeUpdated,
+	"DELETED":     WorkRequestResourceActionTypeDeleted,
+	"IN_PROGRESS": WorkRequestResourceActionTypeInProgress,
+}
+
+// GetWorkRequestResourceActionTypeEnumValues Enumerates the set of values for WorkRequestResourceActionTypeEnum
+func GetWorkRequestResourceActionTypeEnumValues() []WorkRequestResourceActionTypeEnum {
+	values := make([]WorkRequestResourceActionTypeEnum, 0)
+	for _, v := range mappingWorkRequestResourceActionType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/oce/workflow_monitor.go
+++ b/oce/workflow_monitor.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// OceInstance API
+//
+// Oracle Content and Experience is a cloud-based content hub to drive omni-channel content management and accelerate experience delivery
+//
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// WorkflowMonitor The workflow monitor for this work request.
+type WorkflowMonitor struct {
+
+	// workflow name for this work request
+	WorkflowName *string `mandatory:"false" json:"workflowName"`
+
+	// resource name for this work request
+	ResourceName *string `mandatory:"false" json:"resourceName"`
+
+	// Workflow step of workflow monitor.
+	WorkflowSteps []WorkflowStep `mandatory:"false" json:"workflowSteps"`
+}
+
+func (m WorkflowMonitor) String() string {
+	return common.PointerString(m)
+}

--- a/oce/workflow_step.go
+++ b/oce/workflow_step.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// OceInstance API
+//
+// Oracle Content and Experience is a cloud-based content hub to drive omni-channel content management and accelerate experience delivery
+//
+
+package oce
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// WorkflowStep Workflow step of workflow monitor.
+type WorkflowStep struct {
+
+	// workflow step name
+	StepName *string `mandatory:"false" json:"stepName"`
+
+	// workflow step status
+	Status *string `mandatory:"false" json:"status"`
+}
+
+func (m WorkflowStep) String() string {
+	return common.PointerString(m)
+}

--- a/ons/backoff_retry_policy.go
+++ b/ons/backoff_retry_policy.go
@@ -13,7 +13,8 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// BackoffRetryPolicy The backoff retry portion of the subscription delivery policy.
+// BackoffRetryPolicy The backoff retry portion of the subscription delivery policy. For information about retry durations for subscriptions, see
+// How Notifications Works (https://docs.cloud.oracle.com/iaas/Content/Notification/Concepts/notificationoverview.htm#how).
 type BackoffRetryPolicy struct {
 
 	// The maximum retry duration in milliseconds. Default value is `7200000` (2 hours).

--- a/ons/change_subscription_compartment_request_response.go
+++ b/ons/change_subscription_compartment_request_response.go
@@ -61,9 +61,6 @@ type ChangeSubscriptionCompartmentResponse struct {
 	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
 	// a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
-
-	// For optimistic concurrency control. See `if-match`.
-	Etag *string `presentIn:"header" name:"etag"`
 }
 
 func (response ChangeSubscriptionCompartmentResponse) String() string {

--- a/ons/change_topic_compartment_request_response.go
+++ b/ons/change_topic_compartment_request_response.go
@@ -61,9 +61,6 @@ type ChangeTopicCompartmentResponse struct {
 	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
 	// a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
-
-	// For optimistic concurrency control. See `if-match`.
-	Etag *string `presentIn:"header" name:"etag"`
 }
 
 func (response ChangeTopicCompartmentResponse) String() string {

--- a/ons/confirmation_result.go
+++ b/ons/confirmation_result.go
@@ -14,6 +14,8 @@ import (
 )
 
 // ConfirmationResult The confirmation details for the specified subscription.
+// For information about confirming subscriptions, see
+// To confirm a subscription (https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#confirmSub).
 type ConfirmationResult struct {
 
 	// The name of the subscribed topic.
@@ -22,8 +24,8 @@ type ConfirmationResult struct {
 	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the topic associated with the specified subscription.
 	TopicId *string `mandatory:"true" json:"topicId"`
 
-	// The endpoint of the subscription. Valid values depend on the protocol.
-	// For EMAIL, only an email address is valid. For HTTPS, only a PagerDuty URL is valid. A URL cannot exceed 512 characters.
+	// A locator that corresponds to the subscription protocol.
+	// For example, an email address for a subscription that uses the `EMAIL` protocol, or a URL for a subscription that uses an HTTP-based protocol.
 	Endpoint *string `mandatory:"true" json:"endpoint"`
 
 	// The URL for unsubscribing from the topic.

--- a/ons/create_subscription_details.go
+++ b/ons/create_subscription_details.go
@@ -22,15 +22,21 @@ type CreateSubscriptionDetails struct {
 	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment for the subscription.
 	CompartmentId *string `mandatory:"true" json:"compartmentId"`
 
-	// The protocol to use for delivering messages. Valid values: EMAIL, HTTPS.
+	// The protocol used for the subscription.
+	// For information about subscription protocols, see
+	// To create a subscription (https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#createSub).
 	Protocol *string `mandatory:"true" json:"protocol"`
 
-	// The endpoint of the subscription. Valid values depend on the protocol.
-	// For EMAIL, only an email address is valid. For HTTPS, only a PagerDuty URL is valid. A URL cannot exceed 512 characters.
+	// A locator that corresponds to the subscription protocol.
+	// For example, an email address for a subscription that uses the `EMAIL` protocol, or a URL for a subscription that uses an HTTP-based protocol.
+	// HTTP-based protocols use URL endpoints that begin with "http:" or "https:".
+	// A URL cannot exceed 512 characters.
 	// Avoid entering confidential information.
+	// For protocol-specific endpoint formats and steps to get or create endpoints, see
+	// To create a subscription (https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#createSub).
 	Endpoint *string `mandatory:"true" json:"endpoint"`
 
-	// Metadata for the subscription. Avoid entering confidential information.
+	// Metadata for the subscription.
 	Metadata *string `mandatory:"false" json:"metadata"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).

--- a/ons/get_confirm_subscription_request_response.go
+++ b/ons/get_confirm_subscription_request_response.go
@@ -17,7 +17,9 @@ type GetConfirmSubscriptionRequest struct {
 	// The subscription confirmation token.
 	Token *string `mandatory:"true" contributesTo:"query" name:"token"`
 
-	// The subscription protocol. Valid values: EMAIL, HTTPS.
+	// The protocol used for the subscription.
+	// For information about subscription protocols, see
+	// To create a subscription (https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#createSub).
 	Protocol *string `mandatory:"true" contributesTo:"query" name:"protocol"`
 
 	// The unique Oracle-assigned identifier for the request. If you need to contact Oracle about a

--- a/ons/get_unsubscription_request_response.go
+++ b/ons/get_unsubscription_request_response.go
@@ -17,7 +17,9 @@ type GetUnsubscriptionRequest struct {
 	// The subscription confirmation token.
 	Token *string `mandatory:"true" contributesTo:"query" name:"token"`
 
-	// The subscription protocol. Valid values: EMAIL, HTTPS.
+	// The protocol used for the subscription.
+	// For information about subscription protocols, see
+	// To create a subscription (https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#createSub).
 	Protocol *string `mandatory:"true" contributesTo:"query" name:"protocol"`
 
 	// The unique Oracle-assigned identifier for the request. If you need to contact Oracle about a

--- a/ons/notification_topic.go
+++ b/ons/notification_topic.go
@@ -13,7 +13,8 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// NotificationTopic The properties that define a topic.
+// NotificationTopic The properties that define a topic. For general information about topics, see
+// Notifications Overview (https://docs.cloud.oracle.com/iaas/Content/Notification/Concepts/notificationoverview.htm).
 type NotificationTopic struct {
 
 	// The name of the topic.

--- a/ons/ons_notificationdataplane_client.go
+++ b/ons/ons_notificationdataplane_client.go
@@ -109,7 +109,9 @@ func (client NotificationDataPlaneClient) changeSubscriptionCompartment(ctx cont
 	return response, err
 }
 
-// CreateSubscription Creates a subscription for the specified topic.
+// CreateSubscription Creates a subscription for the specified topic and sends a subscription confirmation URL to the endpoint. The subscription remains in "Pending" status until it has been confirmed.
+// For information about confirming subscriptions, see
+// To confirm a subscription (https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#confirmSub).
 // Transactions Per Minute (TPM) per-tenancy limit for this operation: 60.
 func (client NotificationDataPlaneClient) CreateSubscription(ctx context.Context, request CreateSubscriptionRequest) (response CreateSubscriptionResponse, err error) {
 	var ociResponse common.OCIResponse
@@ -374,9 +376,11 @@ func (client NotificationDataPlaneClient) listSubscriptions(ctx context.Context,
 
 // PublishMessage Publishes a message to the specified topic. Limits information follows.
 // Message size limit per request: 64KB.
-// Message delivery rate limit per endpoint: 60 messages per minute for HTTPS (PagerDuty) protocol, 10 messages per minute for Email protocol.
+// Message delivery rate limit per endpoint: 60 messages per minute for HTTP-based protocols, 10 messages per minute for the `EMAIL` protocol.
+// HTTP-based protocols use URL endpoints that begin with "http:" or "https:".
 // Transactions Per Minute (TPM) per-tenancy limit for this operation: 60 per topic.
 // For more information about publishing messages, see Publishing Messages (https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/publishingmessages.htm).
+// For steps to request a limit increase, see Requesting a Service Limit Increase (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/servicelimits.htm#three).
 func (client NotificationDataPlaneClient) PublishMessage(ctx context.Context, request PublishMessageRequest) (response PublishMessageResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()

--- a/ons/subscription.go
+++ b/ons/subscription.go
@@ -13,7 +13,8 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// Subscription The subscription's configuration.
+// Subscription The subscription's configuration. For general information about subscriptions, see
+// Notifications Overview (https://docs.cloud.oracle.com/iaas/Content/Notification/Concepts/notificationoverview.htm).
 type Subscription struct {
 
 	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the subscription.
@@ -22,10 +23,13 @@ type Subscription struct {
 	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the associated topic.
 	TopicId *string `mandatory:"true" json:"topicId"`
 
+	// The protocol used for the subscription.
+	// For information about subscription protocols, see
+	// To create a subscription (https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#createSub).
 	Protocol *string `mandatory:"true" json:"protocol"`
 
-	// The endpoint of the subscription. Valid values depend on the protocol.
-	// For EMAIL, only an email address is valid. For HTTPS, only a PagerDuty URL is valid. A URL cannot exceed 512 characters.
+	// A locator that corresponds to the subscription protocol.
+	// For example, an email address for a subscription that uses the `EMAIL` protocol, or a URL for a subscription that uses an HTTP-based protocol.
 	Endpoint *string `mandatory:"true" json:"endpoint"`
 
 	// The lifecycle state of the subscription. The status of a new subscription is PENDING; when confirmed, the subscription status changes to ACTIVE.

--- a/ons/subscription_summary.go
+++ b/ons/subscription_summary.go
@@ -22,11 +22,13 @@ type SubscriptionSummary struct {
 	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the associated topic.
 	TopicId *string `mandatory:"true" json:"topicId"`
 
-	// The protocol used for the subscription. Valid values: EMAIL, HTTPS.
+	// The protocol used for the subscription.
+	// For information about subscription protocols, see
+	// To create a subscription (https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#createSub).
 	Protocol *string `mandatory:"true" json:"protocol"`
 
-	// The endpoint of the subscription. Valid values depend on the protocol.
-	// For EMAIL, only an email address is valid. For HTTPS, only a PagerDuty URL is valid. A URL cannot exceed 512 characters.
+	// A locator that corresponds to the subscription protocol.
+	// For example, an email address for a subscription that uses the `EMAIL` protocol, or a URL for a subscription that uses an HTTP-based protocol.
 	Endpoint *string `mandatory:"true" json:"endpoint"`
 
 	// The lifecycle state of the subscription. The status of a new subscription is PENDING; when confirmed, the subscription status changes to ACTIVE.


### PR DESCRIPTION
### Added

- Support for specifying the autoBackupWindow field for scheduling backups in the Database service

- Support for network security groups on autonomous Exadata infrastructure in the Database service

- Support for Kubernetes secrets encryption in customer clusters, regional subnets, and cluster authentication for instance principals in the Container Engine for Kubernetes service

- Support for the Oracle Content and Experience service



### Breaking

- The etag field has been removed from the ChangeSubscriptionCompartmentResponse and ChangeTopicCompartmentResponse structs of the Notifications service
