### PR TITLE
Releasing version 10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## 10.0.0 - 2019-09-17
+### Added
+- Support for importing state files in the Resource Manager service
+- Support for Exadata Cloud at Customer in the Database service
+- Support for free tier resources and system tags in the Load Balancing service
+- Support for free tier resources and system tags in the Compute service
+- Support for free tier resources and system tags in the Block Storage service
+- Support for free tier and system tags on autonomous databases in the Database service
+
+### Breaking
+- Interface CreateDbHomeWithDbSystemIdBase is renamed to CreateDbHomeBase and dbSystemId property is removed from it
+- CreateDbHomeWithDbSystemIdBase in CreateDbHomeRequest is replaced with CreateDbHomeWithDbSystemIdDetails
+
 ## 9.0.0 - 2019-09-10
 ### Added
 - Support for specifying the autoBackupWindow field for scheduling backups in the Database service

--- a/common/version.go
+++ b/common/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	major = "9"
+	major = "10"
 	minor = "0"
 	patch = "0"
 	tag   = ""

--- a/database/activate_exadata_infrastructure_details.go
+++ b/database/activate_exadata_infrastructure_details.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ActivateExadataInfrastructureDetails The activation details for the Exadata infrastructure.
+type ActivateExadataInfrastructureDetails struct {
+
+	// The activation zip file.
+	ActivationFile []byte `mandatory:"true" json:"activationFile"`
+}
+
+func (m ActivateExadataInfrastructureDetails) String() string {
+	return common.PointerString(m)
+}

--- a/database/activate_exadata_infrastructure_request_response.go
+++ b/database/activate_exadata_infrastructure_request_response.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ActivateExadataInfrastructureRequest wrapper for the ActivateExadataInfrastructure operation
+type ActivateExadataInfrastructureRequest struct {
+
+	// The Exadata infrastructure OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	ExadataInfrastructureId *string `mandatory:"true" contributesTo:"path" name:"exadataInfrastructureId"`
+
+	// The activation details for the Exadata infrastructure.
+	ActivateExadataInfrastructureDetails `contributesTo:"body"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ActivateExadataInfrastructureRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ActivateExadataInfrastructureRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ActivateExadataInfrastructureRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ActivateExadataInfrastructureResponse wrapper for the ActivateExadataInfrastructure operation
+type ActivateExadataInfrastructureResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ExadataInfrastructure instance
+	ExadataInfrastructure `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ActivateExadataInfrastructureResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ActivateExadataInfrastructureResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/associated_database_details.go
+++ b/database/associated_database_details.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// AssociatedDatabaseDetails Databases associated with a backup destination
+type AssociatedDatabaseDetails struct {
+
+	// The database OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	Id *string `mandatory:"false" json:"id"`
+
+	// The display name of the database that is associated with the backup destination.
+	DbName *string `mandatory:"false" json:"dbName"`
+}
+
+func (m AssociatedDatabaseDetails) String() string {
+	return common.PointerString(m)
+}

--- a/database/backup_destination.go
+++ b/database/backup_destination.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// BackupDestination Backup destination details.
+type BackupDestination struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup destination.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The user-provided name of the backup destination.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// Type of the backup destination.
+	Type BackupDestinationTypeEnum `mandatory:"false" json:"type,omitempty"`
+
+	// List of databases associated with the backup destination.
+	AssociatedDatabases []AssociatedDatabaseDetails `mandatory:"false" json:"associatedDatabases"`
+
+	// For a RECOVERY_APPLIANCE backup destination, the connection string for connecting to the Recovery Appliance.
+	ConnectionString *string `mandatory:"false" json:"connectionString"`
+
+	// For a RECOVERY_APPLIANCE backup destination, the Virtual Private Catalog (VPC) users that are used to access the Recovery Appliance.
+	VpcUsers []string `mandatory:"false" json:"vpcUsers"`
+
+	// The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
+	LocalMountPointPath *string `mandatory:"false" json:"localMountPointPath"`
+
+	// The current lifecycle state of the backup destination.
+	LifecycleState BackupDestinationLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// The date and time the backup destination was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// A descriptive text associated with the lifecycleState.
+	// Typically contains additional displayable text
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m BackupDestination) String() string {
+	return common.PointerString(m)
+}
+
+// BackupDestinationTypeEnum Enum with underlying type: string
+type BackupDestinationTypeEnum string
+
+// Set of constants representing the allowable values for BackupDestinationTypeEnum
+const (
+	BackupDestinationTypeNfs               BackupDestinationTypeEnum = "NFS"
+	BackupDestinationTypeRecoveryAppliance BackupDestinationTypeEnum = "RECOVERY_APPLIANCE"
+)
+
+var mappingBackupDestinationType = map[string]BackupDestinationTypeEnum{
+	"NFS":                BackupDestinationTypeNfs,
+	"RECOVERY_APPLIANCE": BackupDestinationTypeRecoveryAppliance,
+}
+
+// GetBackupDestinationTypeEnumValues Enumerates the set of values for BackupDestinationTypeEnum
+func GetBackupDestinationTypeEnumValues() []BackupDestinationTypeEnum {
+	values := make([]BackupDestinationTypeEnum, 0)
+	for _, v := range mappingBackupDestinationType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// BackupDestinationLifecycleStateEnum Enum with underlying type: string
+type BackupDestinationLifecycleStateEnum string
+
+// Set of constants representing the allowable values for BackupDestinationLifecycleStateEnum
+const (
+	BackupDestinationLifecycleStateActive  BackupDestinationLifecycleStateEnum = "ACTIVE"
+	BackupDestinationLifecycleStateFailed  BackupDestinationLifecycleStateEnum = "FAILED"
+	BackupDestinationLifecycleStateDeleted BackupDestinationLifecycleStateEnum = "DELETED"
+)
+
+var mappingBackupDestinationLifecycleState = map[string]BackupDestinationLifecycleStateEnum{
+	"ACTIVE":  BackupDestinationLifecycleStateActive,
+	"FAILED":  BackupDestinationLifecycleStateFailed,
+	"DELETED": BackupDestinationLifecycleStateDeleted,
+}
+
+// GetBackupDestinationLifecycleStateEnumValues Enumerates the set of values for BackupDestinationLifecycleStateEnum
+func GetBackupDestinationLifecycleStateEnumValues() []BackupDestinationLifecycleStateEnum {
+	values := make([]BackupDestinationLifecycleStateEnum, 0)
+	for _, v := range mappingBackupDestinationLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/backup_destination_details.go
+++ b/database/backup_destination_details.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// BackupDestinationDetails Backup destination details
+type BackupDestinationDetails struct {
+
+	// Type of the database backup destination.
+	Type BackupDestinationDetailsTypeEnum `mandatory:"true" json:"type"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup destination.
+	Id *string `mandatory:"false" json:"id"`
+
+	// For a RECOVERY_APPLIANCE backup destination, the Virtual Private Catalog (VPC) user that is used to access the Recovery Appliance.
+	VpcUser *string `mandatory:"false" json:"vpcUser"`
+
+	// For a RECOVERY_APPLIANCE backup destination, the password for the VPC user that is used to access the Recovery Appliance.
+	VpcPassword *string `mandatory:"false" json:"vpcPassword"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m BackupDestinationDetails) String() string {
+	return common.PointerString(m)
+}
+
+// BackupDestinationDetailsTypeEnum Enum with underlying type: string
+type BackupDestinationDetailsTypeEnum string
+
+// Set of constants representing the allowable values for BackupDestinationDetailsTypeEnum
+const (
+	BackupDestinationDetailsTypeNfs               BackupDestinationDetailsTypeEnum = "NFS"
+	BackupDestinationDetailsTypeRecoveryAppliance BackupDestinationDetailsTypeEnum = "RECOVERY_APPLIANCE"
+	BackupDestinationDetailsTypeObjectStore       BackupDestinationDetailsTypeEnum = "OBJECT_STORE"
+	BackupDestinationDetailsTypeLocal             BackupDestinationDetailsTypeEnum = "LOCAL"
+)
+
+var mappingBackupDestinationDetailsType = map[string]BackupDestinationDetailsTypeEnum{
+	"NFS":                BackupDestinationDetailsTypeNfs,
+	"RECOVERY_APPLIANCE": BackupDestinationDetailsTypeRecoveryAppliance,
+	"OBJECT_STORE":       BackupDestinationDetailsTypeObjectStore,
+	"LOCAL":              BackupDestinationDetailsTypeLocal,
+}
+
+// GetBackupDestinationDetailsTypeEnumValues Enumerates the set of values for BackupDestinationDetailsTypeEnum
+func GetBackupDestinationDetailsTypeEnumValues() []BackupDestinationDetailsTypeEnum {
+	values := make([]BackupDestinationDetailsTypeEnum, 0)
+	for _, v := range mappingBackupDestinationDetailsType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/backup_destination_summary.go
+++ b/database/backup_destination_summary.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// BackupDestinationSummary Backup destination details, including the list of databases using the backup destination.
+type BackupDestinationSummary struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup destination.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The user-provided name of the backup destination.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// Type of the backup destination.
+	Type BackupDestinationSummaryTypeEnum `mandatory:"false" json:"type,omitempty"`
+
+	// List of databases associated with the backup destination.
+	AssociatedDatabases []AssociatedDatabaseDetails `mandatory:"false" json:"associatedDatabases"`
+
+	// For a RECOVERY_APPLIANCE backup destination, the connection string for connecting to the Recovery Appliance.
+	ConnectionString *string `mandatory:"false" json:"connectionString"`
+
+	// For a RECOVERY_APPLIANCE backup destination, the Virtual Private Catalog (VPC) users that are used to access the Recovery Appliance.
+	VpcUsers []string `mandatory:"false" json:"vpcUsers"`
+
+	// The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
+	LocalMountPointPath *string `mandatory:"false" json:"localMountPointPath"`
+
+	// The current lifecycle state of the backup destination.
+	LifecycleState BackupDestinationSummaryLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// The date and time the backup destination was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// A descriptive text associated with the lifecycleState.
+	// Typically contains additional displayable text
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m BackupDestinationSummary) String() string {
+	return common.PointerString(m)
+}
+
+// BackupDestinationSummaryTypeEnum Enum with underlying type: string
+type BackupDestinationSummaryTypeEnum string
+
+// Set of constants representing the allowable values for BackupDestinationSummaryTypeEnum
+const (
+	BackupDestinationSummaryTypeNfs               BackupDestinationSummaryTypeEnum = "NFS"
+	BackupDestinationSummaryTypeRecoveryAppliance BackupDestinationSummaryTypeEnum = "RECOVERY_APPLIANCE"
+)
+
+var mappingBackupDestinationSummaryType = map[string]BackupDestinationSummaryTypeEnum{
+	"NFS":                BackupDestinationSummaryTypeNfs,
+	"RECOVERY_APPLIANCE": BackupDestinationSummaryTypeRecoveryAppliance,
+}
+
+// GetBackupDestinationSummaryTypeEnumValues Enumerates the set of values for BackupDestinationSummaryTypeEnum
+func GetBackupDestinationSummaryTypeEnumValues() []BackupDestinationSummaryTypeEnum {
+	values := make([]BackupDestinationSummaryTypeEnum, 0)
+	for _, v := range mappingBackupDestinationSummaryType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// BackupDestinationSummaryLifecycleStateEnum Enum with underlying type: string
+type BackupDestinationSummaryLifecycleStateEnum string
+
+// Set of constants representing the allowable values for BackupDestinationSummaryLifecycleStateEnum
+const (
+	BackupDestinationSummaryLifecycleStateActive  BackupDestinationSummaryLifecycleStateEnum = "ACTIVE"
+	BackupDestinationSummaryLifecycleStateFailed  BackupDestinationSummaryLifecycleStateEnum = "FAILED"
+	BackupDestinationSummaryLifecycleStateDeleted BackupDestinationSummaryLifecycleStateEnum = "DELETED"
+)
+
+var mappingBackupDestinationSummaryLifecycleState = map[string]BackupDestinationSummaryLifecycleStateEnum{
+	"ACTIVE":  BackupDestinationSummaryLifecycleStateActive,
+	"FAILED":  BackupDestinationSummaryLifecycleStateFailed,
+	"DELETED": BackupDestinationSummaryLifecycleStateDeleted,
+}
+
+// GetBackupDestinationSummaryLifecycleStateEnumValues Enumerates the set of values for BackupDestinationSummaryLifecycleStateEnum
+func GetBackupDestinationSummaryLifecycleStateEnumValues() []BackupDestinationSummaryLifecycleStateEnum {
+	values := make([]BackupDestinationSummaryLifecycleStateEnum, 0)
+	for _, v := range mappingBackupDestinationSummaryLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/change_backup_destination_compartment_request_response.go
+++ b/database/change_backup_destination_compartment_request_response.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ChangeBackupDestinationCompartmentRequest wrapper for the ChangeBackupDestinationCompartment operation
+type ChangeBackupDestinationCompartmentRequest struct {
+
+	// Request to move backup destination to a different compartment
+	ChangeCompartmentDetails `contributesTo:"body"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup destination.
+	BackupDestinationId *string `mandatory:"true" contributesTo:"path" name:"backupDestinationId"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ChangeBackupDestinationCompartmentRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ChangeBackupDestinationCompartmentRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ChangeBackupDestinationCompartmentRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ChangeBackupDestinationCompartmentResponse wrapper for the ChangeBackupDestinationCompartment operation
+type ChangeBackupDestinationCompartmentResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier of the work request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ChangeBackupDestinationCompartmentResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ChangeBackupDestinationCompartmentResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/change_exadata_infrastructure_compartment_details.go
+++ b/database/change_exadata_infrastructure_compartment_details.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ChangeExadataInfrastructureCompartmentDetails The configuration details for moving the resource.
+type ChangeExadataInfrastructureCompartmentDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the resource to.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+}
+
+func (m ChangeExadataInfrastructureCompartmentDetails) String() string {
+	return common.PointerString(m)
+}

--- a/database/change_exadata_infrastructure_compartment_request_response.go
+++ b/database/change_exadata_infrastructure_compartment_request_response.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ChangeExadataInfrastructureCompartmentRequest wrapper for the ChangeExadataInfrastructureCompartment operation
+type ChangeExadataInfrastructureCompartmentRequest struct {
+
+	// Request to move Exadata infrastructure to a different compartment
+	ChangeExadataInfrastructureCompartmentDetails `contributesTo:"body"`
+
+	// The Exadata infrastructure OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	ExadataInfrastructureId *string `mandatory:"true" contributesTo:"path" name:"exadataInfrastructureId"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ChangeExadataInfrastructureCompartmentRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ChangeExadataInfrastructureCompartmentRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ChangeExadataInfrastructureCompartmentRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ChangeExadataInfrastructureCompartmentResponse wrapper for the ChangeExadataInfrastructureCompartment operation
+type ChangeExadataInfrastructureCompartmentResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier of the work request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ChangeExadataInfrastructureCompartmentResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ChangeExadataInfrastructureCompartmentResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/change_vm_cluster_compartment_details.go
+++ b/database/change_vm_cluster_compartment_details.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ChangeVmClusterCompartmentDetails The configuration details for moving the VM cluster.
+type ChangeVmClusterCompartmentDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the VM cluster to.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+}
+
+func (m ChangeVmClusterCompartmentDetails) String() string {
+	return common.PointerString(m)
+}

--- a/database/change_vm_cluster_compartment_request_response.go
+++ b/database/change_vm_cluster_compartment_request_response.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ChangeVmClusterCompartmentRequest wrapper for the ChangeVmClusterCompartment operation
+type ChangeVmClusterCompartmentRequest struct {
+
+	// Request to move VM cluster to a different compartment
+	ChangeVmClusterCompartmentDetails `contributesTo:"body"`
+
+	// The VM cluster OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	VmClusterId *string `mandatory:"true" contributesTo:"path" name:"vmClusterId"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ChangeVmClusterCompartmentRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ChangeVmClusterCompartmentRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ChangeVmClusterCompartmentRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ChangeVmClusterCompartmentResponse wrapper for the ChangeVmClusterCompartment operation
+type ChangeVmClusterCompartmentResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier of the work request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ChangeVmClusterCompartmentResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ChangeVmClusterCompartmentResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/create_backup_destination_details.go
+++ b/database/create_backup_destination_details.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateBackupDestinationDetails Details for creating a backup destination.
+type CreateBackupDestinationDetails interface {
+
+	// The user-provided name of the backup destination.
+	GetDisplayName() *string
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	GetCompartmentId() *string
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	GetFreeformTags() map[string]string
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	GetDefinedTags() map[string]map[string]interface{}
+}
+
+type createbackupdestinationdetails struct {
+	JsonData      []byte
+	DisplayName   *string                           `mandatory:"true" json:"displayName"`
+	CompartmentId *string                           `mandatory:"true" json:"compartmentId"`
+	FreeformTags  map[string]string                 `mandatory:"false" json:"freeformTags"`
+	DefinedTags   map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+	Type          string                            `json:"type"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *createbackupdestinationdetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalercreatebackupdestinationdetails createbackupdestinationdetails
+	s := struct {
+		Model Unmarshalercreatebackupdestinationdetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.DisplayName = s.Model.DisplayName
+	m.CompartmentId = s.Model.CompartmentId
+	m.FreeformTags = s.Model.FreeformTags
+	m.DefinedTags = s.Model.DefinedTags
+	m.Type = s.Model.Type
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *createbackupdestinationdetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.Type {
+	case "NFS":
+		mm := CreateNfsBackupDestinationDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "RECOVERY_APPLIANCE":
+		mm := CreateRecoveryApplianceBackupDestinationDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetDisplayName returns DisplayName
+func (m createbackupdestinationdetails) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetCompartmentId returns CompartmentId
+func (m createbackupdestinationdetails) GetCompartmentId() *string {
+	return m.CompartmentId
+}
+
+//GetFreeformTags returns FreeformTags
+func (m createbackupdestinationdetails) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m createbackupdestinationdetails) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+func (m createbackupdestinationdetails) String() string {
+	return common.PointerString(m)
+}

--- a/database/create_backup_destination_request_response.go
+++ b/database/create_backup_destination_request_response.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateBackupDestinationRequest wrapper for the CreateBackupDestination operation
+type CreateBackupDestinationRequest struct {
+
+	// Request to create a new backup destination.
+	CreateBackupDestinationDetails `contributesTo:"body"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateBackupDestinationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateBackupDestinationRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateBackupDestinationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateBackupDestinationResponse wrapper for the CreateBackupDestination operation
+type CreateBackupDestinationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The BackupDestination instance
+	BackupDestination `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateBackupDestinationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateBackupDestinationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/create_database_details.go
+++ b/database/create_database_details.go
@@ -22,6 +22,9 @@ type CreateDatabaseDetails struct {
 	// A strong password for SYS, SYSTEM, and PDB Admin. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numbers, and two special characters. The special characters must be _, \#, or -.
 	AdminPassword *string `mandatory:"true" json:"adminPassword"`
 
+	// The `DB_UNIQUE_NAME` of the Oracle Database being backed up.
+	DbUniqueName *string `mandatory:"false" json:"dbUniqueName"`
+
 	// The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
 	PdbName *string `mandatory:"false" json:"pdbName"`
 

--- a/database/create_database_from_backup_details.go
+++ b/database/create_database_from_backup_details.go
@@ -24,6 +24,9 @@ type CreateDatabaseFromBackupDetails struct {
 	// A strong password for SYS, SYSTEM, PDB Admin and TDE Wallet. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numbers, and two special characters. The special characters must be _, \#, or -.
 	AdminPassword *string `mandatory:"true" json:"adminPassword"`
 
+	// The `DB_UNIQUE_NAME` of the Oracle Database being backed up.
+	DbUniqueName *string `mandatory:"false" json:"dbUniqueName"`
+
 	// The display name of the database to be created from the backup. It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted.
 	DbName *string `mandatory:"false" json:"dbName"`
 }

--- a/database/create_db_home_base.go
+++ b/database/create_db_home_base.go
@@ -13,36 +13,31 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// CreateDbHomeWithDbSystemIdBase Details for creating a database home.
+// CreateDbHomeBase Details for creating a database home.
 // **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
-type CreateDbHomeWithDbSystemIdBase interface {
-
-	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the DB system.
-	GetDbSystemId() *string
+type CreateDbHomeBase interface {
 
 	// The user-provided name of the database home.
 	GetDisplayName() *string
 }
 
-type createdbhomewithdbsystemidbase struct {
+type createdbhomebase struct {
 	JsonData    []byte
-	DbSystemId  *string `mandatory:"true" json:"dbSystemId"`
 	DisplayName *string `mandatory:"false" json:"displayName"`
 	Source      string  `json:"source"`
 }
 
 // UnmarshalJSON unmarshals json
-func (m *createdbhomewithdbsystemidbase) UnmarshalJSON(data []byte) error {
+func (m *createdbhomebase) UnmarshalJSON(data []byte) error {
 	m.JsonData = data
-	type Unmarshalercreatedbhomewithdbsystemidbase createdbhomewithdbsystemidbase
+	type Unmarshalercreatedbhomebase createdbhomebase
 	s := struct {
-		Model Unmarshalercreatedbhomewithdbsystemidbase
+		Model Unmarshalercreatedbhomebase
 	}{}
 	err := json.Unmarshal(data, &s.Model)
 	if err != nil {
 		return err
 	}
-	m.DbSystemId = s.Model.DbSystemId
 	m.DisplayName = s.Model.DisplayName
 	m.Source = s.Model.Source
 
@@ -50,7 +45,7 @@ func (m *createdbhomewithdbsystemidbase) UnmarshalJSON(data []byte) error {
 }
 
 // UnmarshalPolymorphicJSON unmarshals polymorphic json
-func (m *createdbhomewithdbsystemidbase) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+func (m *createdbhomebase) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
 
 	if data == nil || string(data) == "null" {
 		return nil, nil
@@ -62,8 +57,16 @@ func (m *createdbhomewithdbsystemidbase) UnmarshalPolymorphicJSON(data []byte) (
 		mm := CreateDbHomeWithDbSystemIdFromBackupDetails{}
 		err = json.Unmarshal(data, &mm)
 		return mm, err
+	case "VM_CLUSTER_BACKUP":
+		mm := CreateDbHomeWithVmClusterIdFromBackupDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
 	case "NONE":
 		mm := CreateDbHomeWithDbSystemIdDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "VM_CLUSTER_NEW":
+		mm := CreateDbHomeWithVmClusterIdDetails{}
 		err = json.Unmarshal(data, &mm)
 		return mm, err
 	default:
@@ -71,16 +74,11 @@ func (m *createdbhomewithdbsystemidbase) UnmarshalPolymorphicJSON(data []byte) (
 	}
 }
 
-//GetDbSystemId returns DbSystemId
-func (m createdbhomewithdbsystemidbase) GetDbSystemId() *string {
-	return m.DbSystemId
-}
-
 //GetDisplayName returns DisplayName
-func (m createdbhomewithdbsystemidbase) GetDisplayName() *string {
+func (m createdbhomebase) GetDisplayName() *string {
 	return m.DisplayName
 }
 
-func (m createdbhomewithdbsystemidbase) String() string {
+func (m createdbhomebase) String() string {
 	return common.PointerString(m)
 }

--- a/database/create_db_home_request_response.go
+++ b/database/create_db_home_request_response.go
@@ -12,7 +12,7 @@ import (
 type CreateDbHomeRequest struct {
 
 	// Request to create a new database home.
-	CreateDbHomeWithDbSystemIdBase `contributesTo:"body"`
+	CreateDbHomeWithDbSystemIdDetails CreateDbHomeBase `contributesTo:"body"`
 
 	// A token that uniquely identifies a request so it can be retried in case of a timeout or
 	// server error without risk of executing that same action again. Retry tokens expire after 24

--- a/database/create_db_home_with_db_system_id_details.go
+++ b/database/create_db_home_with_db_system_id_details.go
@@ -28,11 +28,6 @@ type CreateDbHomeWithDbSystemIdDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 }
 
-//GetDbSystemId returns DbSystemId
-func (m CreateDbHomeWithDbSystemIdDetails) GetDbSystemId() *string {
-	return m.DbSystemId
-}
-
 //GetDisplayName returns DisplayName
 func (m CreateDbHomeWithDbSystemIdDetails) GetDisplayName() *string {
 	return m.DisplayName

--- a/database/create_db_home_with_db_system_id_from_backup_details.go
+++ b/database/create_db_home_with_db_system_id_from_backup_details.go
@@ -25,11 +25,6 @@ type CreateDbHomeWithDbSystemIdFromBackupDetails struct {
 	DisplayName *string `mandatory:"false" json:"displayName"`
 }
 
-//GetDbSystemId returns DbSystemId
-func (m CreateDbHomeWithDbSystemIdFromBackupDetails) GetDbSystemId() *string {
-	return m.DbSystemId
-}
-
 //GetDisplayName returns DisplayName
 func (m CreateDbHomeWithDbSystemIdFromBackupDetails) GetDisplayName() *string {
 	return m.DisplayName

--- a/database/create_db_home_with_vm_cluster_id_details.go
+++ b/database/create_db_home_with_vm_cluster_id_details.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateDbHomeWithVmClusterIdDetails Note that a valid `vmClusterId` value must be supplied for the `CreateDbHomeWithVmClusterId` API operation to successfully complete.
+type CreateDbHomeWithVmClusterIdDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster.
+	VmClusterId *string `mandatory:"true" json:"vmClusterId"`
+
+	// A valid Oracle Database version. To get a list of supported versions, use the ListDbVersions operation.
+	DbVersion *string `mandatory:"true" json:"dbVersion"`
+
+	Database *CreateDatabaseDetails `mandatory:"true" json:"database"`
+
+	// The user-provided name of the database home.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+}
+
+//GetDisplayName returns DisplayName
+func (m CreateDbHomeWithVmClusterIdDetails) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+func (m CreateDbHomeWithVmClusterIdDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateDbHomeWithVmClusterIdDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateDbHomeWithVmClusterIdDetails CreateDbHomeWithVmClusterIdDetails
+	s := struct {
+		DiscriminatorParam string `json:"source"`
+		MarshalTypeCreateDbHomeWithVmClusterIdDetails
+	}{
+		"VM_CLUSTER_NEW",
+		(MarshalTypeCreateDbHomeWithVmClusterIdDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/database/create_db_home_with_vm_cluster_id_from_backup_details.go
+++ b/database/create_db_home_with_vm_cluster_id_from_backup_details.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateDbHomeWithVmClusterIdFromBackupDetails Note that a valid `vmClusterId` value must be supplied for the `CreateDbHomeWithVmClusterIdFromBackup` API operation to successfully complete.
+type CreateDbHomeWithVmClusterIdFromBackupDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster.
+	VmClusterId *string `mandatory:"true" json:"vmClusterId"`
+
+	Database *CreateDatabaseFromBackupDetails `mandatory:"true" json:"database"`
+
+	// The user-provided name of the database home.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+}
+
+//GetDisplayName returns DisplayName
+func (m CreateDbHomeWithVmClusterIdFromBackupDetails) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+func (m CreateDbHomeWithVmClusterIdFromBackupDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateDbHomeWithVmClusterIdFromBackupDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateDbHomeWithVmClusterIdFromBackupDetails CreateDbHomeWithVmClusterIdFromBackupDetails
+	s := struct {
+		DiscriminatorParam string `json:"source"`
+		MarshalTypeCreateDbHomeWithVmClusterIdFromBackupDetails
+	}{
+		"VM_CLUSTER_BACKUP",
+		(MarshalTypeCreateDbHomeWithVmClusterIdFromBackupDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/database/create_exadata_infrastructure_details.go
+++ b/database/create_exadata_infrastructure_details.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateExadataInfrastructureDetails Request to create Exadata infrastructure.
+type CreateExadataInfrastructureDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The user-friendly name for the Exadata infrastructure. The name does not need to be unique.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+	Shape *string `mandatory:"true" json:"shape"`
+
+	// The time zone of the Exadata infrastructure. For details, see Exadata Infrastructure Time Zones (https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
+	TimeZone *string `mandatory:"true" json:"timeZone"`
+
+	// The IP address for the first control plane server.
+	CloudControlPlaneServer1 *string `mandatory:"true" json:"cloudControlPlaneServer1"`
+
+	// The IP address for the second control plane server.
+	CloudControlPlaneServer2 *string `mandatory:"true" json:"cloudControlPlaneServer2"`
+
+	// The netmask for the control plane network.
+	Netmask *string `mandatory:"true" json:"netmask"`
+
+	// The gateway for the control plane network.
+	Gateway *string `mandatory:"true" json:"gateway"`
+
+	// The CIDR block for the Exadata administration network.
+	AdminNetworkCIDR *string `mandatory:"true" json:"adminNetworkCIDR"`
+
+	// The CIDR block for the Exadata InfiniBand interconnect.
+	InfiniBandNetworkCIDR *string `mandatory:"true" json:"infiniBandNetworkCIDR"`
+
+	// The corporate network proxy for access to the control plane network.
+	CorporateProxy *string `mandatory:"true" json:"corporateProxy"`
+
+	// The list of DNS server IP addresses. Maximum of 3 allowed.
+	DnsServer []string `mandatory:"true" json:"dnsServer"`
+
+	// The list of NTP server IP addresses. Maximum of 3 allowed.
+	NtpServer []string `mandatory:"true" json:"ntpServer"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m CreateExadataInfrastructureDetails) String() string {
+	return common.PointerString(m)
+}

--- a/database/create_exadata_infrastructure_request_response.go
+++ b/database/create_exadata_infrastructure_request_response.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateExadataInfrastructureRequest wrapper for the CreateExadataInfrastructure operation
+type CreateExadataInfrastructureRequest struct {
+
+	// Request to create Exadata infrastructure.
+	CreateExadataInfrastructureDetails `contributesTo:"body"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateExadataInfrastructureRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateExadataInfrastructureRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateExadataInfrastructureRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateExadataInfrastructureResponse wrapper for the CreateExadataInfrastructure operation
+type CreateExadataInfrastructureResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ExadataInfrastructure instance
+	ExadataInfrastructure `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateExadataInfrastructureResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateExadataInfrastructureResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/create_nfs_backup_destination_details.go
+++ b/database/create_nfs_backup_destination_details.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateNfsBackupDestinationDetails Used for creating NFS backup destinations.
+type CreateNfsBackupDestinationDetails struct {
+
+	// The user-provided name of the backup destination.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
+	LocalMountPointPath *string `mandatory:"true" json:"localMountPointPath"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+//GetDisplayName returns DisplayName
+func (m CreateNfsBackupDestinationDetails) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetCompartmentId returns CompartmentId
+func (m CreateNfsBackupDestinationDetails) GetCompartmentId() *string {
+	return m.CompartmentId
+}
+
+//GetFreeformTags returns FreeformTags
+func (m CreateNfsBackupDestinationDetails) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m CreateNfsBackupDestinationDetails) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+func (m CreateNfsBackupDestinationDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateNfsBackupDestinationDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateNfsBackupDestinationDetails CreateNfsBackupDestinationDetails
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeCreateNfsBackupDestinationDetails
+	}{
+		"NFS",
+		(MarshalTypeCreateNfsBackupDestinationDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/database/create_recovery_appliance_backup_destination_details.go
+++ b/database/create_recovery_appliance_backup_destination_details.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateRecoveryApplianceBackupDestinationDetails Used for creating Recovery Appliance backup destinations.
+type CreateRecoveryApplianceBackupDestinationDetails struct {
+
+	// The user-provided name of the backup destination.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The connection string for connecting to the Recovery Appliance.
+	ConnectionString *string `mandatory:"true" json:"connectionString"`
+
+	// The Virtual Private Catalog (VPC) users that are used to access the Recovery Appliance.
+	VpcUsers []string `mandatory:"true" json:"vpcUsers"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+//GetDisplayName returns DisplayName
+func (m CreateRecoveryApplianceBackupDestinationDetails) GetDisplayName() *string {
+	return m.DisplayName
+}
+
+//GetCompartmentId returns CompartmentId
+func (m CreateRecoveryApplianceBackupDestinationDetails) GetCompartmentId() *string {
+	return m.CompartmentId
+}
+
+//GetFreeformTags returns FreeformTags
+func (m CreateRecoveryApplianceBackupDestinationDetails) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m CreateRecoveryApplianceBackupDestinationDetails) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+func (m CreateRecoveryApplianceBackupDestinationDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateRecoveryApplianceBackupDestinationDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateRecoveryApplianceBackupDestinationDetails CreateRecoveryApplianceBackupDestinationDetails
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeCreateRecoveryApplianceBackupDestinationDetails
+	}{
+		"RECOVERY_APPLIANCE",
+		(MarshalTypeCreateRecoveryApplianceBackupDestinationDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/database/create_vm_cluster_details.go
+++ b/database/create_vm_cluster_details.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateVmClusterDetails Details for the create VM cluster operation.
+type CreateVmClusterDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The user-friendly name for the VM cluster. The name does not need to be unique.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+	ExadataInfrastructureId *string `mandatory:"true" json:"exadataInfrastructureId"`
+
+	// The number of CPU cores to enable for the VM cluster.
+	CpuCoreCount *int `mandatory:"true" json:"cpuCoreCount"`
+
+	// The public key portion of one or more key pairs used for SSH access to the VM cluster.
+	SshPublicKeys []string `mandatory:"true" json:"sshPublicKeys"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster network.
+	VmClusterNetworkId *string `mandatory:"true" json:"vmClusterNetworkId"`
+
+	// The Oracle Grid Infrastructure software version for the VM cluster.
+	GiVersion *string `mandatory:"true" json:"giVersion"`
+
+	// The Oracle license model that applies to the VM cluster. The default is BRING_YOUR_OWN_LICENSE.
+	LicenseModel CreateVmClusterDetailsLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
+
+	// If true, the sparse disk group is configured for the VM cluster. If false, the sparse disk group is not created.
+	IsSparseDiskgroupEnabled *bool `mandatory:"false" json:"isSparseDiskgroupEnabled"`
+
+	// If true, database backup on local Exadata storage is configured for the VM cluster. If false, database backup on local Exadata storage is not available in the VM cluster.
+	IsLocalBackupEnabled *bool `mandatory:"false" json:"isLocalBackupEnabled"`
+
+	// The time zone to use for the VM cluster. For details, see DB System Time Zones (https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
+	TimeZone *string `mandatory:"false" json:"timeZone"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m CreateVmClusterDetails) String() string {
+	return common.PointerString(m)
+}
+
+// CreateVmClusterDetailsLicenseModelEnum Enum with underlying type: string
+type CreateVmClusterDetailsLicenseModelEnum string
+
+// Set of constants representing the allowable values for CreateVmClusterDetailsLicenseModelEnum
+const (
+	CreateVmClusterDetailsLicenseModelLicenseIncluded     CreateVmClusterDetailsLicenseModelEnum = "LICENSE_INCLUDED"
+	CreateVmClusterDetailsLicenseModelBringYourOwnLicense CreateVmClusterDetailsLicenseModelEnum = "BRING_YOUR_OWN_LICENSE"
+)
+
+var mappingCreateVmClusterDetailsLicenseModel = map[string]CreateVmClusterDetailsLicenseModelEnum{
+	"LICENSE_INCLUDED":       CreateVmClusterDetailsLicenseModelLicenseIncluded,
+	"BRING_YOUR_OWN_LICENSE": CreateVmClusterDetailsLicenseModelBringYourOwnLicense,
+}
+
+// GetCreateVmClusterDetailsLicenseModelEnumValues Enumerates the set of values for CreateVmClusterDetailsLicenseModelEnum
+func GetCreateVmClusterDetailsLicenseModelEnumValues() []CreateVmClusterDetailsLicenseModelEnum {
+	values := make([]CreateVmClusterDetailsLicenseModelEnum, 0)
+	for _, v := range mappingCreateVmClusterDetailsLicenseModel {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/create_vm_cluster_network_request_response.go
+++ b/database/create_vm_cluster_network_request_response.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateVmClusterNetworkRequest wrapper for the CreateVmClusterNetwork operation
+type CreateVmClusterNetworkRequest struct {
+
+	// The Exadata infrastructure OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	ExadataInfrastructureId *string `mandatory:"true" contributesTo:"path" name:"exadataInfrastructureId"`
+
+	// Request to create the VM cluster network.
+	VmClusterNetworkDetails `contributesTo:"body"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateVmClusterNetworkRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateVmClusterNetworkRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateVmClusterNetworkRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateVmClusterNetworkResponse wrapper for the CreateVmClusterNetwork operation
+type CreateVmClusterNetworkResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The VmClusterNetwork instance
+	VmClusterNetwork `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateVmClusterNetworkResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateVmClusterNetworkResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/create_vm_cluster_request_response.go
+++ b/database/create_vm_cluster_request_response.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateVmClusterRequest wrapper for the CreateVmCluster operation
+type CreateVmClusterRequest struct {
+
+	// Request to create a VM cluster.
+	CreateVmClusterDetails `contributesTo:"body"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateVmClusterRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateVmClusterRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateVmClusterRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateVmClusterResponse wrapper for the CreateVmCluster operation
+type CreateVmClusterResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The VmCluster instance
+	VmCluster `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateVmClusterResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateVmClusterResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/database_client.go
+++ b/database/database_client.go
@@ -58,6 +58,53 @@ func (client *DatabaseClient) ConfigurationProvider() *common.ConfigurationProvi
 	return client.config
 }
 
+// ActivateExadataInfrastructure Activates the specified Exadata infrastructure.
+func (client DatabaseClient) ActivateExadataInfrastructure(ctx context.Context, request ActivateExadataInfrastructureRequest) (response ActivateExadataInfrastructureResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.activateExadataInfrastructure, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ActivateExadataInfrastructureResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ActivateExadataInfrastructureResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ActivateExadataInfrastructureResponse")
+	}
+	return
+}
+
+// activateExadataInfrastructure implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) activateExadataInfrastructure(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/exadataInfrastructures/{exadataInfrastructureId}/actions/activate")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ActivateExadataInfrastructureResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // ChangeAutonomousContainerDatabaseCompartment Move the Autonomous Container Database and its dependent resources to the specified compartment.
 // For more information about moving Autonomous Container Databases, see
 // Moving Database Resources to a Different Compartment (https://docs.cloud.oracle.com/Content/Database/Concepts/databaseoverview.htm#moveRes).
@@ -205,6 +252,55 @@ func (client DatabaseClient) changeAutonomousExadataInfrastructureCompartment(ct
 	return response, err
 }
 
+// ChangeBackupDestinationCompartment Move the backup destination and its dependent resources to the specified compartment.
+// For more information about moving backup destinations, see
+// Moving Database Resources to a Different Compartment (https://docs.cloud.oracle.com/Content/Database/Concepts/databaseoverview.htm#moveRes).
+func (client DatabaseClient) ChangeBackupDestinationCompartment(ctx context.Context, request ChangeBackupDestinationCompartmentRequest) (response ChangeBackupDestinationCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.changeBackupDestinationCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ChangeBackupDestinationCompartmentResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeBackupDestinationCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeBackupDestinationCompartmentResponse")
+	}
+	return
+}
+
+// changeBackupDestinationCompartment implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) changeBackupDestinationCompartment(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/backupDestinations/{backupDestinationId}/actions/changeCompartment")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeBackupDestinationCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // ChangeDbSystemCompartment Move the DB system and its dependent resources to the specified compartment.
 // For more information about moving DB systems, see
 // Moving Database Resources to a Different Compartment (https://docs.cloud.oracle.com/Content/Database/Concepts/databaseoverview.htm#moveRes).
@@ -242,6 +338,102 @@ func (client DatabaseClient) changeDbSystemCompartment(ctx context.Context, requ
 	}
 
 	var response ChangeDbSystemCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ChangeExadataInfrastructureCompartment To move an Exadata infrastructure and its dependent resources to another compartment, use the
+// ChangeExadataInfrastructureCompartment operation.
+func (client DatabaseClient) ChangeExadataInfrastructureCompartment(ctx context.Context, request ChangeExadataInfrastructureCompartmentRequest) (response ChangeExadataInfrastructureCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.changeExadataInfrastructureCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ChangeExadataInfrastructureCompartmentResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeExadataInfrastructureCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeExadataInfrastructureCompartmentResponse")
+	}
+	return
+}
+
+// changeExadataInfrastructureCompartment implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) changeExadataInfrastructureCompartment(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/exadataInfrastructures/{exadataInfrastructureId}/actions/changeCompartment")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeExadataInfrastructureCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ChangeVmClusterCompartment To move a VM cluster and its dependent resources to another compartment, use the
+// ChangeVmClusterCompartment operation.
+func (client DatabaseClient) ChangeVmClusterCompartment(ctx context.Context, request ChangeVmClusterCompartmentRequest) (response ChangeVmClusterCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.changeVmClusterCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ChangeVmClusterCompartmentResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeVmClusterCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeVmClusterCompartmentResponse")
+	}
+	return
+}
+
+// changeVmClusterCompartment implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) changeVmClusterCompartment(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/vmClusters/{vmClusterId}/actions/changeCompartment")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeVmClusterCompartmentResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -584,6 +776,53 @@ func (client DatabaseClient) createBackup(ctx context.Context, request common.OC
 	return response, err
 }
 
+// CreateBackupDestination Creates a backup destination.
+func (client DatabaseClient) CreateBackupDestination(ctx context.Context, request CreateBackupDestinationRequest) (response CreateBackupDestinationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createBackupDestination, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = CreateBackupDestinationResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateBackupDestinationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateBackupDestinationResponse")
+	}
+	return
+}
+
+// createBackupDestination implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) createBackupDestination(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/backupDestinations")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateBackupDestinationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // CreateDataGuardAssociation Creates a new Data Guard association.  A Data Guard association represents the replication relationship between the
 // specified database and a peer database. For more information, see Using Oracle Data Guard (https://docs.cloud.oracle.com/Content/Database/Tasks/usingdataguard.htm).
 // All Oracle Cloud Infrastructure resources, including Data Guard associations, get an Oracle-assigned, unique ID
@@ -684,6 +923,53 @@ func (client DatabaseClient) createDbHome(ctx context.Context, request common.OC
 	return response, err
 }
 
+// CreateExadataInfrastructure Create Exadata infrastructure.
+func (client DatabaseClient) CreateExadataInfrastructure(ctx context.Context, request CreateExadataInfrastructureRequest) (response CreateExadataInfrastructureResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createExadataInfrastructure, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = CreateExadataInfrastructureResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateExadataInfrastructureResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateExadataInfrastructureResponse")
+	}
+	return
+}
+
+// createExadataInfrastructure implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) createExadataInfrastructure(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/exadataInfrastructures")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateExadataInfrastructureResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // CreateExternalBackupJob Creates a new backup resource and returns the information the caller needs to back up an on-premises Oracle Database to Oracle Cloud Infrastructure.
 // **Note:** This API is used by an Oracle Cloud Infrastructure Python script that is packaged with the Oracle Cloud Infrastructure CLI. Oracle recommends that you use the script instead using the API directly. See Migrating an On-Premises Database to Oracle Cloud Infrastructure by Creating a Backup in the Cloud (https://docs.cloud.oracle.com/Content/Database/Tasks/mig-onprembackup.htm) for more information.
 func (client DatabaseClient) CreateExternalBackupJob(ctx context.Context, request CreateExternalBackupJobRequest) (response CreateExternalBackupJobResponse, err error) {
@@ -720,6 +1006,100 @@ func (client DatabaseClient) createExternalBackupJob(ctx context.Context, reques
 	}
 
 	var response CreateExternalBackupJobResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateVmCluster Creates a VM cluster.
+func (client DatabaseClient) CreateVmCluster(ctx context.Context, request CreateVmClusterRequest) (response CreateVmClusterResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createVmCluster, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = CreateVmClusterResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateVmClusterResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateVmClusterResponse")
+	}
+	return
+}
+
+// createVmCluster implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) createVmCluster(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/vmClusters")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateVmClusterResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateVmClusterNetwork Creates the VM cluster network.
+func (client DatabaseClient) CreateVmClusterNetwork(ctx context.Context, request CreateVmClusterNetworkRequest) (response CreateVmClusterNetworkResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createVmClusterNetwork, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = CreateVmClusterNetworkResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateVmClusterNetworkResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateVmClusterNetworkResponse")
+	}
+	return
+}
+
+// createVmClusterNetwork implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) createVmClusterNetwork(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/exadataInfrastructures/{exadataInfrastructureId}/vmClusterNetworks")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateVmClusterNetworkResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -916,6 +1296,48 @@ func (client DatabaseClient) deleteBackup(ctx context.Context, request common.OC
 	return response, err
 }
 
+// DeleteBackupDestination Deletes a backup destination.
+func (client DatabaseClient) DeleteBackupDestination(ctx context.Context, request DeleteBackupDestinationRequest) (response DeleteBackupDestinationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteBackupDestination, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = DeleteBackupDestinationResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteBackupDestinationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteBackupDestinationResponse")
+	}
+	return
+}
+
+// deleteBackupDestination implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) deleteBackupDestination(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/backupDestinations/{backupDestinationId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteBackupDestinationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // DeleteDbHome Deletes a DB Home. The DB Home and its database data are local to the DB system and will be lost when it is deleted. Oracle recommends that you back up any data in the DB system prior to deleting it.
 func (client DatabaseClient) DeleteDbHome(ctx context.Context, request DeleteDbHomeRequest) (response DeleteDbHomeResponse, err error) {
 	var ociResponse common.OCIResponse
@@ -949,6 +1371,224 @@ func (client DatabaseClient) deleteDbHome(ctx context.Context, request common.OC
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteExadataInfrastructure Deletes the Exadata infrastructure.
+func (client DatabaseClient) DeleteExadataInfrastructure(ctx context.Context, request DeleteExadataInfrastructureRequest) (response DeleteExadataInfrastructureResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteExadataInfrastructure, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = DeleteExadataInfrastructureResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteExadataInfrastructureResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteExadataInfrastructureResponse")
+	}
+	return
+}
+
+// deleteExadataInfrastructure implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) deleteExadataInfrastructure(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/exadataInfrastructures/{exadataInfrastructureId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteExadataInfrastructureResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteVmCluster Deletes the specified VM cluster.
+func (client DatabaseClient) DeleteVmCluster(ctx context.Context, request DeleteVmClusterRequest) (response DeleteVmClusterResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteVmCluster, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = DeleteVmClusterResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteVmClusterResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteVmClusterResponse")
+	}
+	return
+}
+
+// deleteVmCluster implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) deleteVmCluster(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/vmClusters/{vmClusterId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteVmClusterResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteVmClusterNetwork Deletes the specified VM cluster network.
+func (client DatabaseClient) DeleteVmClusterNetwork(ctx context.Context, request DeleteVmClusterNetworkRequest) (response DeleteVmClusterNetworkResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteVmClusterNetwork, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = DeleteVmClusterNetworkResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteVmClusterNetworkResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteVmClusterNetworkResponse")
+	}
+	return
+}
+
+// deleteVmClusterNetwork implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) deleteVmClusterNetwork(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/exadataInfrastructures/{exadataInfrastructureId}/vmClusterNetworks/{vmClusterNetworkId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteVmClusterNetworkResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DownloadExadataInfrastructureConfigFile Downloads the configuration file for the specified Exadata infrastructure.
+func (client DatabaseClient) DownloadExadataInfrastructureConfigFile(ctx context.Context, request DownloadExadataInfrastructureConfigFileRequest) (response DownloadExadataInfrastructureConfigFileResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.downloadExadataInfrastructureConfigFile, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = DownloadExadataInfrastructureConfigFileResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DownloadExadataInfrastructureConfigFileResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DownloadExadataInfrastructureConfigFileResponse")
+	}
+	return
+}
+
+// downloadExadataInfrastructureConfigFile implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) downloadExadataInfrastructureConfigFile(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/exadataInfrastructures/{exadataInfrastructureId}/actions/downloadConfigFile")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DownloadExadataInfrastructureConfigFileResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DownloadVmClusterNetworkConfigFile Downloads the configuration file for the specified VM Cluster Network.
+func (client DatabaseClient) DownloadVmClusterNetworkConfigFile(ctx context.Context, request DownloadVmClusterNetworkConfigFileRequest) (response DownloadVmClusterNetworkConfigFileResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.downloadVmClusterNetworkConfigFile, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = DownloadVmClusterNetworkConfigFileResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DownloadVmClusterNetworkConfigFileResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DownloadVmClusterNetworkConfigFileResponse")
+	}
+	return
+}
+
+// downloadVmClusterNetworkConfigFile implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) downloadVmClusterNetworkConfigFile(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/exadataInfrastructures/{exadataInfrastructureId}/vmClusterNetworks/{vmClusterNetworkId}/actions/downloadConfigFile")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DownloadVmClusterNetworkConfigFileResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
 	response.RawResponse = httpResponse
 	if err != nil {
 		return response, err
@@ -1086,6 +1726,53 @@ func (client DatabaseClient) generateAutonomousDatabaseWallet(ctx context.Contex
 	var response GenerateAutonomousDatabaseWalletResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GenerateRecommendedVmClusterNetwork Generates a recommended VM cluster network configuration.
+func (client DatabaseClient) GenerateRecommendedVmClusterNetwork(ctx context.Context, request GenerateRecommendedVmClusterNetworkRequest) (response GenerateRecommendedVmClusterNetworkResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.generateRecommendedVmClusterNetwork, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = GenerateRecommendedVmClusterNetworkResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GenerateRecommendedVmClusterNetworkResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GenerateRecommendedVmClusterNetworkResponse")
+	}
+	return
+}
+
+// generateRecommendedVmClusterNetwork implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) generateRecommendedVmClusterNetwork(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/exadataInfrastructures/{exadataInfrastructureId}/vmClusterNetworks/actions/generateRecommendedNetwork")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GenerateRecommendedVmClusterNetworkResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
 	response.RawResponse = httpResponse
 	if err != nil {
 		return response, err
@@ -1377,6 +2064,48 @@ func (client DatabaseClient) getBackup(ctx context.Context, request common.OCIRe
 	}
 
 	var response GetBackupResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetBackupDestination Gets information about the specified backup destination.
+func (client DatabaseClient) GetBackupDestination(ctx context.Context, request GetBackupDestinationRequest) (response GetBackupDestinationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getBackupDestination, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = GetBackupDestinationResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetBackupDestinationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetBackupDestinationResponse")
+	}
+	return
+}
+
+// getBackupDestination implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) getBackupDestination(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/backupDestinations/{backupDestinationId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetBackupDestinationResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -1767,6 +2496,48 @@ func (client DatabaseClient) getDbSystemPatchHistoryEntry(ctx context.Context, r
 	return response, err
 }
 
+// GetExadataInfrastructure Gets information about the specified Exadata infrastructure.
+func (client DatabaseClient) GetExadataInfrastructure(ctx context.Context, request GetExadataInfrastructureRequest) (response GetExadataInfrastructureResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getExadataInfrastructure, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = GetExadataInfrastructureResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetExadataInfrastructureResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetExadataInfrastructureResponse")
+	}
+	return
+}
+
+// getExadataInfrastructure implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) getExadataInfrastructure(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/exadataInfrastructures/{exadataInfrastructureId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetExadataInfrastructureResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // GetExadataIormConfig Gets `IORM` Setting for the requested Exadata DB System.
 // The default IORM Settings is pre-created in all the Exadata DB System.
 func (client DatabaseClient) GetExadataIormConfig(ctx context.Context, request GetExadataIormConfigRequest) (response GetExadataIormConfigResponse, err error) {
@@ -1883,6 +2654,90 @@ func (client DatabaseClient) getMaintenanceRun(ctx context.Context, request comm
 	}
 
 	var response GetMaintenanceRunResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetVmCluster Gets information about the specified VM cluster.
+func (client DatabaseClient) GetVmCluster(ctx context.Context, request GetVmClusterRequest) (response GetVmClusterResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getVmCluster, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = GetVmClusterResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetVmClusterResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetVmClusterResponse")
+	}
+	return
+}
+
+// getVmCluster implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) getVmCluster(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/vmClusters/{vmClusterId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetVmClusterResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetVmClusterNetwork Gets information about the specified VM cluster network.
+func (client DatabaseClient) GetVmClusterNetwork(ctx context.Context, request GetVmClusterNetworkRequest) (response GetVmClusterNetworkResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getVmClusterNetwork, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = GetVmClusterNetworkResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetVmClusterNetworkResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetVmClusterNetworkResponse")
+	}
+	return
+}
+
+// getVmClusterNetwork implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) getVmClusterNetwork(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/exadataInfrastructures/{exadataInfrastructureId}/vmClusterNetworks/{vmClusterNetworkId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetVmClusterNetworkResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -2317,6 +3172,48 @@ func (client DatabaseClient) listAutonomousExadataInfrastructures(ctx context.Co
 	}
 
 	var response ListAutonomousExadataInfrastructuresResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListBackupDestination Gets a list of backup destinations in the specified compartment.
+func (client DatabaseClient) ListBackupDestination(ctx context.Context, request ListBackupDestinationRequest) (response ListBackupDestinationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listBackupDestination, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ListBackupDestinationResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListBackupDestinationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListBackupDestinationResponse")
+	}
+	return
+}
+
+// listBackupDestination implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) listBackupDestination(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/backupDestinations")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListBackupDestinationResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -2834,6 +3731,90 @@ func (client DatabaseClient) listDbVersions(ctx context.Context, request common.
 	return response, err
 }
 
+// ListExadataInfrastructures Gets a list of the Exadata infrastructure in the specified compartment.
+func (client DatabaseClient) ListExadataInfrastructures(ctx context.Context, request ListExadataInfrastructuresRequest) (response ListExadataInfrastructuresResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listExadataInfrastructures, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ListExadataInfrastructuresResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListExadataInfrastructuresResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListExadataInfrastructuresResponse")
+	}
+	return
+}
+
+// listExadataInfrastructures implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) listExadataInfrastructures(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/exadataInfrastructures")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListExadataInfrastructuresResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListGiVersions Gets a list of supported GI versions for VM Cluster.
+func (client DatabaseClient) ListGiVersions(ctx context.Context, request ListGiVersionsRequest) (response ListGiVersionsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listGiVersions, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ListGiVersionsResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListGiVersionsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListGiVersionsResponse")
+	}
+	return
+}
+
+// listGiVersions implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) listGiVersions(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/giVersions")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListGiVersionsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // ListMaintenanceRuns Gets a list of the Maintenance Runs in the specified compartment.
 func (client DatabaseClient) ListMaintenanceRuns(ctx context.Context, request ListMaintenanceRunsRequest) (response ListMaintenanceRunsResponse, err error) {
 	var ociResponse common.OCIResponse
@@ -2864,6 +3845,90 @@ func (client DatabaseClient) listMaintenanceRuns(ctx context.Context, request co
 	}
 
 	var response ListMaintenanceRunsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListVmClusterNetworks Gets a list of the VM cluster networks in the specified compartment.
+func (client DatabaseClient) ListVmClusterNetworks(ctx context.Context, request ListVmClusterNetworksRequest) (response ListVmClusterNetworksResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listVmClusterNetworks, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ListVmClusterNetworksResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListVmClusterNetworksResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListVmClusterNetworksResponse")
+	}
+	return
+}
+
+// listVmClusterNetworks implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) listVmClusterNetworks(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/exadataInfrastructures/{exadataInfrastructureId}/vmClusterNetworks")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListVmClusterNetworksResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListVmClusters Gets a list of the VM clusters in the specified compartment.
+func (client DatabaseClient) ListVmClusters(ctx context.Context, request ListVmClustersRequest) (response ListVmClustersResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listVmClusters, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ListVmClustersResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListVmClustersResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListVmClustersResponse")
+	}
+	return
+}
+
+// listVmClusters implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) listVmClusters(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/vmClusters")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListVmClustersResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -3592,6 +4657,50 @@ func (client DatabaseClient) updateAutonomousExadataInfrastructure(ctx context.C
 	return response, err
 }
 
+// UpdateBackupDestination If no database is associated with the backup destination:
+// - For a RECOVERY_APPLIANCE backup destination, updates the connection string and/or the list of VPC users.
+// - For an NFS backup destination, updates the NFS location.
+func (client DatabaseClient) UpdateBackupDestination(ctx context.Context, request UpdateBackupDestinationRequest) (response UpdateBackupDestinationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateBackupDestination, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = UpdateBackupDestinationResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateBackupDestinationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateBackupDestinationResponse")
+	}
+	return
+}
+
+// updateBackupDestination implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) updateBackupDestination(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/backupDestinations/{backupDestinationId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateBackupDestinationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // UpdateDatabase Update a Database based on the request parameters you provide.
 func (client DatabaseClient) UpdateDatabase(ctx context.Context, request UpdateDatabaseRequest) (response UpdateDatabaseResponse, err error) {
 	var ociResponse common.OCIResponse
@@ -3718,6 +4827,48 @@ func (client DatabaseClient) updateDbSystem(ctx context.Context, request common.
 	return response, err
 }
 
+// UpdateExadataInfrastructure Updates the Exadata infrastructure.
+func (client DatabaseClient) UpdateExadataInfrastructure(ctx context.Context, request UpdateExadataInfrastructureRequest) (response UpdateExadataInfrastructureResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateExadataInfrastructure, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = UpdateExadataInfrastructureResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateExadataInfrastructureResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateExadataInfrastructureResponse")
+	}
+	return
+}
+
+// updateExadataInfrastructure implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) updateExadataInfrastructure(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/exadataInfrastructures/{exadataInfrastructureId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateExadataInfrastructureResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // UpdateExadataIormConfig Update `IORM` Settings for the requested Exadata DB System.
 func (client DatabaseClient) UpdateExadataIormConfig(ctx context.Context, request UpdateExadataIormConfigRequest) (response UpdateExadataIormConfigResponse, err error) {
 	var ociResponse common.OCIResponse
@@ -3790,6 +4941,137 @@ func (client DatabaseClient) updateMaintenanceRun(ctx context.Context, request c
 	}
 
 	var response UpdateMaintenanceRunResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateVmCluster Updates the specified VM cluster.
+func (client DatabaseClient) UpdateVmCluster(ctx context.Context, request UpdateVmClusterRequest) (response UpdateVmClusterResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateVmCluster, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = UpdateVmClusterResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateVmClusterResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateVmClusterResponse")
+	}
+	return
+}
+
+// updateVmCluster implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) updateVmCluster(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/vmClusters/{vmClusterId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateVmClusterResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateVmClusterNetwork Updates the specified VM cluster network.
+func (client DatabaseClient) UpdateVmClusterNetwork(ctx context.Context, request UpdateVmClusterNetworkRequest) (response UpdateVmClusterNetworkResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateVmClusterNetwork, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = UpdateVmClusterNetworkResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateVmClusterNetworkResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateVmClusterNetworkResponse")
+	}
+	return
+}
+
+// updateVmClusterNetwork implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) updateVmClusterNetwork(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/exadataInfrastructures/{exadataInfrastructureId}/vmClusterNetworks/{vmClusterNetworkId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateVmClusterNetworkResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ValidateVmClusterNetwork Validates the specified VM cluster network.
+func (client DatabaseClient) ValidateVmClusterNetwork(ctx context.Context, request ValidateVmClusterNetworkRequest) (response ValidateVmClusterNetworkResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.validateVmClusterNetwork, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ValidateVmClusterNetworkResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ValidateVmClusterNetworkResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ValidateVmClusterNetworkResponse")
+	}
+	return
+}
+
+// validateVmClusterNetwork implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) validateVmClusterNetwork(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/exadataInfrastructures/{exadataInfrastructureId}/vmClusterNetworks/{vmClusterNetworkId}/actions/validate")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ValidateVmClusterNetworkResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)

--- a/database/db_backup_config.go
+++ b/database/db_backup_config.go
@@ -27,6 +27,9 @@ type DbBackupConfig struct {
 	// Time window selected for initiating automatic backup for the database system. There are twelve available two-hour time windows. If no option is selected, a start time between 12:00 AM to 7:00 AM in the region of the database is automatically chosen. For example, if the user selects SLOT_TWO from the enum list, the automatic backup job will start in between 2:00 AM (inclusive) to 4:00 AM (exclusive).
 	// Example: `SLOT_TWO`
 	AutoBackupWindow DbBackupConfigAutoBackupWindowEnum `mandatory:"false" json:"autoBackupWindow,omitempty"`
+
+	// Backup destination details.
+	BackupDestinationDetails []BackupDestinationDetails `mandatory:"false" json:"backupDestinationDetails"`
 }
 
 func (m DbBackupConfig) String() string {

--- a/database/db_home.go
+++ b/database/db_home.go
@@ -36,6 +36,9 @@ type DbHome struct {
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the DB system.
 	DbSystemId *string `mandatory:"false" json:"dbSystemId"`
 
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster.
+	VmClusterId *string `mandatory:"false" json:"vmClusterId"`
+
 	// The date and time the database home was created.
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 }

--- a/database/db_home_summary.go
+++ b/database/db_home_summary.go
@@ -42,6 +42,9 @@ type DbHomeSummary struct {
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the DB system.
 	DbSystemId *string `mandatory:"false" json:"dbSystemId"`
 
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster.
+	VmClusterId *string `mandatory:"false" json:"vmClusterId"`
+
 	// The date and time the database home was created.
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 }

--- a/database/db_system_shape_summary.go
+++ b/database/db_system_shape_summary.go
@@ -25,6 +25,9 @@ type DbSystemShapeSummary struct {
 	// The maximum number of CPU cores that can be enabled on the DB system for this shape.
 	AvailableCoreCount *int `mandatory:"true" json:"availableCoreCount"`
 
+	// The family of the shape used for the DB system.
+	ShapeFamily *string `mandatory:"false" json:"shapeFamily"`
+
 	// Deprecated. Use `name` instead of `shape`.
 	Shape *string `mandatory:"false" json:"shape"`
 

--- a/database/delete_backup_destination_request_response.go
+++ b/database/delete_backup_destination_request_response.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteBackupDestinationRequest wrapper for the DeleteBackupDestination operation
+type DeleteBackupDestinationRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup destination.
+	BackupDestinationId *string `mandatory:"true" contributesTo:"path" name:"backupDestinationId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteBackupDestinationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteBackupDestinationRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteBackupDestinationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteBackupDestinationResponse wrapper for the DeleteBackupDestination operation
+type DeleteBackupDestinationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteBackupDestinationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteBackupDestinationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/delete_exadata_infrastructure_request_response.go
+++ b/database/delete_exadata_infrastructure_request_response.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteExadataInfrastructureRequest wrapper for the DeleteExadataInfrastructure operation
+type DeleteExadataInfrastructureRequest struct {
+
+	// The Exadata infrastructure OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	ExadataInfrastructureId *string `mandatory:"true" contributesTo:"path" name:"exadataInfrastructureId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteExadataInfrastructureRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteExadataInfrastructureRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteExadataInfrastructureRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteExadataInfrastructureResponse wrapper for the DeleteExadataInfrastructure operation
+type DeleteExadataInfrastructureResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteExadataInfrastructureResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteExadataInfrastructureResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/delete_vm_cluster_network_request_response.go
+++ b/database/delete_vm_cluster_network_request_response.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteVmClusterNetworkRequest wrapper for the DeleteVmClusterNetwork operation
+type DeleteVmClusterNetworkRequest struct {
+
+	// The Exadata infrastructure OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	ExadataInfrastructureId *string `mandatory:"true" contributesTo:"path" name:"exadataInfrastructureId"`
+
+	// The VM cluster network OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	VmClusterNetworkId *string `mandatory:"true" contributesTo:"path" name:"vmClusterNetworkId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteVmClusterNetworkRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteVmClusterNetworkRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteVmClusterNetworkRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteVmClusterNetworkResponse wrapper for the DeleteVmClusterNetwork operation
+type DeleteVmClusterNetworkResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteVmClusterNetworkResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteVmClusterNetworkResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/delete_vm_cluster_request_response.go
+++ b/database/delete_vm_cluster_request_response.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteVmClusterRequest wrapper for the DeleteVmCluster operation
+type DeleteVmClusterRequest struct {
+
+	// The VM cluster OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	VmClusterId *string `mandatory:"true" contributesTo:"path" name:"vmClusterId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteVmClusterRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteVmClusterRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteVmClusterRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteVmClusterResponse wrapper for the DeleteVmCluster operation
+type DeleteVmClusterResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteVmClusterResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteVmClusterResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/download_exadata_infrastructure_config_file_request_response.go
+++ b/database/download_exadata_infrastructure_config_file_request_response.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"io"
+	"net/http"
+)
+
+// DownloadExadataInfrastructureConfigFileRequest wrapper for the DownloadExadataInfrastructureConfigFile operation
+type DownloadExadataInfrastructureConfigFileRequest struct {
+
+	// The Exadata infrastructure OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	ExadataInfrastructureId *string `mandatory:"true" contributesTo:"path" name:"exadataInfrastructureId"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DownloadExadataInfrastructureConfigFileRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DownloadExadataInfrastructureConfigFileRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DownloadExadataInfrastructureConfigFileRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DownloadExadataInfrastructureConfigFileResponse wrapper for the DownloadExadataInfrastructureConfigFile operation
+type DownloadExadataInfrastructureConfigFileResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The io.ReadCloser instance
+	Content io.ReadCloser `presentIn:"body" encoding:"binary"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Size of the file.
+	ContentLength *int64 `presentIn:"header" name:"content-length"`
+
+	// The date and time the configuration file was created, as described in RFC 3339 (https://tools.ietf.org/rfc/rfc3339), section 14.29.
+	LastModified *common.SDKTime `presentIn:"header" name:"last-modified"`
+}
+
+func (response DownloadExadataInfrastructureConfigFileResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DownloadExadataInfrastructureConfigFileResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/download_vm_cluster_network_config_file_request_response.go
+++ b/database/download_vm_cluster_network_config_file_request_response.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"io"
+	"net/http"
+)
+
+// DownloadVmClusterNetworkConfigFileRequest wrapper for the DownloadVmClusterNetworkConfigFile operation
+type DownloadVmClusterNetworkConfigFileRequest struct {
+
+	// The Exadata infrastructure OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	ExadataInfrastructureId *string `mandatory:"true" contributesTo:"path" name:"exadataInfrastructureId"`
+
+	// The VM cluster network OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	VmClusterNetworkId *string `mandatory:"true" contributesTo:"path" name:"vmClusterNetworkId"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DownloadVmClusterNetworkConfigFileRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DownloadVmClusterNetworkConfigFileRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DownloadVmClusterNetworkConfigFileRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DownloadVmClusterNetworkConfigFileResponse wrapper for the DownloadVmClusterNetworkConfigFile operation
+type DownloadVmClusterNetworkConfigFileResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The io.ReadCloser instance
+	Content io.ReadCloser `presentIn:"body" encoding:"binary"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Size of the file.
+	ContentLength *int64 `presentIn:"header" name:"content-length"`
+
+	// The date and time the configuration file was created, as described in RFC 3339 (https://tools.ietf.org/rfc/rfc3339), section 14.29.
+	LastModified *common.SDKTime `presentIn:"header" name:"last-modified"`
+}
+
+func (response DownloadVmClusterNetworkConfigFileResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DownloadVmClusterNetworkConfigFileResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/exadata_infrastructure.go
+++ b/database/exadata_infrastructure.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ExadataInfrastructure ExadataInfrastructure
+type ExadataInfrastructure struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The current lifecycle state of the Exadata infrastructure.
+	LifecycleState ExadataInfrastructureLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// The user-friendly name for the Exadata infrastructure. The name does not need to be unique.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+	Shape *string `mandatory:"true" json:"shape"`
+
+	// The time zone of the Exadata infrastructure. For details, see Exadata Infrastructure Time Zones (https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
+	TimeZone *string `mandatory:"false" json:"timeZone"`
+
+	// The number of enabled CPU cores.
+	CpusEnabled *int `mandatory:"false" json:"cpusEnabled"`
+
+	// Size, in terabytes, of the DATA disk group.
+	DataStorageSizeInTBs *int `mandatory:"false" json:"dataStorageSizeInTBs"`
+
+	// The IP address for the first control plane server.
+	CloudControlPlaneServer1 *string `mandatory:"false" json:"cloudControlPlaneServer1"`
+
+	// The IP address for the second control plane server.
+	CloudControlPlaneServer2 *string `mandatory:"false" json:"cloudControlPlaneServer2"`
+
+	// The netmask for the control plane network.
+	Netmask *string `mandatory:"false" json:"netmask"`
+
+	// The gateway for the control plane network.
+	Gateway *string `mandatory:"false" json:"gateway"`
+
+	// The CIDR block for the Exadata administration network.
+	AdminNetworkCIDR *string `mandatory:"false" json:"adminNetworkCIDR"`
+
+	// The CIDR block for the Exadata InfiniBand interconnect.
+	InfiniBandNetworkCIDR *string `mandatory:"false" json:"infiniBandNetworkCIDR"`
+
+	// The corporate network proxy for access to the control plane network.
+	CorporateProxy *string `mandatory:"false" json:"corporateProxy"`
+
+	// The list of DNS server IP addresses. Maximum of 3 allowed.
+	DnsServer []string `mandatory:"false" json:"dnsServer"`
+
+	// The list of NTP server IP addresses. Maximum of 3 allowed.
+	NtpServer []string `mandatory:"false" json:"ntpServer"`
+
+	// The date and time the Exadata infrastructure was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// Additional information about the current lifecycle state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m ExadataInfrastructure) String() string {
+	return common.PointerString(m)
+}
+
+// ExadataInfrastructureLifecycleStateEnum Enum with underlying type: string
+type ExadataInfrastructureLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ExadataInfrastructureLifecycleStateEnum
+const (
+	ExadataInfrastructureLifecycleStateCreating           ExadataInfrastructureLifecycleStateEnum = "CREATING"
+	ExadataInfrastructureLifecycleStateRequiresActivation ExadataInfrastructureLifecycleStateEnum = "REQUIRES_ACTIVATION"
+	ExadataInfrastructureLifecycleStateActivating         ExadataInfrastructureLifecycleStateEnum = "ACTIVATING"
+	ExadataInfrastructureLifecycleStateActive             ExadataInfrastructureLifecycleStateEnum = "ACTIVE"
+	ExadataInfrastructureLifecycleStateActivationFailed   ExadataInfrastructureLifecycleStateEnum = "ACTIVATION_FAILED"
+	ExadataInfrastructureLifecycleStateFailed             ExadataInfrastructureLifecycleStateEnum = "FAILED"
+	ExadataInfrastructureLifecycleStateUpdating           ExadataInfrastructureLifecycleStateEnum = "UPDATING"
+	ExadataInfrastructureLifecycleStateDeleting           ExadataInfrastructureLifecycleStateEnum = "DELETING"
+	ExadataInfrastructureLifecycleStateDeleted            ExadataInfrastructureLifecycleStateEnum = "DELETED"
+	ExadataInfrastructureLifecycleStateOffline            ExadataInfrastructureLifecycleStateEnum = "OFFLINE"
+)
+
+var mappingExadataInfrastructureLifecycleState = map[string]ExadataInfrastructureLifecycleStateEnum{
+	"CREATING":            ExadataInfrastructureLifecycleStateCreating,
+	"REQUIRES_ACTIVATION": ExadataInfrastructureLifecycleStateRequiresActivation,
+	"ACTIVATING":          ExadataInfrastructureLifecycleStateActivating,
+	"ACTIVE":              ExadataInfrastructureLifecycleStateActive,
+	"ACTIVATION_FAILED":   ExadataInfrastructureLifecycleStateActivationFailed,
+	"FAILED":              ExadataInfrastructureLifecycleStateFailed,
+	"UPDATING":            ExadataInfrastructureLifecycleStateUpdating,
+	"DELETING":            ExadataInfrastructureLifecycleStateDeleting,
+	"DELETED":             ExadataInfrastructureLifecycleStateDeleted,
+	"OFFLINE":             ExadataInfrastructureLifecycleStateOffline,
+}
+
+// GetExadataInfrastructureLifecycleStateEnumValues Enumerates the set of values for ExadataInfrastructureLifecycleStateEnum
+func GetExadataInfrastructureLifecycleStateEnumValues() []ExadataInfrastructureLifecycleStateEnum {
+	values := make([]ExadataInfrastructureLifecycleStateEnum, 0)
+	for _, v := range mappingExadataInfrastructureLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/exadata_infrastructure_summary.go
+++ b/database/exadata_infrastructure_summary.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ExadataInfrastructureSummary Details of the Exadata infrastructure.
+type ExadataInfrastructureSummary struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The current lifecycle state of the Exadata infrastructure.
+	LifecycleState ExadataInfrastructureSummaryLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// The user-friendly name for the Exadata infrastructure. The name does not need to be unique.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+	Shape *string `mandatory:"true" json:"shape"`
+
+	// The time zone of the Exadata infrastructure. For details, see Exadata Infrastructure Time Zones (https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
+	TimeZone *string `mandatory:"false" json:"timeZone"`
+
+	// The number of enabled CPU cores.
+	CpusEnabled *int `mandatory:"false" json:"cpusEnabled"`
+
+	// Size, in terabytes, of the DATA disk group.
+	DataStorageSizeInTBs *int `mandatory:"false" json:"dataStorageSizeInTBs"`
+
+	// The IP address for the first control plane server.
+	CloudControlPlaneServer1 *string `mandatory:"false" json:"cloudControlPlaneServer1"`
+
+	// The IP address for the second control plane server.
+	CloudControlPlaneServer2 *string `mandatory:"false" json:"cloudControlPlaneServer2"`
+
+	// The netmask for the control plane network.
+	Netmask *string `mandatory:"false" json:"netmask"`
+
+	// The gateway for the control plane network.
+	Gateway *string `mandatory:"false" json:"gateway"`
+
+	// The CIDR block for the Exadata administration network.
+	AdminNetworkCIDR *string `mandatory:"false" json:"adminNetworkCIDR"`
+
+	// The CIDR block for the Exadata InfiniBand interconnect.
+	InfiniBandNetworkCIDR *string `mandatory:"false" json:"infiniBandNetworkCIDR"`
+
+	// The corporate network proxy for access to the control plane network.
+	CorporateProxy *string `mandatory:"false" json:"corporateProxy"`
+
+	// The list of DNS server IP addresses. Maximum of 3 allowed.
+	DnsServer []string `mandatory:"false" json:"dnsServer"`
+
+	// The list of NTP server IP addresses. Maximum of 3 allowed.
+	NtpServer []string `mandatory:"false" json:"ntpServer"`
+
+	// The date and time the Exadata infrastructure was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// Additional information about the current lifecycle state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m ExadataInfrastructureSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ExadataInfrastructureSummaryLifecycleStateEnum Enum with underlying type: string
+type ExadataInfrastructureSummaryLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ExadataInfrastructureSummaryLifecycleStateEnum
+const (
+	ExadataInfrastructureSummaryLifecycleStateCreating           ExadataInfrastructureSummaryLifecycleStateEnum = "CREATING"
+	ExadataInfrastructureSummaryLifecycleStateRequiresActivation ExadataInfrastructureSummaryLifecycleStateEnum = "REQUIRES_ACTIVATION"
+	ExadataInfrastructureSummaryLifecycleStateActivating         ExadataInfrastructureSummaryLifecycleStateEnum = "ACTIVATING"
+	ExadataInfrastructureSummaryLifecycleStateActive             ExadataInfrastructureSummaryLifecycleStateEnum = "ACTIVE"
+	ExadataInfrastructureSummaryLifecycleStateActivationFailed   ExadataInfrastructureSummaryLifecycleStateEnum = "ACTIVATION_FAILED"
+	ExadataInfrastructureSummaryLifecycleStateFailed             ExadataInfrastructureSummaryLifecycleStateEnum = "FAILED"
+	ExadataInfrastructureSummaryLifecycleStateUpdating           ExadataInfrastructureSummaryLifecycleStateEnum = "UPDATING"
+	ExadataInfrastructureSummaryLifecycleStateDeleting           ExadataInfrastructureSummaryLifecycleStateEnum = "DELETING"
+	ExadataInfrastructureSummaryLifecycleStateDeleted            ExadataInfrastructureSummaryLifecycleStateEnum = "DELETED"
+	ExadataInfrastructureSummaryLifecycleStateOffline            ExadataInfrastructureSummaryLifecycleStateEnum = "OFFLINE"
+)
+
+var mappingExadataInfrastructureSummaryLifecycleState = map[string]ExadataInfrastructureSummaryLifecycleStateEnum{
+	"CREATING":            ExadataInfrastructureSummaryLifecycleStateCreating,
+	"REQUIRES_ACTIVATION": ExadataInfrastructureSummaryLifecycleStateRequiresActivation,
+	"ACTIVATING":          ExadataInfrastructureSummaryLifecycleStateActivating,
+	"ACTIVE":              ExadataInfrastructureSummaryLifecycleStateActive,
+	"ACTIVATION_FAILED":   ExadataInfrastructureSummaryLifecycleStateActivationFailed,
+	"FAILED":              ExadataInfrastructureSummaryLifecycleStateFailed,
+	"UPDATING":            ExadataInfrastructureSummaryLifecycleStateUpdating,
+	"DELETING":            ExadataInfrastructureSummaryLifecycleStateDeleting,
+	"DELETED":             ExadataInfrastructureSummaryLifecycleStateDeleted,
+	"OFFLINE":             ExadataInfrastructureSummaryLifecycleStateOffline,
+}
+
+// GetExadataInfrastructureSummaryLifecycleStateEnumValues Enumerates the set of values for ExadataInfrastructureSummaryLifecycleStateEnum
+func GetExadataInfrastructureSummaryLifecycleStateEnumValues() []ExadataInfrastructureSummaryLifecycleStateEnum {
+	values := make([]ExadataInfrastructureSummaryLifecycleStateEnum, 0)
+	for _, v := range mappingExadataInfrastructureSummaryLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/generate_recommended_network_details.go
+++ b/database/generate_recommended_network_details.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// GenerateRecommendedNetworkDetails Generates a recommended VM cluster network configuration.
+type GenerateRecommendedNetworkDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The user-friendly name for the VM cluster network. The name does not need to be unique.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// List of parameters for generation of the client and backup networks.
+	Networks []InfoForNetworkGenDetails `mandatory:"true" json:"networks"`
+
+	// The list of DNS server IP addresses. Maximum of 3 allowed.
+	Dns []string `mandatory:"false" json:"dns"`
+
+	// The list of NTP server IP addresses. Maximum of 3 allowed.
+	Ntp []string `mandatory:"false" json:"ntp"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m GenerateRecommendedNetworkDetails) String() string {
+	return common.PointerString(m)
+}

--- a/database/generate_recommended_vm_cluster_network_request_response.go
+++ b/database/generate_recommended_vm_cluster_network_request_response.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GenerateRecommendedVmClusterNetworkRequest wrapper for the GenerateRecommendedVmClusterNetwork operation
+type GenerateRecommendedVmClusterNetworkRequest struct {
+
+	// The Exadata infrastructure OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	ExadataInfrastructureId *string `mandatory:"true" contributesTo:"path" name:"exadataInfrastructureId"`
+
+	// Request to generate a recommended VM cluster network configuration.
+	GenerateRecommendedNetworkDetails `contributesTo:"body"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GenerateRecommendedVmClusterNetworkRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GenerateRecommendedVmClusterNetworkRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GenerateRecommendedVmClusterNetworkRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GenerateRecommendedVmClusterNetworkResponse wrapper for the GenerateRecommendedVmClusterNetwork operation
+type GenerateRecommendedVmClusterNetworkResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The VmClusterNetworkDetails instance
+	VmClusterNetworkDetails `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GenerateRecommendedVmClusterNetworkResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GenerateRecommendedVmClusterNetworkResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/get_backup_destination_request_response.go
+++ b/database/get_backup_destination_request_response.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetBackupDestinationRequest wrapper for the GetBackupDestination operation
+type GetBackupDestinationRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup destination.
+	BackupDestinationId *string `mandatory:"true" contributesTo:"path" name:"backupDestinationId"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetBackupDestinationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetBackupDestinationRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetBackupDestinationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetBackupDestinationResponse wrapper for the GetBackupDestination operation
+type GetBackupDestinationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The BackupDestination instance
+	BackupDestination `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetBackupDestinationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetBackupDestinationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/get_exadata_infrastructure_request_response.go
+++ b/database/get_exadata_infrastructure_request_response.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetExadataInfrastructureRequest wrapper for the GetExadataInfrastructure operation
+type GetExadataInfrastructureRequest struct {
+
+	// The Exadata infrastructure OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	ExadataInfrastructureId *string `mandatory:"true" contributesTo:"path" name:"exadataInfrastructureId"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetExadataInfrastructureRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetExadataInfrastructureRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetExadataInfrastructureRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetExadataInfrastructureResponse wrapper for the GetExadataInfrastructure operation
+type GetExadataInfrastructureResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ExadataInfrastructure instance
+	ExadataInfrastructure `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetExadataInfrastructureResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetExadataInfrastructureResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/get_vm_cluster_network_request_response.go
+++ b/database/get_vm_cluster_network_request_response.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetVmClusterNetworkRequest wrapper for the GetVmClusterNetwork operation
+type GetVmClusterNetworkRequest struct {
+
+	// The Exadata infrastructure OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	ExadataInfrastructureId *string `mandatory:"true" contributesTo:"path" name:"exadataInfrastructureId"`
+
+	// The VM cluster network OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	VmClusterNetworkId *string `mandatory:"true" contributesTo:"path" name:"vmClusterNetworkId"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetVmClusterNetworkRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetVmClusterNetworkRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetVmClusterNetworkRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetVmClusterNetworkResponse wrapper for the GetVmClusterNetwork operation
+type GetVmClusterNetworkResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The VmClusterNetwork instance
+	VmClusterNetwork `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetVmClusterNetworkResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetVmClusterNetworkResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/get_vm_cluster_request_response.go
+++ b/database/get_vm_cluster_request_response.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetVmClusterRequest wrapper for the GetVmCluster operation
+type GetVmClusterRequest struct {
+
+	// The VM cluster OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	VmClusterId *string `mandatory:"true" contributesTo:"path" name:"vmClusterId"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetVmClusterRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetVmClusterRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetVmClusterRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetVmClusterResponse wrapper for the GetVmCluster operation
+type GetVmClusterResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The VmCluster instance
+	VmCluster `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetVmClusterResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetVmClusterResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/gi_version_summary.go
+++ b/database/gi_version_summary.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// GiVersionSummary The Oracle Grid Infrastructure (GI) version.
+// To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized, talk to an administrator. If you're an administrator who needs to write policies to give users access, see Getting Started with Policies (https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+type GiVersionSummary struct {
+
+	// A valid Oracle Grid Infrastructure (GI) software version.
+	Version *string `mandatory:"true" json:"version"`
+}
+
+func (m GiVersionSummary) String() string {
+	return common.PointerString(m)
+}

--- a/database/info_for_network_gen_details.go
+++ b/database/info_for_network_gen_details.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// InfoForNetworkGenDetails Parameters for generation of the client or backup network in a VM cluster network.
+type InfoForNetworkGenDetails struct {
+
+	// The network type.
+	NetworkType InfoForNetworkGenDetailsNetworkTypeEnum `mandatory:"true" json:"networkType"`
+
+	// The network VLAN ID.
+	VlanId *string `mandatory:"true" json:"vlanId"`
+
+	// The cidr for the network.
+	Cidr *string `mandatory:"true" json:"cidr"`
+
+	// The network gateway.
+	Gateway *string `mandatory:"true" json:"gateway"`
+
+	// The network netmask.
+	Netmask *string `mandatory:"true" json:"netmask"`
+
+	// The network domain name.
+	Domain *string `mandatory:"true" json:"domain"`
+
+	// The network domain name.
+	Prefix *string `mandatory:"true" json:"prefix"`
+}
+
+func (m InfoForNetworkGenDetails) String() string {
+	return common.PointerString(m)
+}
+
+// InfoForNetworkGenDetailsNetworkTypeEnum Enum with underlying type: string
+type InfoForNetworkGenDetailsNetworkTypeEnum string
+
+// Set of constants representing the allowable values for InfoForNetworkGenDetailsNetworkTypeEnum
+const (
+	InfoForNetworkGenDetailsNetworkTypeClient InfoForNetworkGenDetailsNetworkTypeEnum = "CLIENT"
+	InfoForNetworkGenDetailsNetworkTypeBackup InfoForNetworkGenDetailsNetworkTypeEnum = "BACKUP"
+)
+
+var mappingInfoForNetworkGenDetailsNetworkType = map[string]InfoForNetworkGenDetailsNetworkTypeEnum{
+	"CLIENT": InfoForNetworkGenDetailsNetworkTypeClient,
+	"BACKUP": InfoForNetworkGenDetailsNetworkTypeBackup,
+}
+
+// GetInfoForNetworkGenDetailsNetworkTypeEnumValues Enumerates the set of values for InfoForNetworkGenDetailsNetworkTypeEnum
+func GetInfoForNetworkGenDetailsNetworkTypeEnumValues() []InfoForNetworkGenDetailsNetworkTypeEnum {
+	values := make([]InfoForNetworkGenDetailsNetworkTypeEnum, 0)
+	for _, v := range mappingInfoForNetworkGenDetailsNetworkType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/list_backup_destination_request_response.go
+++ b/database/list_backup_destination_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListBackupDestinationRequest wrapper for the ListBackupDestination operation
+type ListBackupDestinationRequest struct {
+
+	// The compartment OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The maximum number of items to return per page.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The pagination token to continue listing from.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A filter to return only resources that match the given type of the Backup Destination.
+	Type *string `mandatory:"false" contributesTo:"query" name:"type"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListBackupDestinationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListBackupDestinationRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListBackupDestinationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListBackupDestinationResponse wrapper for the ListBackupDestination operation
+type ListBackupDestinationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []BackupDestinationSummary instances
+	Items []BackupDestinationSummary `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListBackupDestinationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListBackupDestinationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/list_db_homes_request_response.go
+++ b/database/list_db_homes_request_response.go
@@ -17,6 +17,9 @@ type ListDbHomesRequest struct {
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the DB system.
 	DbSystemId *string `mandatory:"false" contributesTo:"query" name:"dbSystemId"`
 
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster.
+	VmClusterId *string `mandatory:"false" contributesTo:"query" name:"vmClusterId"`
+
 	// The maximum number of items to return per page.
 	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
 

--- a/database/list_db_nodes_request_response.go
+++ b/database/list_db_nodes_request_response.go
@@ -17,6 +17,9 @@ type ListDbNodesRequest struct {
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the DB system.
 	DbSystemId *string `mandatory:"false" contributesTo:"query" name:"dbSystemId"`
 
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster.
+	VmClusterId *string `mandatory:"false" contributesTo:"query" name:"vmClusterId"`
+
 	// The maximum number of items to return per page.
 	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
 

--- a/database/list_db_system_shapes_request_response.go
+++ b/database/list_db_system_shapes_request_response.go
@@ -11,11 +11,11 @@ import (
 // ListDbSystemShapesRequest wrapper for the ListDbSystemShapes operation
 type ListDbSystemShapesRequest struct {
 
-	// The name of the Availability Domain.
-	AvailabilityDomain *string `mandatory:"true" contributesTo:"query" name:"availabilityDomain"`
-
 	// The compartment OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The name of the Availability Domain.
+	AvailabilityDomain *string `mandatory:"false" contributesTo:"query" name:"availabilityDomain"`
 
 	// The maximum number of items to return per page.
 	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`

--- a/database/list_exadata_infrastructures_request_response.go
+++ b/database/list_exadata_infrastructures_request_response.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListExadataInfrastructuresRequest wrapper for the ListExadataInfrastructures operation
+type ListExadataInfrastructuresRequest struct {
+
+	// The compartment OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The maximum number of items to return per page.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The pagination token to continue listing from.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The field to sort by.  You can provide one sort order (`sortOrder`).  Default order for TIMECREATED is descending.  Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+	SortBy ListExadataInfrastructuresSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+	SortOrder ListExadataInfrastructuresSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// A filter to return only resources that match the given lifecycle state exactly.
+	LifecycleState ExadataInfrastructureSummaryLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+
+	// A filter to return only resources that match the entire display name given. The match is not case sensitive.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListExadataInfrastructuresRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListExadataInfrastructuresRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListExadataInfrastructuresRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListExadataInfrastructuresResponse wrapper for the ListExadataInfrastructures operation
+type ListExadataInfrastructuresResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []ExadataInfrastructureSummary instances
+	Items []ExadataInfrastructureSummary `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then there are additional items still to get. Include this value as the `page` parameter for the
+	// subsequent GET request. For information about pagination, see
+	// List Pagination (https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListExadataInfrastructuresResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListExadataInfrastructuresResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListExadataInfrastructuresSortByEnum Enum with underlying type: string
+type ListExadataInfrastructuresSortByEnum string
+
+// Set of constants representing the allowable values for ListExadataInfrastructuresSortByEnum
+const (
+	ListExadataInfrastructuresSortByTimecreated ListExadataInfrastructuresSortByEnum = "TIMECREATED"
+	ListExadataInfrastructuresSortByDisplayname ListExadataInfrastructuresSortByEnum = "DISPLAYNAME"
+)
+
+var mappingListExadataInfrastructuresSortBy = map[string]ListExadataInfrastructuresSortByEnum{
+	"TIMECREATED": ListExadataInfrastructuresSortByTimecreated,
+	"DISPLAYNAME": ListExadataInfrastructuresSortByDisplayname,
+}
+
+// GetListExadataInfrastructuresSortByEnumValues Enumerates the set of values for ListExadataInfrastructuresSortByEnum
+func GetListExadataInfrastructuresSortByEnumValues() []ListExadataInfrastructuresSortByEnum {
+	values := make([]ListExadataInfrastructuresSortByEnum, 0)
+	for _, v := range mappingListExadataInfrastructuresSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListExadataInfrastructuresSortOrderEnum Enum with underlying type: string
+type ListExadataInfrastructuresSortOrderEnum string
+
+// Set of constants representing the allowable values for ListExadataInfrastructuresSortOrderEnum
+const (
+	ListExadataInfrastructuresSortOrderAsc  ListExadataInfrastructuresSortOrderEnum = "ASC"
+	ListExadataInfrastructuresSortOrderDesc ListExadataInfrastructuresSortOrderEnum = "DESC"
+)
+
+var mappingListExadataInfrastructuresSortOrder = map[string]ListExadataInfrastructuresSortOrderEnum{
+	"ASC":  ListExadataInfrastructuresSortOrderAsc,
+	"DESC": ListExadataInfrastructuresSortOrderDesc,
+}
+
+// GetListExadataInfrastructuresSortOrderEnumValues Enumerates the set of values for ListExadataInfrastructuresSortOrderEnum
+func GetListExadataInfrastructuresSortOrderEnumValues() []ListExadataInfrastructuresSortOrderEnum {
+	values := make([]ListExadataInfrastructuresSortOrderEnum, 0)
+	for _, v := range mappingListExadataInfrastructuresSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/list_gi_versions_request_response.go
+++ b/database/list_gi_versions_request_response.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListGiVersionsRequest wrapper for the ListGiVersions operation
+type ListGiVersionsRequest struct {
+
+	// The compartment OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The maximum number of items to return per page.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The pagination token to continue listing from.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+	SortOrder ListGiVersionsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// If provided, filters the results for the given shape.
+	Shape *string `mandatory:"false" contributesTo:"query" name:"shape"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListGiVersionsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListGiVersionsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListGiVersionsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListGiVersionsResponse wrapper for the ListGiVersions operation
+type ListGiVersionsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []GiVersionSummary instances
+	Items []GiVersionSummary `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then there are additional items still to get. Include this value as the `page` parameter for the
+	// subsequent GET request. For information about pagination, see
+	// List Pagination (https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListGiVersionsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListGiVersionsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListGiVersionsSortOrderEnum Enum with underlying type: string
+type ListGiVersionsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListGiVersionsSortOrderEnum
+const (
+	ListGiVersionsSortOrderAsc  ListGiVersionsSortOrderEnum = "ASC"
+	ListGiVersionsSortOrderDesc ListGiVersionsSortOrderEnum = "DESC"
+)
+
+var mappingListGiVersionsSortOrder = map[string]ListGiVersionsSortOrderEnum{
+	"ASC":  ListGiVersionsSortOrderAsc,
+	"DESC": ListGiVersionsSortOrderDesc,
+}
+
+// GetListGiVersionsSortOrderEnumValues Enumerates the set of values for ListGiVersionsSortOrderEnum
+func GetListGiVersionsSortOrderEnumValues() []ListGiVersionsSortOrderEnum {
+	values := make([]ListGiVersionsSortOrderEnum, 0)
+	for _, v := range mappingListGiVersionsSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/list_vm_cluster_networks_request_response.go
+++ b/database/list_vm_cluster_networks_request_response.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListVmClusterNetworksRequest wrapper for the ListVmClusterNetworks operation
+type ListVmClusterNetworksRequest struct {
+
+	// The Exadata infrastructure OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	ExadataInfrastructureId *string `mandatory:"true" contributesTo:"path" name:"exadataInfrastructureId"`
+
+	// The compartment OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The maximum number of items to return per page.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The pagination token to continue listing from.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The field to sort by.  You can provide one sort order (`sortOrder`).  Default order for TIMECREATED is descending.  Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+	SortBy ListVmClusterNetworksSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+	SortOrder ListVmClusterNetworksSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// A filter to return only resources that match the given lifecycle state exactly.
+	LifecycleState VmClusterNetworkSummaryLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+
+	// A filter to return only resources that match the entire display name given. The match is not case sensitive.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListVmClusterNetworksRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListVmClusterNetworksRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListVmClusterNetworksRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListVmClusterNetworksResponse wrapper for the ListVmClusterNetworks operation
+type ListVmClusterNetworksResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []VmClusterNetworkSummary instances
+	Items []VmClusterNetworkSummary `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then there are additional items still to get. Include this value as the `page` parameter for the
+	// subsequent GET request. For information about pagination, see
+	// List Pagination (https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListVmClusterNetworksResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListVmClusterNetworksResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListVmClusterNetworksSortByEnum Enum with underlying type: string
+type ListVmClusterNetworksSortByEnum string
+
+// Set of constants representing the allowable values for ListVmClusterNetworksSortByEnum
+const (
+	ListVmClusterNetworksSortByTimecreated ListVmClusterNetworksSortByEnum = "TIMECREATED"
+	ListVmClusterNetworksSortByDisplayname ListVmClusterNetworksSortByEnum = "DISPLAYNAME"
+)
+
+var mappingListVmClusterNetworksSortBy = map[string]ListVmClusterNetworksSortByEnum{
+	"TIMECREATED": ListVmClusterNetworksSortByTimecreated,
+	"DISPLAYNAME": ListVmClusterNetworksSortByDisplayname,
+}
+
+// GetListVmClusterNetworksSortByEnumValues Enumerates the set of values for ListVmClusterNetworksSortByEnum
+func GetListVmClusterNetworksSortByEnumValues() []ListVmClusterNetworksSortByEnum {
+	values := make([]ListVmClusterNetworksSortByEnum, 0)
+	for _, v := range mappingListVmClusterNetworksSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListVmClusterNetworksSortOrderEnum Enum with underlying type: string
+type ListVmClusterNetworksSortOrderEnum string
+
+// Set of constants representing the allowable values for ListVmClusterNetworksSortOrderEnum
+const (
+	ListVmClusterNetworksSortOrderAsc  ListVmClusterNetworksSortOrderEnum = "ASC"
+	ListVmClusterNetworksSortOrderDesc ListVmClusterNetworksSortOrderEnum = "DESC"
+)
+
+var mappingListVmClusterNetworksSortOrder = map[string]ListVmClusterNetworksSortOrderEnum{
+	"ASC":  ListVmClusterNetworksSortOrderAsc,
+	"DESC": ListVmClusterNetworksSortOrderDesc,
+}
+
+// GetListVmClusterNetworksSortOrderEnumValues Enumerates the set of values for ListVmClusterNetworksSortOrderEnum
+func GetListVmClusterNetworksSortOrderEnumValues() []ListVmClusterNetworksSortOrderEnum {
+	values := make([]ListVmClusterNetworksSortOrderEnum, 0)
+	for _, v := range mappingListVmClusterNetworksSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/list_vm_clusters_request_response.go
+++ b/database/list_vm_clusters_request_response.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListVmClustersRequest wrapper for the ListVmClusters operation
+type ListVmClustersRequest struct {
+
+	// The compartment OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// If provided, filters the results for the given Exadata Infrastructure.
+	ExadataInfrastructureId *string `mandatory:"false" contributesTo:"query" name:"exadataInfrastructureId"`
+
+	// The maximum number of items to return per page.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The pagination token to continue listing from.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The field to sort by.  You can provide one sort order (`sortOrder`).  Default order for TIMECREATED is descending.  Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+	SortBy ListVmClustersSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+	SortOrder ListVmClustersSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// A filter to return only resources that match the given lifecycle state exactly.
+	LifecycleState VmClusterSummaryLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+
+	// A filter to return only resources that match the entire display name given. The match is not case sensitive.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListVmClustersRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListVmClustersRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListVmClustersRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListVmClustersResponse wrapper for the ListVmClusters operation
+type ListVmClustersResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []VmClusterSummary instances
+	Items []VmClusterSummary `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then there are additional items still to get. Include this value as the `page` parameter for the
+	// subsequent GET request. For information about pagination, see
+	// List Pagination (https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListVmClustersResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListVmClustersResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListVmClustersSortByEnum Enum with underlying type: string
+type ListVmClustersSortByEnum string
+
+// Set of constants representing the allowable values for ListVmClustersSortByEnum
+const (
+	ListVmClustersSortByTimecreated ListVmClustersSortByEnum = "TIMECREATED"
+	ListVmClustersSortByDisplayname ListVmClustersSortByEnum = "DISPLAYNAME"
+)
+
+var mappingListVmClustersSortBy = map[string]ListVmClustersSortByEnum{
+	"TIMECREATED": ListVmClustersSortByTimecreated,
+	"DISPLAYNAME": ListVmClustersSortByDisplayname,
+}
+
+// GetListVmClustersSortByEnumValues Enumerates the set of values for ListVmClustersSortByEnum
+func GetListVmClustersSortByEnumValues() []ListVmClustersSortByEnum {
+	values := make([]ListVmClustersSortByEnum, 0)
+	for _, v := range mappingListVmClustersSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListVmClustersSortOrderEnum Enum with underlying type: string
+type ListVmClustersSortOrderEnum string
+
+// Set of constants representing the allowable values for ListVmClustersSortOrderEnum
+const (
+	ListVmClustersSortOrderAsc  ListVmClustersSortOrderEnum = "ASC"
+	ListVmClustersSortOrderDesc ListVmClustersSortOrderEnum = "DESC"
+)
+
+var mappingListVmClustersSortOrder = map[string]ListVmClustersSortOrderEnum{
+	"ASC":  ListVmClustersSortOrderAsc,
+	"DESC": ListVmClustersSortOrderDesc,
+}
+
+// GetListVmClustersSortOrderEnumValues Enumerates the set of values for ListVmClustersSortOrderEnum
+func GetListVmClustersSortOrderEnumValues() []ListVmClustersSortOrderEnum {
+	values := make([]ListVmClustersSortOrderEnum, 0)
+	for _, v := range mappingListVmClustersSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/node_details.go
+++ b/database/node_details.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// NodeDetails Node details associated with a network.
+type NodeDetails struct {
+
+	// The node IP address.
+	Ip *string `mandatory:"true" json:"ip"`
+
+	// The node host name.
+	Hostname *string `mandatory:"false" json:"hostname"`
+
+	// The node virtual IP (VIP) host name.
+	VipHostname *string `mandatory:"false" json:"vipHostname"`
+
+	// The node virtual IP (VIP) address.
+	Vip *string `mandatory:"false" json:"vip"`
+}
+
+func (m NodeDetails) String() string {
+	return common.PointerString(m)
+}

--- a/database/scan_details.go
+++ b/database/scan_details.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ScanDetails The Single Client Access Name (SCAN) details.
+type ScanDetails struct {
+
+	// The SCAN hostname.
+	Hostname *string `mandatory:"true" json:"hostname"`
+
+	// The SCAN port. Default is 1521.
+	Port *int `mandatory:"true" json:"port"`
+
+	// The list of SCAN IP addresses. Three addresses should be provided.
+	Ips []string `mandatory:"true" json:"ips"`
+}
+
+func (m ScanDetails) String() string {
+	return common.PointerString(m)
+}

--- a/database/update_backup_destination_details.go
+++ b/database/update_backup_destination_details.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateBackupDestinationDetails For a RECOVERY_APPLIANCE backup destination, used to update the connection string and/or the list of VPC users.
+// For an NFS backup destination, used to update the NFS location.
+type UpdateBackupDestinationDetails struct {
+
+	// For a RECOVERY_APPLIANCE backup destination, the Virtual Private Catalog (VPC) users that are used to access the Recovery Appliance.
+	VpcUsers []string `mandatory:"false" json:"vpcUsers"`
+
+	// For a RECOVERY_APPLIANCE backup destination, the connection string for connecting to the Recovery Appliance.
+	ConnectionString *string `mandatory:"false" json:"connectionString"`
+
+	// The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
+	LocalMountPointPath *string `mandatory:"false" json:"localMountPointPath"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m UpdateBackupDestinationDetails) String() string {
+	return common.PointerString(m)
+}

--- a/database/update_backup_destination_request_response.go
+++ b/database/update_backup_destination_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateBackupDestinationRequest wrapper for the UpdateBackupDestination operation
+type UpdateBackupDestinationRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup destination.
+	BackupDestinationId *string `mandatory:"true" contributesTo:"path" name:"backupDestinationId"`
+
+	// For a RECOVERY_APPLIANCE backup destination, request to update the connection string and/or the list of VPC users.
+	// For an NFS backup destination, request to update the NFS location.
+	UpdateBackupDestinationDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateBackupDestinationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateBackupDestinationRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateBackupDestinationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateBackupDestinationResponse wrapper for the UpdateBackupDestination operation
+type UpdateBackupDestinationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The BackupDestination instance
+	BackupDestination `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateBackupDestinationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateBackupDestinationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/update_exadata_infrastructure_details.go
+++ b/database/update_exadata_infrastructure_details.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateExadataInfrastructureDetails Updates the Exadata infrastructure.
+type UpdateExadataInfrastructureDetails struct {
+
+	// The IP address for the first control plane server.
+	CloudControlPlaneServer1 *string `mandatory:"false" json:"cloudControlPlaneServer1"`
+
+	// The IP address for the second control plane server.
+	CloudControlPlaneServer2 *string `mandatory:"false" json:"cloudControlPlaneServer2"`
+
+	// The netmask for the control plane network.
+	Netmask *string `mandatory:"false" json:"netmask"`
+
+	// The gateway for the control plane network.
+	Gateway *string `mandatory:"false" json:"gateway"`
+
+	// The CIDR block for the Exadata administration network.
+	AdminNetworkCIDR *string `mandatory:"false" json:"adminNetworkCIDR"`
+
+	// The CIDR block for the Exadata InfiniBand interconnect.
+	InfiniBandNetworkCIDR *string `mandatory:"false" json:"infiniBandNetworkCIDR"`
+
+	// The corporate network proxy for access to the control plane network.
+	CorporateProxy *string `mandatory:"false" json:"corporateProxy"`
+
+	// The list of DNS server IP addresses. Maximum of 3 allowed.
+	DnsServer []string `mandatory:"false" json:"dnsServer"`
+
+	// The list of NTP server IP addresses. Maximum of 3 allowed.
+	NtpServer []string `mandatory:"false" json:"ntpServer"`
+
+	// The time zone of the Exadata infrastructure. For details, see Exadata Infrastructure Time Zones (https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
+	TimeZone *string `mandatory:"false" json:"timeZone"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m UpdateExadataInfrastructureDetails) String() string {
+	return common.PointerString(m)
+}

--- a/database/update_exadata_infrastructure_request_response.go
+++ b/database/update_exadata_infrastructure_request_response.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateExadataInfrastructureRequest wrapper for the UpdateExadataInfrastructure operation
+type UpdateExadataInfrastructureRequest struct {
+
+	// The Exadata infrastructure OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	ExadataInfrastructureId *string `mandatory:"true" contributesTo:"path" name:"exadataInfrastructureId"`
+
+	// Request to update the properties of an Exadata infrastructure
+	UpdateExadataInfrastructureDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateExadataInfrastructureRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateExadataInfrastructureRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateExadataInfrastructureRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateExadataInfrastructureResponse wrapper for the UpdateExadataInfrastructure operation
+type UpdateExadataInfrastructureResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ExadataInfrastructure instance
+	ExadataInfrastructure `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateExadataInfrastructureResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateExadataInfrastructureResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/update_vm_cluster_details.go
+++ b/database/update_vm_cluster_details.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateVmClusterDetails Details for updating the VM cluster.
+type UpdateVmClusterDetails struct {
+
+	// The number of CPU cores to enable for the VM cluster.
+	CpuCoreCount *int `mandatory:"false" json:"cpuCoreCount"`
+
+	// The Oracle license model that applies to the VM cluster. The default is BRING_YOUR_OWN_LICENSE.
+	LicenseModel UpdateVmClusterDetailsLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
+
+	// The public key portion of one or more key pairs used for SSH access to the VM cluster.
+	SshPublicKeys []string `mandatory:"false" json:"sshPublicKeys"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m UpdateVmClusterDetails) String() string {
+	return common.PointerString(m)
+}
+
+// UpdateVmClusterDetailsLicenseModelEnum Enum with underlying type: string
+type UpdateVmClusterDetailsLicenseModelEnum string
+
+// Set of constants representing the allowable values for UpdateVmClusterDetailsLicenseModelEnum
+const (
+	UpdateVmClusterDetailsLicenseModelLicenseIncluded     UpdateVmClusterDetailsLicenseModelEnum = "LICENSE_INCLUDED"
+	UpdateVmClusterDetailsLicenseModelBringYourOwnLicense UpdateVmClusterDetailsLicenseModelEnum = "BRING_YOUR_OWN_LICENSE"
+)
+
+var mappingUpdateVmClusterDetailsLicenseModel = map[string]UpdateVmClusterDetailsLicenseModelEnum{
+	"LICENSE_INCLUDED":       UpdateVmClusterDetailsLicenseModelLicenseIncluded,
+	"BRING_YOUR_OWN_LICENSE": UpdateVmClusterDetailsLicenseModelBringYourOwnLicense,
+}
+
+// GetUpdateVmClusterDetailsLicenseModelEnumValues Enumerates the set of values for UpdateVmClusterDetailsLicenseModelEnum
+func GetUpdateVmClusterDetailsLicenseModelEnumValues() []UpdateVmClusterDetailsLicenseModelEnum {
+	values := make([]UpdateVmClusterDetailsLicenseModelEnum, 0)
+	for _, v := range mappingUpdateVmClusterDetailsLicenseModel {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/update_vm_cluster_network_details.go
+++ b/database/update_vm_cluster_network_details.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateVmClusterNetworkDetails Details for a VM cluster network.
+type UpdateVmClusterNetworkDetails struct {
+
+	// The SCAN details.
+	Scans []ScanDetails `mandatory:"false" json:"scans"`
+
+	// The list of DNS server IP addresses. Maximum of 3 allowed.
+	Dns []string `mandatory:"false" json:"dns"`
+
+	// The list of NTP server IP addresses. Maximum of 3 allowed.
+	Ntp []string `mandatory:"false" json:"ntp"`
+
+	// Details of the client and backup networks.
+	VmNetworks []VmNetworkDetails `mandatory:"false" json:"vmNetworks"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m UpdateVmClusterNetworkDetails) String() string {
+	return common.PointerString(m)
+}

--- a/database/update_vm_cluster_network_request_response.go
+++ b/database/update_vm_cluster_network_request_response.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateVmClusterNetworkRequest wrapper for the UpdateVmClusterNetwork operation
+type UpdateVmClusterNetworkRequest struct {
+
+	// The Exadata infrastructure OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	ExadataInfrastructureId *string `mandatory:"true" contributesTo:"path" name:"exadataInfrastructureId"`
+
+	// The VM cluster network OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	VmClusterNetworkId *string `mandatory:"true" contributesTo:"path" name:"vmClusterNetworkId"`
+
+	// Request to update the properties of a VM cluster network.
+	UpdateVmClusterNetworkDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateVmClusterNetworkRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateVmClusterNetworkRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateVmClusterNetworkRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateVmClusterNetworkResponse wrapper for the UpdateVmClusterNetwork operation
+type UpdateVmClusterNetworkResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The VmClusterNetwork instance
+	VmClusterNetwork `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateVmClusterNetworkResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateVmClusterNetworkResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/update_vm_cluster_request_response.go
+++ b/database/update_vm_cluster_request_response.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateVmClusterRequest wrapper for the UpdateVmCluster operation
+type UpdateVmClusterRequest struct {
+
+	// The VM cluster OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	VmClusterId *string `mandatory:"true" contributesTo:"path" name:"vmClusterId"`
+
+	// Request to update the attributes of a VM cluster.
+	UpdateVmClusterDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateVmClusterRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateVmClusterRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateVmClusterRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateVmClusterResponse wrapper for the UpdateVmCluster operation
+type UpdateVmClusterResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The VmCluster instance
+	VmCluster `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateVmClusterResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateVmClusterResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/validate_vm_cluster_network_request_response.go
+++ b/database/validate_vm_cluster_network_request_response.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ValidateVmClusterNetworkRequest wrapper for the ValidateVmClusterNetwork operation
+type ValidateVmClusterNetworkRequest struct {
+
+	// The Exadata infrastructure OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	ExadataInfrastructureId *string `mandatory:"true" contributesTo:"path" name:"exadataInfrastructureId"`
+
+	// The VM cluster network OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	VmClusterNetworkId *string `mandatory:"true" contributesTo:"path" name:"vmClusterNetworkId"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ValidateVmClusterNetworkRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ValidateVmClusterNetworkRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ValidateVmClusterNetworkRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateVmClusterNetworkResponse wrapper for the ValidateVmClusterNetwork operation
+type ValidateVmClusterNetworkResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The VmClusterNetwork instance
+	VmClusterNetwork `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ValidateVmClusterNetworkResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ValidateVmClusterNetworkResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/vm_cluster.go
+++ b/database/vm_cluster.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// VmCluster Details of the VM cluster.
+type VmCluster struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The current state of the VM cluster.
+	LifecycleState VmClusterLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// The user-friendly name for the VM cluster. The name does not need to be unique.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// The date and time that the VM cluster was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// Additional information about the current lifecycle state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The time zone of the Exadata infrastructure. For details, see Exadata Infrastructure Time Zones (https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
+	TimeZone *string `mandatory:"false" json:"timeZone"`
+
+	// If true, database backup on local Exadata storage is configured for the VM cluster. If false, database backup on local Exadata storage is not available in the VM cluster.
+	IsLocalBackupEnabled *bool `mandatory:"false" json:"isLocalBackupEnabled"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+	ExadataInfrastructureId *string `mandatory:"false" json:"exadataInfrastructureId"`
+
+	// If true, sparse disk group is configured for the VM cluster. If false, sparse disk group is not created.
+	IsSparseDiskgroupEnabled *bool `mandatory:"false" json:"isSparseDiskgroupEnabled"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster network.
+	VmClusterNetworkId *string `mandatory:"false" json:"vmClusterNetworkId"`
+
+	// The number of enabled CPU cores.
+	CpusEnabled *int `mandatory:"false" json:"cpusEnabled"`
+
+	// Size, in terabytes, of the DATA disk group.
+	DataStorageSizeInTBs *int `mandatory:"false" json:"dataStorageSizeInTBs"`
+
+	// The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+	Shape *string `mandatory:"false" json:"shape"`
+
+	// The Oracle Grid Infrastructure software version for the VM cluster.
+	GiVersion *string `mandatory:"false" json:"giVersion"`
+
+	// The public key portion of one or more key pairs used for SSH access to the VM cluster.
+	SshPublicKeys []string `mandatory:"false" json:"sshPublicKeys"`
+
+	// The Oracle license model that applies to the VM cluster. The default is LICENSE_INCLUDED.
+	LicenseModel VmClusterLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m VmCluster) String() string {
+	return common.PointerString(m)
+}
+
+// VmClusterLifecycleStateEnum Enum with underlying type: string
+type VmClusterLifecycleStateEnum string
+
+// Set of constants representing the allowable values for VmClusterLifecycleStateEnum
+const (
+	VmClusterLifecycleStateProvisioning VmClusterLifecycleStateEnum = "PROVISIONING"
+	VmClusterLifecycleStateAvailable    VmClusterLifecycleStateEnum = "AVAILABLE"
+	VmClusterLifecycleStateUpdating     VmClusterLifecycleStateEnum = "UPDATING"
+	VmClusterLifecycleStateTerminating  VmClusterLifecycleStateEnum = "TERMINATING"
+	VmClusterLifecycleStateTerminated   VmClusterLifecycleStateEnum = "TERMINATED"
+	VmClusterLifecycleStateFailed       VmClusterLifecycleStateEnum = "FAILED"
+)
+
+var mappingVmClusterLifecycleState = map[string]VmClusterLifecycleStateEnum{
+	"PROVISIONING": VmClusterLifecycleStateProvisioning,
+	"AVAILABLE":    VmClusterLifecycleStateAvailable,
+	"UPDATING":     VmClusterLifecycleStateUpdating,
+	"TERMINATING":  VmClusterLifecycleStateTerminating,
+	"TERMINATED":   VmClusterLifecycleStateTerminated,
+	"FAILED":       VmClusterLifecycleStateFailed,
+}
+
+// GetVmClusterLifecycleStateEnumValues Enumerates the set of values for VmClusterLifecycleStateEnum
+func GetVmClusterLifecycleStateEnumValues() []VmClusterLifecycleStateEnum {
+	values := make([]VmClusterLifecycleStateEnum, 0)
+	for _, v := range mappingVmClusterLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}
+
+// VmClusterLicenseModelEnum Enum with underlying type: string
+type VmClusterLicenseModelEnum string
+
+// Set of constants representing the allowable values for VmClusterLicenseModelEnum
+const (
+	VmClusterLicenseModelLicenseIncluded     VmClusterLicenseModelEnum = "LICENSE_INCLUDED"
+	VmClusterLicenseModelBringYourOwnLicense VmClusterLicenseModelEnum = "BRING_YOUR_OWN_LICENSE"
+)
+
+var mappingVmClusterLicenseModel = map[string]VmClusterLicenseModelEnum{
+	"LICENSE_INCLUDED":       VmClusterLicenseModelLicenseIncluded,
+	"BRING_YOUR_OWN_LICENSE": VmClusterLicenseModelBringYourOwnLicense,
+}
+
+// GetVmClusterLicenseModelEnumValues Enumerates the set of values for VmClusterLicenseModelEnum
+func GetVmClusterLicenseModelEnumValues() []VmClusterLicenseModelEnum {
+	values := make([]VmClusterLicenseModelEnum, 0)
+	for _, v := range mappingVmClusterLicenseModel {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/vm_cluster_network.go
+++ b/database/vm_cluster_network.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// VmClusterNetwork The VM cluster network.
+type VmClusterNetwork struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster network.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+	ExadataInfrastructureId *string `mandatory:"false" json:"exadataInfrastructureId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the associated VM Cluster.
+	VmClusterId *string `mandatory:"false" json:"vmClusterId"`
+
+	// The user-friendly name for the VM cluster network. The name does not need to be unique.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// The SCAN details.
+	Scans []ScanDetails `mandatory:"false" json:"scans"`
+
+	// The list of DNS server IP addresses. Maximum of 3 allowed.
+	Dns []string `mandatory:"false" json:"dns"`
+
+	// The list of NTP server IP addresses. Maximum of 3 allowed.
+	Ntp []string `mandatory:"false" json:"ntp"`
+
+	// Details of the client and backup networks.
+	VmNetworks []VmNetworkDetails `mandatory:"false" json:"vmNetworks"`
+
+	// The current state of the VM cluster network.
+	LifecycleState VmClusterNetworkLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// The date and time when the VM cluster network was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// Additional information about the current lifecycle state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m VmClusterNetwork) String() string {
+	return common.PointerString(m)
+}
+
+// VmClusterNetworkLifecycleStateEnum Enum with underlying type: string
+type VmClusterNetworkLifecycleStateEnum string
+
+// Set of constants representing the allowable values for VmClusterNetworkLifecycleStateEnum
+const (
+	VmClusterNetworkLifecycleStateCreating           VmClusterNetworkLifecycleStateEnum = "CREATING"
+	VmClusterNetworkLifecycleStateRequiresValidation VmClusterNetworkLifecycleStateEnum = "REQUIRES_VALIDATION"
+	VmClusterNetworkLifecycleStateValidating         VmClusterNetworkLifecycleStateEnum = "VALIDATING"
+	VmClusterNetworkLifecycleStateValidated          VmClusterNetworkLifecycleStateEnum = "VALIDATED"
+	VmClusterNetworkLifecycleStateValidationFailed   VmClusterNetworkLifecycleStateEnum = "VALIDATION_FAILED"
+	VmClusterNetworkLifecycleStateUpdating           VmClusterNetworkLifecycleStateEnum = "UPDATING"
+	VmClusterNetworkLifecycleStateAllocated          VmClusterNetworkLifecycleStateEnum = "ALLOCATED"
+	VmClusterNetworkLifecycleStateTerminating        VmClusterNetworkLifecycleStateEnum = "TERMINATING"
+	VmClusterNetworkLifecycleStateTerminated         VmClusterNetworkLifecycleStateEnum = "TERMINATED"
+	VmClusterNetworkLifecycleStateFailed             VmClusterNetworkLifecycleStateEnum = "FAILED"
+)
+
+var mappingVmClusterNetworkLifecycleState = map[string]VmClusterNetworkLifecycleStateEnum{
+	"CREATING":            VmClusterNetworkLifecycleStateCreating,
+	"REQUIRES_VALIDATION": VmClusterNetworkLifecycleStateRequiresValidation,
+	"VALIDATING":          VmClusterNetworkLifecycleStateValidating,
+	"VALIDATED":           VmClusterNetworkLifecycleStateValidated,
+	"VALIDATION_FAILED":   VmClusterNetworkLifecycleStateValidationFailed,
+	"UPDATING":            VmClusterNetworkLifecycleStateUpdating,
+	"ALLOCATED":           VmClusterNetworkLifecycleStateAllocated,
+	"TERMINATING":         VmClusterNetworkLifecycleStateTerminating,
+	"TERMINATED":          VmClusterNetworkLifecycleStateTerminated,
+	"FAILED":              VmClusterNetworkLifecycleStateFailed,
+}
+
+// GetVmClusterNetworkLifecycleStateEnumValues Enumerates the set of values for VmClusterNetworkLifecycleStateEnum
+func GetVmClusterNetworkLifecycleStateEnumValues() []VmClusterNetworkLifecycleStateEnum {
+	values := make([]VmClusterNetworkLifecycleStateEnum, 0)
+	for _, v := range mappingVmClusterNetworkLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/vm_cluster_network_details.go
+++ b/database/vm_cluster_network_details.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// VmClusterNetworkDetails Details for a VM cluster network.
+type VmClusterNetworkDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The user-friendly name for the VM cluster network. The name does not need to be unique.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The SCAN details.
+	Scans []ScanDetails `mandatory:"true" json:"scans"`
+
+	// Details of the client and backup networks.
+	VmNetworks []VmNetworkDetails `mandatory:"true" json:"vmNetworks"`
+
+	// The list of DNS server IP addresses. Maximum of 3 allowed.
+	Dns []string `mandatory:"false" json:"dns"`
+
+	// The list of NTP server IP addresses. Maximum of 3 allowed.
+	Ntp []string `mandatory:"false" json:"ntp"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m VmClusterNetworkDetails) String() string {
+	return common.PointerString(m)
+}

--- a/database/vm_cluster_network_summary.go
+++ b/database/vm_cluster_network_summary.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// VmClusterNetworkSummary Details of the VM cluster network.
+type VmClusterNetworkSummary struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster network.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+	ExadataInfrastructureId *string `mandatory:"false" json:"exadataInfrastructureId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the associated VM Cluster.
+	VmClusterId *string `mandatory:"false" json:"vmClusterId"`
+
+	// The user-friendly name for the VM cluster network. The name does not need to be unique.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// The SCAN details.
+	Scans []ScanDetails `mandatory:"false" json:"scans"`
+
+	// The list of DNS server IP addresses. Maximum of 3 allowed.
+	Dns []string `mandatory:"false" json:"dns"`
+
+	// The list of NTP server IP addresses. Maximum of 3 allowed.
+	Ntp []string `mandatory:"false" json:"ntp"`
+
+	// Details of the client and backup networks.
+	VmNetworks []VmNetworkDetails `mandatory:"false" json:"vmNetworks"`
+
+	// The current state of the VM cluster network.
+	LifecycleState VmClusterNetworkSummaryLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// The date and time when the VM cluster network was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// Additional information about the current lifecycle state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m VmClusterNetworkSummary) String() string {
+	return common.PointerString(m)
+}
+
+// VmClusterNetworkSummaryLifecycleStateEnum Enum with underlying type: string
+type VmClusterNetworkSummaryLifecycleStateEnum string
+
+// Set of constants representing the allowable values for VmClusterNetworkSummaryLifecycleStateEnum
+const (
+	VmClusterNetworkSummaryLifecycleStateCreating           VmClusterNetworkSummaryLifecycleStateEnum = "CREATING"
+	VmClusterNetworkSummaryLifecycleStateRequiresValidation VmClusterNetworkSummaryLifecycleStateEnum = "REQUIRES_VALIDATION"
+	VmClusterNetworkSummaryLifecycleStateValidating         VmClusterNetworkSummaryLifecycleStateEnum = "VALIDATING"
+	VmClusterNetworkSummaryLifecycleStateValidated          VmClusterNetworkSummaryLifecycleStateEnum = "VALIDATED"
+	VmClusterNetworkSummaryLifecycleStateValidationFailed   VmClusterNetworkSummaryLifecycleStateEnum = "VALIDATION_FAILED"
+	VmClusterNetworkSummaryLifecycleStateUpdating           VmClusterNetworkSummaryLifecycleStateEnum = "UPDATING"
+	VmClusterNetworkSummaryLifecycleStateAllocated          VmClusterNetworkSummaryLifecycleStateEnum = "ALLOCATED"
+	VmClusterNetworkSummaryLifecycleStateTerminating        VmClusterNetworkSummaryLifecycleStateEnum = "TERMINATING"
+	VmClusterNetworkSummaryLifecycleStateTerminated         VmClusterNetworkSummaryLifecycleStateEnum = "TERMINATED"
+	VmClusterNetworkSummaryLifecycleStateFailed             VmClusterNetworkSummaryLifecycleStateEnum = "FAILED"
+)
+
+var mappingVmClusterNetworkSummaryLifecycleState = map[string]VmClusterNetworkSummaryLifecycleStateEnum{
+	"CREATING":            VmClusterNetworkSummaryLifecycleStateCreating,
+	"REQUIRES_VALIDATION": VmClusterNetworkSummaryLifecycleStateRequiresValidation,
+	"VALIDATING":          VmClusterNetworkSummaryLifecycleStateValidating,
+	"VALIDATED":           VmClusterNetworkSummaryLifecycleStateValidated,
+	"VALIDATION_FAILED":   VmClusterNetworkSummaryLifecycleStateValidationFailed,
+	"UPDATING":            VmClusterNetworkSummaryLifecycleStateUpdating,
+	"ALLOCATED":           VmClusterNetworkSummaryLifecycleStateAllocated,
+	"TERMINATING":         VmClusterNetworkSummaryLifecycleStateTerminating,
+	"TERMINATED":          VmClusterNetworkSummaryLifecycleStateTerminated,
+	"FAILED":              VmClusterNetworkSummaryLifecycleStateFailed,
+}
+
+// GetVmClusterNetworkSummaryLifecycleStateEnumValues Enumerates the set of values for VmClusterNetworkSummaryLifecycleStateEnum
+func GetVmClusterNetworkSummaryLifecycleStateEnumValues() []VmClusterNetworkSummaryLifecycleStateEnum {
+	values := make([]VmClusterNetworkSummaryLifecycleStateEnum, 0)
+	for _, v := range mappingVmClusterNetworkSummaryLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/vm_cluster_summary.go
+++ b/database/vm_cluster_summary.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// VmClusterSummary Details of the VM cluster.
+type VmClusterSummary struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The current state of the VM cluster.
+	LifecycleState VmClusterSummaryLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// The user-friendly name for the VM cluster. The name does not need to be unique.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// The date and time that the VM cluster was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// Additional information about the current lifecycle state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The time zone of the Exadata infrastructure. For details, see Exadata Infrastructure Time Zones (https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
+	TimeZone *string `mandatory:"false" json:"timeZone"`
+
+	// If true, database backup on local Exadata storage is configured for the VM cluster. If false, database backup on local Exadata storage is not available in the VM cluster.
+	IsLocalBackupEnabled *bool `mandatory:"false" json:"isLocalBackupEnabled"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+	ExadataInfrastructureId *string `mandatory:"false" json:"exadataInfrastructureId"`
+
+	// If true, sparse disk group is configured for the VM cluster. If false, sparse disk group is not created.
+	IsSparseDiskgroupEnabled *bool `mandatory:"false" json:"isSparseDiskgroupEnabled"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster network.
+	VmClusterNetworkId *string `mandatory:"false" json:"vmClusterNetworkId"`
+
+	// The number of enabled CPU cores.
+	CpusEnabled *int `mandatory:"false" json:"cpusEnabled"`
+
+	// Size, in terabytes, of the DATA disk group.
+	DataStorageSizeInTBs *int `mandatory:"false" json:"dataStorageSizeInTBs"`
+
+	// The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+	Shape *string `mandatory:"false" json:"shape"`
+
+	// The Oracle Grid Infrastructure software version for the VM cluster.
+	GiVersion *string `mandatory:"false" json:"giVersion"`
+
+	// The public key portion of one or more key pairs used for SSH access to the VM cluster.
+	SshPublicKeys []string `mandatory:"false" json:"sshPublicKeys"`
+
+	// The Oracle license model that applies to the VM cluster. The default is LICENSE_INCLUDED.
+	LicenseModel VmClusterSummaryLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m VmClusterSummary) String() string {
+	return common.PointerString(m)
+}
+
+// VmClusterSummaryLifecycleStateEnum Enum with underlying type: string
+type VmClusterSummaryLifecycleStateEnum string
+
+// Set of constants representing the allowable values for VmClusterSummaryLifecycleStateEnum
+const (
+	VmClusterSummaryLifecycleStateProvisioning VmClusterSummaryLifecycleStateEnum = "PROVISIONING"
+	VmClusterSummaryLifecycleStateAvailable    VmClusterSummaryLifecycleStateEnum = "AVAILABLE"
+	VmClusterSummaryLifecycleStateUpdating     VmClusterSummaryLifecycleStateEnum = "UPDATING"
+	VmClusterSummaryLifecycleStateTerminating  VmClusterSummaryLifecycleStateEnum = "TERMINATING"
+	VmClusterSummaryLifecycleStateTerminated   VmClusterSummaryLifecycleStateEnum = "TERMINATED"
+	VmClusterSummaryLifecycleStateFailed       VmClusterSummaryLifecycleStateEnum = "FAILED"
+)
+
+var mappingVmClusterSummaryLifecycleState = map[string]VmClusterSummaryLifecycleStateEnum{
+	"PROVISIONING": VmClusterSummaryLifecycleStateProvisioning,
+	"AVAILABLE":    VmClusterSummaryLifecycleStateAvailable,
+	"UPDATING":     VmClusterSummaryLifecycleStateUpdating,
+	"TERMINATING":  VmClusterSummaryLifecycleStateTerminating,
+	"TERMINATED":   VmClusterSummaryLifecycleStateTerminated,
+	"FAILED":       VmClusterSummaryLifecycleStateFailed,
+}
+
+// GetVmClusterSummaryLifecycleStateEnumValues Enumerates the set of values for VmClusterSummaryLifecycleStateEnum
+func GetVmClusterSummaryLifecycleStateEnumValues() []VmClusterSummaryLifecycleStateEnum {
+	values := make([]VmClusterSummaryLifecycleStateEnum, 0)
+	for _, v := range mappingVmClusterSummaryLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}
+
+// VmClusterSummaryLicenseModelEnum Enum with underlying type: string
+type VmClusterSummaryLicenseModelEnum string
+
+// Set of constants representing the allowable values for VmClusterSummaryLicenseModelEnum
+const (
+	VmClusterSummaryLicenseModelLicenseIncluded     VmClusterSummaryLicenseModelEnum = "LICENSE_INCLUDED"
+	VmClusterSummaryLicenseModelBringYourOwnLicense VmClusterSummaryLicenseModelEnum = "BRING_YOUR_OWN_LICENSE"
+)
+
+var mappingVmClusterSummaryLicenseModel = map[string]VmClusterSummaryLicenseModelEnum{
+	"LICENSE_INCLUDED":       VmClusterSummaryLicenseModelLicenseIncluded,
+	"BRING_YOUR_OWN_LICENSE": VmClusterSummaryLicenseModelBringYourOwnLicense,
+}
+
+// GetVmClusterSummaryLicenseModelEnumValues Enumerates the set of values for VmClusterSummaryLicenseModelEnum
+func GetVmClusterSummaryLicenseModelEnumValues() []VmClusterSummaryLicenseModelEnum {
+	values := make([]VmClusterSummaryLicenseModelEnum, 0)
+	for _, v := range mappingVmClusterSummaryLicenseModel {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/vm_network_details.go
+++ b/database/vm_network_details.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// VmNetworkDetails Details of the client or backup networks in a VM cluster network.
+type VmNetworkDetails struct {
+
+	// The network VLAN ID.
+	VlanId *string `mandatory:"true" json:"vlanId"`
+
+	// The network type.
+	NetworkType VmNetworkDetailsNetworkTypeEnum `mandatory:"true" json:"networkType"`
+
+	// The network netmask.
+	Netmask *string `mandatory:"true" json:"netmask"`
+
+	// The network gateway.
+	Gateway *string `mandatory:"true" json:"gateway"`
+
+	// The network domain name.
+	DomainName *string `mandatory:"true" json:"domainName"`
+
+	// The list of node details.
+	Nodes []NodeDetails `mandatory:"true" json:"nodes"`
+}
+
+func (m VmNetworkDetails) String() string {
+	return common.PointerString(m)
+}
+
+// VmNetworkDetailsNetworkTypeEnum Enum with underlying type: string
+type VmNetworkDetailsNetworkTypeEnum string
+
+// Set of constants representing the allowable values for VmNetworkDetailsNetworkTypeEnum
+const (
+	VmNetworkDetailsNetworkTypeClient VmNetworkDetailsNetworkTypeEnum = "CLIENT"
+	VmNetworkDetailsNetworkTypeBackup VmNetworkDetailsNetworkTypeEnum = "BACKUP"
+)
+
+var mappingVmNetworkDetailsNetworkType = map[string]VmNetworkDetailsNetworkTypeEnum{
+	"CLIENT": VmNetworkDetailsNetworkTypeClient,
+	"BACKUP": VmNetworkDetailsNetworkTypeBackup,
+}
+
+// GetVmNetworkDetailsNetworkTypeEnumValues Enumerates the set of values for VmNetworkDetailsNetworkTypeEnum
+func GetVmNetworkDetailsNetworkTypeEnumValues() []VmNetworkDetailsNetworkTypeEnum {
+	values := make([]VmNetworkDetailsNetworkTypeEnum, 0)
+	for _, v := range mappingVmNetworkDetailsNetworkType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/example/example_backup_destination_test.go
+++ b/example/example_backup_destination_test.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+//
+// Example code for Backup Destination. It demonstrates CRUD(Create, Read, Update and Delete) operations on
+// BackupDestination , Create DbHome with BackupDestination and Update Database with BackupDestination.
+//
+package example
+
+import (
+	"context"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/common"
+	"github.com/oracle/oci-go-sdk/database"
+	"github.com/oracle/oci-go-sdk/example/helpers"
+	"os"
+	"strings"
+)
+
+var (
+	displayNameBackupDestination, localMountPath string
+)
+
+func ExampleCreateNFSBackupDestination() {
+	c, clerr := database.NewDatabaseClientWithConfigurationProvider(common.DefaultConfigProvider())
+	helpers.FatalIfError(clerr)
+	displayNameBackupDestination := helpers.GetRandomString(32)
+	compartmentId := os.Getenv("OCI_COMPARTMENT_ID")
+
+	createBackupDestinationDetails := database.CreateNfsBackupDestinationDetails{
+		CompartmentId:       &compartmentId,
+		DisplayName:         &displayNameBackupDestination,
+		LocalMountPointPath: common.String("path"),
+	}
+
+	createbackupdestinationReq := database.CreateBackupDestinationRequest{
+		CreateBackupDestinationDetails: createBackupDestinationDetails,
+	}
+
+	_, err := c.CreateBackupDestination(context.Background(), createbackupdestinationReq)
+	helpers.FatalIfError(err)
+
+	fmt.Println("create backup destination is successful")
+
+	// Output:
+	// create backup destination is successful
+}
+
+func ExampleGetBackupDestination() {
+	c, clerr := database.NewDatabaseClientWithConfigurationProvider(common.DefaultConfigProvider())
+	helpers.FatalIfError(clerr)
+
+	getbackupDestinationReq := database.GetBackupDestinationRequest{
+		BackupDestinationId: common.String("backup-destination-ocid"),
+	}
+
+	_, err := c.GetBackupDestination(context.Background(), getbackupDestinationReq)
+	helpers.FatalIfError(err)
+
+	fmt.Println("get backup destination is successful")
+
+	// Output:
+	// get backup destination is successful
+}
+
+func ExampleUpdateBackupDestination() {
+	c, clerr := database.NewDatabaseClientWithConfigurationProvider(common.DefaultConfigProvider())
+	helpers.FatalIfError(clerr)
+
+	updateBackupDestinationDetails := database.UpdateBackupDestinationDetails{
+		LocalMountPointPath: &localMountPath,
+	}
+
+	updatebackupdestinationReq := database.UpdateBackupDestinationRequest{
+		UpdateBackupDestinationDetails: updateBackupDestinationDetails,
+		BackupDestinationId:            common.String("backup-destination-ocid"),
+	}
+
+	_, err := c.UpdateBackupDestination(context.Background(), updatebackupdestinationReq)
+	helpers.FatalIfError(err)
+
+	fmt.Println("update backup destination is successful")
+
+	// Output:
+	// update backup destination is successful
+}
+
+func ExampleUpdateDbBackupBackupDestination() {
+	c, clerr := database.NewDatabaseClientWithConfigurationProvider(common.DefaultConfigProvider())
+	helpers.FatalIfError(clerr)
+
+	backupDestination := database.BackupDestinationDetails{
+		Type: database.BackupDestinationDetailsTypeEnum("NFS"),
+		Id:   common.String("backup-destination-ocid"),
+	}
+
+	dbBackupConfig := database.DbBackupConfig{
+		BackupDestinationDetails: []database.BackupDestinationDetails{backupDestination},
+	}
+
+	updatedatabaseDetails := database.UpdateDatabaseDetails{
+		DbBackupConfig: &dbBackupConfig,
+	}
+
+	updateDatabaseReq := database.UpdateDatabaseRequest{
+		UpdateDatabaseDetails: updatedatabaseDetails,
+		DatabaseId:            common.String("database-ocid"),
+	}
+
+	_, err := c.UpdateDatabase(context.Background(), updateDatabaseReq)
+	helpers.FatalIfError(err)
+
+	fmt.Println("update backup destination is successful")
+
+	// Output:
+	// update backup destination is successful
+}
+
+func ExampleCreateDbHomeBackupDestination() {
+	c, clerr := database.NewDatabaseClientWithConfigurationProvider(common.DefaultConfigProvider())
+	helpers.FatalIfError(clerr)
+
+	dbName := strings.ToLower(helpers.GetRandomString(8))
+	dbUniqueName := dbName + "_" + strings.ToLower(helpers.GetRandomString(20))
+	dbVersion := "18.0.0.0"
+	adminPassword := "DBaaS12345_#"
+	displayName := helpers.GetRandomString(32)
+
+	backupDestination := database.BackupDestinationDetails{
+		Type: database.BackupDestinationDetailsTypeEnum("NFS"),
+		Id:   common.String("backup-destination-ocid"),
+	}
+
+	dbBackupConfig := database.DbBackupConfig{
+		BackupDestinationDetails: []database.BackupDestinationDetails{backupDestination},
+	}
+
+	// create database details
+	createDatabaseDetails := database.CreateDatabaseDetails{
+		AdminPassword:  &adminPassword,
+		DbName:         &dbName,
+		DbUniqueName:   &dbUniqueName,
+		DbBackupConfig: &dbBackupConfig,
+	}
+
+	// create dbhome details
+	createDbHomeDetails := database.CreateDbHomeWithVmClusterIdDetails{
+		DisplayName: &displayName,
+		Database:    &createDatabaseDetails,
+		VmClusterId: common.String("vm-cluster-ocid"),
+		DbVersion:   &dbVersion,
+	}
+
+	// create dbome request
+	request := database.CreateDbHomeRequest{CreateDbHomeWithDbSystemIdDetails: createDbHomeDetails}
+
+	_, createErrors := c.CreateDbHome(context.Background(), request)
+
+	helpers.FatalIfError(createErrors)
+
+	fmt.Printf("Create DB Home with backupDestination completed")
+
+	// Output:
+	// Create DB Home with backupDestination completed
+}
+
+func ExampleDeleteBackupDestination() {
+	c, clerr := database.NewDatabaseClientWithConfigurationProvider(common.DefaultConfigProvider())
+	helpers.FatalIfError(clerr)
+
+	deletebackupDestinationReq := database.DeleteBackupDestinationRequest{
+		BackupDestinationId: common.String("backup-destination-ocid"),
+	}
+
+	_, err := c.DeleteBackupDestination(context.Background(), deletebackupDestinationReq)
+	helpers.FatalIfError(err)
+
+	fmt.Println("delete backup destination is successful")
+
+	// Output:
+	// delete backup destination is successful
+}

--- a/resourcemanager/apply_job_operation_details.go
+++ b/resourcemanager/apply_job_operation_details.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Resource Manager API
+//
+// API for the Resource Manager service. Use this API to install, configure, and manage resources via the "infrastructure-as-code" model. For more information, see Overview of Resource Manager (https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Concepts/resourcemanager.htm).
+//
+
+package resourcemanager
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ApplyJobOperationDetails Job details that are specific to apply operations.
+type ApplyJobOperationDetails struct {
+
+	// The OCID of the plan job that contains the execution plan used for this job,
+	// or `null` if no execution plan was used.
+	ExecutionPlanJobId *string `mandatory:"false" json:"executionPlanJobId"`
+
+	// Specifies the source of the execution plan to apply.
+	// Use `AUTO_APPROVED` to run the job without an execution plan.
+	ExecutionPlanStrategy ApplyJobOperationDetailsExecutionPlanStrategyEnum `mandatory:"true" json:"executionPlanStrategy"`
+}
+
+func (m ApplyJobOperationDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ApplyJobOperationDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeApplyJobOperationDetails ApplyJobOperationDetails
+	s := struct {
+		DiscriminatorParam string `json:"operation"`
+		MarshalTypeApplyJobOperationDetails
+	}{
+		"APPLY",
+		(MarshalTypeApplyJobOperationDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// ApplyJobOperationDetailsExecutionPlanStrategyEnum Enum with underlying type: string
+type ApplyJobOperationDetailsExecutionPlanStrategyEnum string
+
+// Set of constants representing the allowable values for ApplyJobOperationDetailsExecutionPlanStrategyEnum
+const (
+	ApplyJobOperationDetailsExecutionPlanStrategyFromPlanJobId     ApplyJobOperationDetailsExecutionPlanStrategyEnum = "FROM_PLAN_JOB_ID"
+	ApplyJobOperationDetailsExecutionPlanStrategyFromLatestPlanJob ApplyJobOperationDetailsExecutionPlanStrategyEnum = "FROM_LATEST_PLAN_JOB"
+	ApplyJobOperationDetailsExecutionPlanStrategyAutoApproved      ApplyJobOperationDetailsExecutionPlanStrategyEnum = "AUTO_APPROVED"
+)
+
+var mappingApplyJobOperationDetailsExecutionPlanStrategy = map[string]ApplyJobOperationDetailsExecutionPlanStrategyEnum{
+	"FROM_PLAN_JOB_ID":     ApplyJobOperationDetailsExecutionPlanStrategyFromPlanJobId,
+	"FROM_LATEST_PLAN_JOB": ApplyJobOperationDetailsExecutionPlanStrategyFromLatestPlanJob,
+	"AUTO_APPROVED":        ApplyJobOperationDetailsExecutionPlanStrategyAutoApproved,
+}
+
+// GetApplyJobOperationDetailsExecutionPlanStrategyEnumValues Enumerates the set of values for ApplyJobOperationDetailsExecutionPlanStrategyEnum
+func GetApplyJobOperationDetailsExecutionPlanStrategyEnumValues() []ApplyJobOperationDetailsExecutionPlanStrategyEnum {
+	values := make([]ApplyJobOperationDetailsExecutionPlanStrategyEnum, 0)
+	for _, v := range mappingApplyJobOperationDetailsExecutionPlanStrategy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/resourcemanager/apply_job_operation_details_summary.go
+++ b/resourcemanager/apply_job_operation_details_summary.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Resource Manager API
+//
+// API for the Resource Manager service. Use this API to install, configure, and manage resources via the "infrastructure-as-code" model. For more information, see Overview of Resource Manager (https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Concepts/resourcemanager.htm).
+//
+
+package resourcemanager
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ApplyJobOperationDetailsSummary Job details that are specific to apply operations.
+type ApplyJobOperationDetailsSummary struct {
+
+	// The OCID of the plan job that contains the execution plan used for this job,
+	// or `null` if no execution plan was used.
+	ExecutionPlanJobId *string `mandatory:"false" json:"executionPlanJobId"`
+
+	// Specifies the source of the execution plan to apply.
+	// Use `AUTO_APPROVED` to run the job without an execution plan.
+	ExecutionPlanStrategy ApplyJobOperationDetailsExecutionPlanStrategyEnum `mandatory:"true" json:"executionPlanStrategy"`
+}
+
+func (m ApplyJobOperationDetailsSummary) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ApplyJobOperationDetailsSummary) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeApplyJobOperationDetailsSummary ApplyJobOperationDetailsSummary
+	s := struct {
+		DiscriminatorParam string `json:"operation"`
+		MarshalTypeApplyJobOperationDetailsSummary
+	}{
+		"APPLY",
+		(MarshalTypeApplyJobOperationDetailsSummary)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/resourcemanager/create_apply_job_operation_details.go
+++ b/resourcemanager/create_apply_job_operation_details.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Resource Manager API
+//
+// API for the Resource Manager service. Use this API to install, configure, and manage resources via the "infrastructure-as-code" model. For more information, see Overview of Resource Manager (https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Concepts/resourcemanager.htm).
+//
+
+package resourcemanager
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateApplyJobOperationDetails Job details that are specific to apply operations.
+type CreateApplyJobOperationDetails struct {
+
+	// The OCID of a plan job, for use when specifying `FROM_PLAN_JOB_ID` as the `executionPlanStrategy`.
+	ExecutionPlanJobId *string `mandatory:"false" json:"executionPlanJobId"`
+
+	// Specifies the source of the execution plan to apply.
+	// Use `AUTO_APPROVED` to run the job without an execution plan.
+	ExecutionPlanStrategy ApplyJobOperationDetailsExecutionPlanStrategyEnum `mandatory:"false" json:"executionPlanStrategy,omitempty"`
+}
+
+func (m CreateApplyJobOperationDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateApplyJobOperationDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateApplyJobOperationDetails CreateApplyJobOperationDetails
+	s := struct {
+		DiscriminatorParam string `json:"operation"`
+		MarshalTypeCreateApplyJobOperationDetails
+	}{
+		"APPLY",
+		(MarshalTypeCreateApplyJobOperationDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/resourcemanager/create_destroy_job_operation_details.go
+++ b/resourcemanager/create_destroy_job_operation_details.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Resource Manager API
+//
+// API for the Resource Manager service. Use this API to install, configure, and manage resources via the "infrastructure-as-code" model. For more information, see Overview of Resource Manager (https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Concepts/resourcemanager.htm).
+//
+
+package resourcemanager
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateDestroyJobOperationDetails Job details that are specific to destroy operations.
+type CreateDestroyJobOperationDetails struct {
+
+	// Specifies the source of the execution plan to apply.
+	// Currently, only `AUTO_APPROVED` is allowed, which indicates that the job
+	// will be run without an execution plan.
+	ExecutionPlanStrategy DestroyJobOperationDetailsExecutionPlanStrategyEnum `mandatory:"true" json:"executionPlanStrategy"`
+}
+
+func (m CreateDestroyJobOperationDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateDestroyJobOperationDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateDestroyJobOperationDetails CreateDestroyJobOperationDetails
+	s := struct {
+		DiscriminatorParam string `json:"operation"`
+		MarshalTypeCreateDestroyJobOperationDetails
+	}{
+		"DESTROY",
+		(MarshalTypeCreateDestroyJobOperationDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/resourcemanager/create_import_tf_state_job_operation_details.go
+++ b/resourcemanager/create_import_tf_state_job_operation_details.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Resource Manager API
+//
+// API for the Resource Manager service. Use this API to install, configure, and manage resources via the "infrastructure-as-code" model. For more information, see Overview of Resource Manager (https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Concepts/resourcemanager.htm).
+//
+
+package resourcemanager
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateImportTfStateJobOperationDetails Job details that are specific to import Terraform state operations.
+type CreateImportTfStateJobOperationDetails struct {
+
+	// Base64-encoded state file
+	TfStateBase64Encoded []byte `mandatory:"true" json:"tfStateBase64Encoded"`
+}
+
+func (m CreateImportTfStateJobOperationDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateImportTfStateJobOperationDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateImportTfStateJobOperationDetails CreateImportTfStateJobOperationDetails
+	s := struct {
+		DiscriminatorParam string `json:"operation"`
+		MarshalTypeCreateImportTfStateJobOperationDetails
+	}{
+		"IMPORT_TF_STATE",
+		(MarshalTypeCreateImportTfStateJobOperationDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/resourcemanager/create_job_details.go
+++ b/resourcemanager/create_job_details.go
@@ -9,6 +9,7 @@
 package resourcemanager
 
 import (
+	"encoding/json"
 	"github.com/oracle/oci-go-sdk/common"
 )
 
@@ -18,12 +19,16 @@ type CreateJobDetails struct {
 	// OCID of the stack that is associated with the current job.
 	StackId *string `mandatory:"true" json:"stackId"`
 
-	// Terraform-specific operation to execute.
-	Operation JobOperationEnum `mandatory:"true" json:"operation"`
-
 	// Description of the job.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
+	// Terraform-specific operation to execute.
+	Operation JobOperationEnum `mandatory:"false" json:"operation,omitempty"`
+
+	// Job details that are specific to the operation type.
+	JobOperationDetails CreateJobOperationDetails `mandatory:"false" json:"jobOperationDetails"`
+
+	// Deprecated. Use the property `executionPlanStrategy` in `jobOperationDetails` instead.
 	ApplyJobPlanResolution *ApplyJobPlanResolution `mandatory:"false" json:"applyJobPlanResolution"`
 
 	// Free-form tags associated with this resource. Each tag is a key-value pair with no predefined name, type, or namespace.
@@ -39,4 +44,38 @@ type CreateJobDetails struct {
 
 func (m CreateJobDetails) String() string {
 	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *CreateJobDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		DisplayName            *string                           `json:"displayName"`
+		Operation              JobOperationEnum                  `json:"operation"`
+		JobOperationDetails    createjoboperationdetails         `json:"jobOperationDetails"`
+		ApplyJobPlanResolution *ApplyJobPlanResolution           `json:"applyJobPlanResolution"`
+		FreeformTags           map[string]string                 `json:"freeformTags"`
+		DefinedTags            map[string]map[string]interface{} `json:"definedTags"`
+		StackId                *string                           `json:"stackId"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	m.DisplayName = model.DisplayName
+	m.Operation = model.Operation
+	nn, e := model.JobOperationDetails.UnmarshalPolymorphicJSON(model.JobOperationDetails.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.JobOperationDetails = nn.(CreateJobOperationDetails)
+	} else {
+		m.JobOperationDetails = nil
+	}
+	m.ApplyJobPlanResolution = model.ApplyJobPlanResolution
+	m.FreeformTags = model.FreeformTags
+	m.DefinedTags = model.DefinedTags
+	m.StackId = model.StackId
+	return
 }

--- a/resourcemanager/create_job_operation_details.go
+++ b/resourcemanager/create_job_operation_details.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Resource Manager API
+//
+// API for the Resource Manager service. Use this API to install, configure, and manage resources via the "infrastructure-as-code" model. For more information, see Overview of Resource Manager (https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Concepts/resourcemanager.htm).
+//
+
+package resourcemanager
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateJobOperationDetails Job details that are specific to the operation type.
+type CreateJobOperationDetails interface {
+}
+
+type createjoboperationdetails struct {
+	JsonData  []byte
+	Operation string `json:"operation"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *createjoboperationdetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalercreatejoboperationdetails createjoboperationdetails
+	s := struct {
+		Model Unmarshalercreatejoboperationdetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Operation = s.Model.Operation
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *createjoboperationdetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.Operation {
+	case "IMPORT_TF_STATE":
+		mm := CreateImportTfStateJobOperationDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "APPLY":
+		mm := CreateApplyJobOperationDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "PLAN":
+		mm := CreatePlanJobOperationDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "DESTROY":
+		mm := CreateDestroyJobOperationDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m createjoboperationdetails) String() string {
+	return common.PointerString(m)
+}

--- a/resourcemanager/create_plan_job_operation_details.go
+++ b/resourcemanager/create_plan_job_operation_details.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Resource Manager API
+//
+// API for the Resource Manager service. Use this API to install, configure, and manage resources via the "infrastructure-as-code" model. For more information, see Overview of Resource Manager (https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Concepts/resourcemanager.htm).
+//
+
+package resourcemanager
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreatePlanJobOperationDetails Job details that are specific to plan operations.
+type CreatePlanJobOperationDetails struct {
+}
+
+func (m CreatePlanJobOperationDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreatePlanJobOperationDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreatePlanJobOperationDetails CreatePlanJobOperationDetails
+	s := struct {
+		DiscriminatorParam string `json:"operation"`
+		MarshalTypeCreatePlanJobOperationDetails
+	}{
+		"PLAN",
+		(MarshalTypeCreatePlanJobOperationDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/resourcemanager/destroy_job_operation_details.go
+++ b/resourcemanager/destroy_job_operation_details.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Resource Manager API
+//
+// API for the Resource Manager service. Use this API to install, configure, and manage resources via the "infrastructure-as-code" model. For more information, see Overview of Resource Manager (https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Concepts/resourcemanager.htm).
+//
+
+package resourcemanager
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DestroyJobOperationDetails Job details that are specific to destroy operations.
+type DestroyJobOperationDetails struct {
+
+	// Specifies the source of the execution plan to apply.
+	// Currently, only `AUTO_APPROVED` is allowed, which indicates that the job
+	// will be run without an execution plan.
+	ExecutionPlanStrategy DestroyJobOperationDetailsExecutionPlanStrategyEnum `mandatory:"true" json:"executionPlanStrategy"`
+}
+
+func (m DestroyJobOperationDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DestroyJobOperationDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDestroyJobOperationDetails DestroyJobOperationDetails
+	s := struct {
+		DiscriminatorParam string `json:"operation"`
+		MarshalTypeDestroyJobOperationDetails
+	}{
+		"DESTROY",
+		(MarshalTypeDestroyJobOperationDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// DestroyJobOperationDetailsExecutionPlanStrategyEnum Enum with underlying type: string
+type DestroyJobOperationDetailsExecutionPlanStrategyEnum string
+
+// Set of constants representing the allowable values for DestroyJobOperationDetailsExecutionPlanStrategyEnum
+const (
+	DestroyJobOperationDetailsExecutionPlanStrategyAutoApproved DestroyJobOperationDetailsExecutionPlanStrategyEnum = "AUTO_APPROVED"
+)
+
+var mappingDestroyJobOperationDetailsExecutionPlanStrategy = map[string]DestroyJobOperationDetailsExecutionPlanStrategyEnum{
+	"AUTO_APPROVED": DestroyJobOperationDetailsExecutionPlanStrategyAutoApproved,
+}
+
+// GetDestroyJobOperationDetailsExecutionPlanStrategyEnumValues Enumerates the set of values for DestroyJobOperationDetailsExecutionPlanStrategyEnum
+func GetDestroyJobOperationDetailsExecutionPlanStrategyEnumValues() []DestroyJobOperationDetailsExecutionPlanStrategyEnum {
+	values := make([]DestroyJobOperationDetailsExecutionPlanStrategyEnum, 0)
+	for _, v := range mappingDestroyJobOperationDetailsExecutionPlanStrategy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/resourcemanager/destroy_job_operation_details_summary.go
+++ b/resourcemanager/destroy_job_operation_details_summary.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Resource Manager API
+//
+// API for the Resource Manager service. Use this API to install, configure, and manage resources via the "infrastructure-as-code" model. For more information, see Overview of Resource Manager (https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Concepts/resourcemanager.htm).
+//
+
+package resourcemanager
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DestroyJobOperationDetailsSummary Job details that are specific to destroy operations.
+type DestroyJobOperationDetailsSummary struct {
+
+	// Specifies the source of the execution plan to apply.
+	// Currently, only `AUTO_APPROVED` is allowed, which indicates that the job
+	// will be run without an execution plan.
+	ExecutionPlanStrategy DestroyJobOperationDetailsExecutionPlanStrategyEnum `mandatory:"true" json:"executionPlanStrategy"`
+}
+
+func (m DestroyJobOperationDetailsSummary) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DestroyJobOperationDetailsSummary) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDestroyJobOperationDetailsSummary DestroyJobOperationDetailsSummary
+	s := struct {
+		DiscriminatorParam string `json:"operation"`
+		MarshalTypeDestroyJobOperationDetailsSummary
+	}{
+		"DESTROY",
+		(MarshalTypeDestroyJobOperationDetailsSummary)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/resourcemanager/import_tf_state_job_operation_details.go
+++ b/resourcemanager/import_tf_state_job_operation_details.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Resource Manager API
+//
+// API for the Resource Manager service. Use this API to install, configure, and manage resources via the "infrastructure-as-code" model. For more information, see Overview of Resource Manager (https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Concepts/resourcemanager.htm).
+//
+
+package resourcemanager
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ImportTfStateJobOperationDetails Job details that are specific to import Terraform state operations.
+type ImportTfStateJobOperationDetails struct {
+}
+
+func (m ImportTfStateJobOperationDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ImportTfStateJobOperationDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeImportTfStateJobOperationDetails ImportTfStateJobOperationDetails
+	s := struct {
+		DiscriminatorParam string `json:"operation"`
+		MarshalTypeImportTfStateJobOperationDetails
+	}{
+		"IMPORT_TF_STATE",
+		(MarshalTypeImportTfStateJobOperationDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/resourcemanager/import_tf_state_job_operation_details_summary.go
+++ b/resourcemanager/import_tf_state_job_operation_details_summary.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Resource Manager API
+//
+// API for the Resource Manager service. Use this API to install, configure, and manage resources via the "infrastructure-as-code" model. For more information, see Overview of Resource Manager (https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Concepts/resourcemanager.htm).
+//
+
+package resourcemanager
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ImportTfStateJobOperationDetailsSummary Job details that are specific to import Terraform state operations.
+type ImportTfStateJobOperationDetailsSummary struct {
+}
+
+func (m ImportTfStateJobOperationDetailsSummary) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ImportTfStateJobOperationDetailsSummary) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeImportTfStateJobOperationDetailsSummary ImportTfStateJobOperationDetailsSummary
+	s := struct {
+		DiscriminatorParam string `json:"operation"`
+		MarshalTypeImportTfStateJobOperationDetailsSummary
+	}{
+		"IMPORT_TF_STATE",
+		(MarshalTypeImportTfStateJobOperationDetailsSummary)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/resourcemanager/job.go
+++ b/resourcemanager/job.go
@@ -9,6 +9,7 @@
 package resourcemanager
 
 import (
+	"encoding/json"
 	"github.com/oracle/oci-go-sdk/common"
 )
 
@@ -19,6 +20,8 @@ import (
 // - **Destroy job**. To clean up the infrastructure controlled by the stack, you run a destroy job.
 // A destroy job does not delete the stack or associated job resources,
 // but instead releases the resources managed by the stack.
+// - **Import_TF_State job**. An import Terraform state job takes a Terraform state file and sets it as the current
+// state of the stack. This is used to migrate local Terraform environments to Resource Manager.
 type Job struct {
 
 	// The job's OCID.
@@ -36,8 +39,13 @@ type Job struct {
 	// The type of job executing.
 	Operation JobOperationEnum `mandatory:"false" json:"operation,omitempty"`
 
+	// Job details that are specific to the operation type.
+	JobOperationDetails JobOperationDetails `mandatory:"false" json:"jobOperationDetails"`
+
+	// Deprecated. Use the property `executionPlanStrategy` in `jobOperationDetails` instead.
 	ApplyJobPlanResolution *ApplyJobPlanResolution `mandatory:"false" json:"applyJobPlanResolution"`
 
+	// Deprecated. Use the property `executionPlanJobId` in `jobOperationDetails` instead.
 	// The plan job OCID that was used (if this was an apply job and was not auto-approved).
 	ResolvedPlanJobId *string `mandatory:"false" json:"resolvedPlanJobId"`
 
@@ -75,20 +83,74 @@ func (m Job) String() string {
 	return common.PointerString(m)
 }
 
+// UnmarshalJSON unmarshals from json
+func (m *Job) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Id                     *string                           `json:"id"`
+		StackId                *string                           `json:"stackId"`
+		CompartmentId          *string                           `json:"compartmentId"`
+		DisplayName            *string                           `json:"displayName"`
+		Operation              JobOperationEnum                  `json:"operation"`
+		JobOperationDetails    joboperationdetails               `json:"jobOperationDetails"`
+		ApplyJobPlanResolution *ApplyJobPlanResolution           `json:"applyJobPlanResolution"`
+		ResolvedPlanJobId      *string                           `json:"resolvedPlanJobId"`
+		TimeCreated            *common.SDKTime                   `json:"timeCreated"`
+		TimeFinished           *common.SDKTime                   `json:"timeFinished"`
+		LifecycleState         JobLifecycleStateEnum             `json:"lifecycleState"`
+		FailureDetails         *FailureDetails                   `json:"failureDetails"`
+		WorkingDirectory       *string                           `json:"workingDirectory"`
+		Variables              map[string]string                 `json:"variables"`
+		FreeformTags           map[string]string                 `json:"freeformTags"`
+		DefinedTags            map[string]map[string]interface{} `json:"definedTags"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	m.Id = model.Id
+	m.StackId = model.StackId
+	m.CompartmentId = model.CompartmentId
+	m.DisplayName = model.DisplayName
+	m.Operation = model.Operation
+	nn, e := model.JobOperationDetails.UnmarshalPolymorphicJSON(model.JobOperationDetails.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.JobOperationDetails = nn.(JobOperationDetails)
+	} else {
+		m.JobOperationDetails = nil
+	}
+	m.ApplyJobPlanResolution = model.ApplyJobPlanResolution
+	m.ResolvedPlanJobId = model.ResolvedPlanJobId
+	m.TimeCreated = model.TimeCreated
+	m.TimeFinished = model.TimeFinished
+	m.LifecycleState = model.LifecycleState
+	m.FailureDetails = model.FailureDetails
+	m.WorkingDirectory = model.WorkingDirectory
+	m.Variables = model.Variables
+	m.FreeformTags = model.FreeformTags
+	m.DefinedTags = model.DefinedTags
+	return
+}
+
 // JobOperationEnum Enum with underlying type: string
 type JobOperationEnum string
 
 // Set of constants representing the allowable values for JobOperationEnum
 const (
-	JobOperationPlan    JobOperationEnum = "PLAN"
-	JobOperationApply   JobOperationEnum = "APPLY"
-	JobOperationDestroy JobOperationEnum = "DESTROY"
+	JobOperationPlan          JobOperationEnum = "PLAN"
+	JobOperationApply         JobOperationEnum = "APPLY"
+	JobOperationDestroy       JobOperationEnum = "DESTROY"
+	JobOperationImportTfState JobOperationEnum = "IMPORT_TF_STATE"
 )
 
 var mappingJobOperation = map[string]JobOperationEnum{
-	"PLAN":    JobOperationPlan,
-	"APPLY":   JobOperationApply,
-	"DESTROY": JobOperationDestroy,
+	"PLAN":            JobOperationPlan,
+	"APPLY":           JobOperationApply,
+	"DESTROY":         JobOperationDestroy,
+	"IMPORT_TF_STATE": JobOperationImportTfState,
 }
 
 // GetJobOperationEnumValues Enumerates the set of values for JobOperationEnum

--- a/resourcemanager/job_operation_details.go
+++ b/resourcemanager/job_operation_details.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Resource Manager API
+//
+// API for the Resource Manager service. Use this API to install, configure, and manage resources via the "infrastructure-as-code" model. For more information, see Overview of Resource Manager (https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Concepts/resourcemanager.htm).
+//
+
+package resourcemanager
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// JobOperationDetails Job details that are specific to the operation type.
+type JobOperationDetails interface {
+}
+
+type joboperationdetails struct {
+	JsonData  []byte
+	Operation string `json:"operation"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *joboperationdetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerjoboperationdetails joboperationdetails
+	s := struct {
+		Model Unmarshalerjoboperationdetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Operation = s.Model.Operation
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *joboperationdetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.Operation {
+	case "IMPORT_TF_STATE":
+		mm := ImportTfStateJobOperationDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "PLAN":
+		mm := PlanJobOperationDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "APPLY":
+		mm := ApplyJobOperationDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "DESTROY":
+		mm := DestroyJobOperationDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m joboperationdetails) String() string {
+	return common.PointerString(m)
+}

--- a/resourcemanager/job_operation_details_summary.go
+++ b/resourcemanager/job_operation_details_summary.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Resource Manager API
+//
+// API for the Resource Manager service. Use this API to install, configure, and manage resources via the "infrastructure-as-code" model. For more information, see Overview of Resource Manager (https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Concepts/resourcemanager.htm).
+//
+
+package resourcemanager
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// JobOperationDetailsSummary Job details that are specific to the operation type.
+type JobOperationDetailsSummary interface {
+}
+
+type joboperationdetailssummary struct {
+	JsonData  []byte
+	Operation string `json:"operation"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *joboperationdetailssummary) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerjoboperationdetailssummary joboperationdetailssummary
+	s := struct {
+		Model Unmarshalerjoboperationdetailssummary
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Operation = s.Model.Operation
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *joboperationdetailssummary) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.Operation {
+	case "IMPORT_TF_STATE":
+		mm := ImportTfStateJobOperationDetailsSummary{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "PLAN":
+		mm := PlanJobOperationDetailsSummary{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "DESTROY":
+		mm := DestroyJobOperationDetailsSummary{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "APPLY":
+		mm := ApplyJobOperationDetailsSummary{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m joboperationdetailssummary) String() string {
+	return common.PointerString(m)
+}

--- a/resourcemanager/job_summary.go
+++ b/resourcemanager/job_summary.go
@@ -9,6 +9,7 @@
 package resourcemanager
 
 import (
+	"encoding/json"
 	"github.com/oracle/oci-go-sdk/common"
 )
 
@@ -30,9 +31,14 @@ type JobSummary struct {
 	// The type of job executing
 	Operation JobOperationEnum `mandatory:"false" json:"operation,omitempty"`
 
+	// Job details that are specific to the operation type.
+	JobOperationDetails JobOperationDetailsSummary `mandatory:"false" json:"jobOperationDetails"`
+
+	// Deprecated. Use the property `executionPlanStrategy` in `jobOperationDetails` instead.
 	ApplyJobPlanResolution *ApplyJobPlanResolution `mandatory:"false" json:"applyJobPlanResolution"`
 
-	// The plan job OCID that was used (if this was an APPLY job and not auto approved).
+	// Deprecated. Use the property `executionPlanJobId` in `jobOperationDetails` instead.
+	// The plan job OCID that was used (if this was an apply job and was not auto-approved).
 	ResolvedPlanJobId *string `mandatory:"false" json:"resolvedPlanJobId"`
 
 	// The date and time the job was created.
@@ -63,4 +69,50 @@ type JobSummary struct {
 
 func (m JobSummary) String() string {
 	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *JobSummary) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Id                     *string                           `json:"id"`
+		StackId                *string                           `json:"stackId"`
+		CompartmentId          *string                           `json:"compartmentId"`
+		DisplayName            *string                           `json:"displayName"`
+		Operation              JobOperationEnum                  `json:"operation"`
+		JobOperationDetails    joboperationdetailssummary        `json:"jobOperationDetails"`
+		ApplyJobPlanResolution *ApplyJobPlanResolution           `json:"applyJobPlanResolution"`
+		ResolvedPlanJobId      *string                           `json:"resolvedPlanJobId"`
+		TimeCreated            *common.SDKTime                   `json:"timeCreated"`
+		TimeFinished           *common.SDKTime                   `json:"timeFinished"`
+		LifecycleState         JobLifecycleStateEnum             `json:"lifecycleState"`
+		FreeformTags           map[string]string                 `json:"freeformTags"`
+		DefinedTags            map[string]map[string]interface{} `json:"definedTags"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	m.Id = model.Id
+	m.StackId = model.StackId
+	m.CompartmentId = model.CompartmentId
+	m.DisplayName = model.DisplayName
+	m.Operation = model.Operation
+	nn, e := model.JobOperationDetails.UnmarshalPolymorphicJSON(model.JobOperationDetails.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.JobOperationDetails = nn.(JobOperationDetailsSummary)
+	} else {
+		m.JobOperationDetails = nil
+	}
+	m.ApplyJobPlanResolution = model.ApplyJobPlanResolution
+	m.ResolvedPlanJobId = model.ResolvedPlanJobId
+	m.TimeCreated = model.TimeCreated
+	m.TimeFinished = model.TimeFinished
+	m.LifecycleState = model.LifecycleState
+	m.FreeformTags = model.FreeformTags
+	m.DefinedTags = model.DefinedTags
+	return
 }

--- a/resourcemanager/plan_job_operation_details.go
+++ b/resourcemanager/plan_job_operation_details.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Resource Manager API
+//
+// API for the Resource Manager service. Use this API to install, configure, and manage resources via the "infrastructure-as-code" model. For more information, see Overview of Resource Manager (https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Concepts/resourcemanager.htm).
+//
+
+package resourcemanager
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// PlanJobOperationDetails Job details that are specific to plan operations.
+type PlanJobOperationDetails struct {
+}
+
+func (m PlanJobOperationDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m PlanJobOperationDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypePlanJobOperationDetails PlanJobOperationDetails
+	s := struct {
+		DiscriminatorParam string `json:"operation"`
+		MarshalTypePlanJobOperationDetails
+	}{
+		"PLAN",
+		(MarshalTypePlanJobOperationDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/resourcemanager/plan_job_operation_details_summary.go
+++ b/resourcemanager/plan_job_operation_details_summary.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Resource Manager API
+//
+// API for the Resource Manager service. Use this API to install, configure, and manage resources via the "infrastructure-as-code" model. For more information, see Overview of Resource Manager (https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Concepts/resourcemanager.htm).
+//
+
+package resourcemanager
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// PlanJobOperationDetailsSummary Job details that are specific to plan operations.
+type PlanJobOperationDetailsSummary struct {
+}
+
+func (m PlanJobOperationDetailsSummary) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m PlanJobOperationDetailsSummary) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypePlanJobOperationDetailsSummary PlanJobOperationDetailsSummary
+	s := struct {
+		DiscriminatorParam string `json:"operation"`
+		MarshalTypePlanJobOperationDetailsSummary
+	}{
+		"PLAN",
+		(MarshalTypePlanJobOperationDetailsSummary)(m),
+	}
+
+	return json.Marshal(&s)
+}


### PR DESCRIPTION
### Added

- Support for importing state files in the Resource Manager service

- Support for Exadata Cloud at Customer in the Database service

- Support for free tier resources and system tags in the Load Balancing service

- Support for free tier resources and system tags in the Compute service

- Support for free tier resources and system tags in the Block Storage service

- Support for free tier and system tags on autonomous databases in the Database service



### Breaking

- Interface CreateDbHomeWithDbSystemIdBase is renamed to CreateDbHomeBase and dbSystemId property is removed from it

- CreateDbHomeWithDbSystemIdBase in CreateDbHomeRequest is replaced with CreateDbHomeWithDbSystemIdDetails
