### PR TITLE
Releasing version 11.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## 11.0.0 - 2019-10-01
+### Added
+- Support for required tags in the Identity service
+- Support for work requests on tagging operations in the Identity service
+- Support for enumerated tag values in the Identity service
+- Support for moving dynamic routing gateway resources across compartments in the Networking service
+- Support for migrating zones from Dyn managed DNS to OCI in the DNS service
+- Support for fast provisioning for virtual machine databases in the Database service
+
+### Breaking changes
+- The field``CreateZoneDetails`` is no longer an anonymous field and the type changed from struct to interface in struct ``CreateZoneRequest``. Here is sample code that shows how to update your code to incorporate this change. 
+
+
+    - Before
+
+    ```golang
+    // There were two ways to initialize the CreateZoneRequest struct.
+    // This breaking change only impact option #2
+    request := dns.CreateZoneRequest{}
+
+    // #1. Instantiate CreateZoneDetails directly: no impact
+    details := dns.CreateZoneDetails{}
+    details.Name = common.String('some name')
+    // ... other properties
+    // Set it to the request class
+    request.CreateZoneDetails = details
+
+    // #2. Instantiate CreateZoneDetails through anonymous fields: will break
+    request.Name = common.String('some name')
+    // ... other properties
+    ```
+
+    - After
+
+    ```golang
+    // #2 no longer supported. Create CreateZoneDetails directly
+    details := dns.CreateZoneDetails{}
+    details.Name = common.String('some name')
+    // ... other properties
+
+    request := dns.CreateZoneRequest{
+        CreateZoneDetails: details
+    }
+    // ...
+    ```
+
 ## 10.1.0 - 2019-09-24
 ### Added
 - Support for selecting the Terraform version to use in the Resource Manager service

--- a/common/common.go
+++ b/common/common.go
@@ -134,6 +134,8 @@ func StringToRegion(stringRegion string) (r Region) {
 		r = RegionEUZurich1
 	case "gru", "sa-saopaulo-1":
 		r = RegionSASaopaulo1
+	case "syd", "ap-sydney-1":
+		r = RegionAPSydney1
 	case "us-langley-1":
 		r = RegionUSLangley1
 	case "us-luke-1":

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -56,6 +56,13 @@ func TestEndpointForTemplate(t *testing.T) {
 			expected:         "https://foo.region.oraclecloud.com",
 		},
 		{
+			// template with second level domain
+			region:           StringToRegion("ap-sydney-1"),
+			service:          "test",
+			endpointTemplate: "https://foo.region.{secondLevelDomain}",
+			expected:         "https://foo.region.oraclecloud.com",
+		},
+		{
 			// template with everything for OC2
 			region:           StringToRegion("us-langley-1"),
 			service:          "test",
@@ -86,4 +93,7 @@ func TestStringToRegion(t *testing.T) {
 
 	region = StringToRegion("gru")
 	assert.Equal(t, RegionSASaopaulo1, region)
+
+	region = StringToRegion("syd")
+	assert.Equal(t, RegionAPSydney1, region)
 }

--- a/common/version.go
+++ b/common/version.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	major = "10"
-	minor = "1"
+	major = "11"
+	minor = "0"
 	patch = "0"
 	tag   = ""
 )

--- a/core/change_dedicated_vm_host_compartment_request_response.go
+++ b/core/change_dedicated_vm_host_compartment_request_response.go
@@ -14,7 +14,7 @@ type ChangeDedicatedVmHostCompartmentRequest struct {
 	// The OCID of the dedicated VM host.
 	DedicatedVmHostId *string `mandatory:"true" contributesTo:"path" name:"dedicatedVmHostId"`
 
-	// Request to change the compartment of a given dedicated vm host.
+	// The request to move the dedicated virtual machine host to a different compartment.
 	ChangeDedicatedVmHostCompartmentDetails `contributesTo:"body"`
 
 	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`

--- a/core/change_drg_compartment_details.go
+++ b/core/change_drg_compartment_details.go
@@ -16,14 +16,14 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// ChangeDedicatedVmHostCompartmentDetails Specifies the compartment to move the dedicated virtual machine host to.
-type ChangeDedicatedVmHostCompartmentDetails struct {
+// ChangeDrgCompartmentDetails The configuration details for the move operation.
+type ChangeDrgCompartmentDetails struct {
 
-	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment
-	// to move the dedicated virtual machine host to.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the
+	// DRG to.
 	CompartmentId *string `mandatory:"true" json:"compartmentId"`
 }
 
-func (m ChangeDedicatedVmHostCompartmentDetails) String() string {
+func (m ChangeDrgCompartmentDetails) String() string {
 	return common.PointerString(m)
 }

--- a/core/change_drg_compartment_request_response.go
+++ b/core/change_drg_compartment_request_response.go
@@ -8,11 +8,14 @@ import (
 	"net/http"
 )
 
-// CreateDedicatedVmHostRequest wrapper for the CreateDedicatedVmHost operation
-type CreateDedicatedVmHostRequest struct {
+// ChangeDrgCompartmentRequest wrapper for the ChangeDrgCompartment operation
+type ChangeDrgCompartmentRequest struct {
 
-	// The details for creating a new dedicated virtual machine host.
-	CreateDedicatedVmHostDetails `contributesTo:"body"`
+	// The OCID of the DRG.
+	DrgId *string `mandatory:"true" contributesTo:"path" name:"drgId"`
+
+	// Request to change the compartment of a DRG.
+	ChangeDrgCompartmentDetails `contributesTo:"body"`
 
 	// Unique identifier for the request.
 	// If you need to contact Oracle about a particular request, please provide the request ID.
@@ -30,28 +33,25 @@ type CreateDedicatedVmHostRequest struct {
 	RequestMetadata common.RequestMetadata
 }
 
-func (request CreateDedicatedVmHostRequest) String() string {
+func (request ChangeDrgCompartmentRequest) String() string {
 	return common.PointerString(request)
 }
 
 // HTTPRequest implements the OCIRequest interface
-func (request CreateDedicatedVmHostRequest) HTTPRequest(method, path string) (http.Request, error) {
+func (request ChangeDrgCompartmentRequest) HTTPRequest(method, path string) (http.Request, error) {
 	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
 }
 
 // RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
-func (request CreateDedicatedVmHostRequest) RetryPolicy() *common.RetryPolicy {
+func (request ChangeDrgCompartmentRequest) RetryPolicy() *common.RetryPolicy {
 	return request.RequestMetadata.RetryPolicy
 }
 
-// CreateDedicatedVmHostResponse wrapper for the CreateDedicatedVmHost operation
-type CreateDedicatedVmHostResponse struct {
+// ChangeDrgCompartmentResponse wrapper for the ChangeDrgCompartment operation
+type ChangeDrgCompartmentResponse struct {
 
 	// The underlying http response
 	RawResponse *http.Response
-
-	// The DedicatedVmHost instance
-	DedicatedVmHost `presentIn:"body"`
 
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
@@ -65,11 +65,11 @@ type CreateDedicatedVmHostResponse struct {
 	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
 }
 
-func (response CreateDedicatedVmHostResponse) String() string {
+func (response ChangeDrgCompartmentResponse) String() string {
 	return common.PointerString(response)
 }
 
 // HTTPResponse implements the OCIResponse interface
-func (response CreateDedicatedVmHostResponse) HTTPResponse() *http.Response {
+func (response ChangeDrgCompartmentResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
 }

--- a/core/core_compute_client.go
+++ b/core/core_compute_client.go
@@ -266,7 +266,7 @@ func (client ComputeClient) captureConsoleHistory(ctx context.Context, request c
 	return response, err
 }
 
-// ChangeDedicatedVmHostCompartment Moves a dedicated vm host from one compartment to another
+// ChangeDedicatedVmHostCompartment Moves a dedicated virtual machine host from one compartment to another.
 func (client ComputeClient) ChangeDedicatedVmHostCompartment(ctx context.Context, request ChangeDedicatedVmHostCompartmentRequest) (response ChangeDedicatedVmHostCompartmentResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()
@@ -460,7 +460,10 @@ func (client ComputeClient) createAppCatalogSubscription(ctx context.Context, re
 	return response, err
 }
 
-// CreateDedicatedVmHost Creates a new dedicated virtual machine (VM) host in the specified compartment and the specified availability domain.
+// CreateDedicatedVmHost Creates a new dedicated virtual machine host in the specified compartment and the specified availability domain.
+// Dedicated virtual machine hosts enable you to run your Compute virtual machine (VM) instances on dedicated servers
+// that are a single tenant and not shared with other customers.
+// For more information, see Dedicated Virtual Machine Hosts (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/dedicatedvmhosts.htm).
 func (client ComputeClient) CreateDedicatedVmHost(ctx context.Context, request CreateDedicatedVmHostRequest) (response CreateDedicatedVmHostResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()
@@ -704,8 +707,9 @@ func (client ComputeClient) deleteConsoleHistory(ctx context.Context, request co
 	return response, err
 }
 
-// DeleteDedicatedVmHost Deletes the specified dedicated virtual machine (VM) host.
-// If any VM instances are assigned to the dedicated VM host, it will not be deleted and the service will return a 409 response code.
+// DeleteDedicatedVmHost Deletes the specified dedicated virtual machine host.
+// If any VM instances are assigned to the dedicated virtual machine host,
+// the delete operation will fail and the service will return a 409 response code.
 func (client ComputeClient) DeleteDedicatedVmHost(ctx context.Context, request DeleteDedicatedVmHostRequest) (response DeleteDedicatedVmHostResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()
@@ -1278,7 +1282,7 @@ func (client ComputeClient) getConsoleHistoryContent(ctx context.Context, reques
 	return response, err
 }
 
-// GetDedicatedVmHost Gets information about the specified dedicated virtual machine (VM) host.
+// GetDedicatedVmHost Gets information about the specified dedicated virtual machine host.
 func (client ComputeClient) GetDedicatedVmHost(ctx context.Context, request GetDedicatedVmHostRequest) (response GetDedicatedVmHostResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()
@@ -1908,8 +1912,8 @@ func (client ComputeClient) listConsoleHistories(ctx context.Context, request co
 	return response, err
 }
 
-// ListDedicatedVmHostInstanceShapes Lists the shapes that can be used to launch a virtual machine (VM) instance on a dedicated VM host within the specified compartment.
-// You can filter the list by compatibility with a specific dedicated VM host shape.
+// ListDedicatedVmHostInstanceShapes Lists the shapes that can be used to launch a virtual machine instance on a dedicated virtual machine host within the specified compartment.
+// You can filter the list by compatibility with a specific dedicated virtual machine host shape.
 func (client ComputeClient) ListDedicatedVmHostInstanceShapes(ctx context.Context, request ListDedicatedVmHostInstanceShapesRequest) (response ListDedicatedVmHostInstanceShapesResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()
@@ -1951,7 +1955,7 @@ func (client ComputeClient) listDedicatedVmHostInstanceShapes(ctx context.Contex
 	return response, err
 }
 
-// ListDedicatedVmHostInstances Returns the list of instances on the dedicated virtual machine (VM) hosts that match the specified criteria.
+// ListDedicatedVmHostInstances Returns the list of instances on the dedicated virtual machine hosts that match the specified criteria.
 func (client ComputeClient) ListDedicatedVmHostInstances(ctx context.Context, request ListDedicatedVmHostInstancesRequest) (response ListDedicatedVmHostInstancesResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()
@@ -1993,7 +1997,7 @@ func (client ComputeClient) listDedicatedVmHostInstances(ctx context.Context, re
 	return response, err
 }
 
-// ListDedicatedVmHostShapes Lists the shapes that can be used to launch a dedicated virtual machine (VM) host within the specified compartment.
+// ListDedicatedVmHostShapes Lists the shapes that can be used to launch a dedicated virtual machine host within the specified compartment.
 func (client ComputeClient) ListDedicatedVmHostShapes(ctx context.Context, request ListDedicatedVmHostShapesRequest) (response ListDedicatedVmHostShapesResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()
@@ -2035,9 +2039,9 @@ func (client ComputeClient) listDedicatedVmHostShapes(ctx context.Context, reque
 	return response, err
 }
 
-// ListDedicatedVmHosts Returns the list of dedicated virtual machine (VM) hosts that match the specified criteria from the specified compartment.
-// You can limit the list by specifying a dedicated VM host display name. The list will include all the identically-named
-// dedicated VM hosts in the compartment.
+// ListDedicatedVmHosts Returns the list of dedicated virtual machine hosts that match the specified criteria in the specified compartment.
+// You can limit the list by specifying a dedicated virtual machine host display name. The list will include all the identically-named
+// dedicated virtual machine hosts in the compartment.
 func (client ComputeClient) ListDedicatedVmHosts(ctx context.Context, request ListDedicatedVmHostsRequest) (response ListDedicatedVmHostsResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()
@@ -2492,7 +2496,7 @@ func (client ComputeClient) updateConsoleHistory(ctx context.Context, request co
 	return response, err
 }
 
-// UpdateDedicatedVmHost Updates the displayName, freeformTags, and definedTags attributes for the specified dedicated virtual machine (VM) host.
+// UpdateDedicatedVmHost Updates the displayName, freeformTags, and definedTags attributes for the specified dedicated virtual machine host.
 // If an attribute value is not included, it will not be updated.
 func (client ComputeClient) UpdateDedicatedVmHost(ctx context.Context, request UpdateDedicatedVmHostRequest) (response UpdateDedicatedVmHostResponse, err error) {
 	var ociResponse common.OCIResponse

--- a/core/core_virtualnetwork_client.go
+++ b/core/core_virtualnetwork_client.go
@@ -416,6 +416,55 @@ func (client VirtualNetworkClient) changeDhcpOptionsCompartment(ctx context.Cont
 	return response, err
 }
 
+// ChangeDrgCompartment Moves a DRG into a different compartment within the same tenancy. For information
+// about moving resources between compartments, see
+// Moving Resources to a Different Compartment (https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+func (client VirtualNetworkClient) ChangeDrgCompartment(ctx context.Context, request ChangeDrgCompartmentRequest) (response ChangeDrgCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.changeDrgCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ChangeDrgCompartmentResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeDrgCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeDrgCompartmentResponse")
+	}
+	return
+}
+
+// changeDrgCompartment implements the OCIOperation interface (enables retrying operations)
+func (client VirtualNetworkClient) changeDrgCompartment(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/drgs/{drgId}/actions/changeCompartment")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeDrgCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // ChangeIPSecConnectionCompartment Moves an IPSec connection into a different compartment within the same tenancy. For information
 // about moving resources between compartments, see
 // Moving Resources to a Different Compartment (https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).

--- a/core/create_cluster_network_request_response.go
+++ b/core/create_cluster_network_request_response.go
@@ -59,6 +59,10 @@ type CreateClusterNetworkResponse struct {
 	// Unique Oracle-assigned identifier for the request. If you need to contact
 	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// The OCID of the work request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+	// with this ID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
 }
 
 func (response CreateClusterNetworkResponse) String() string {

--- a/core/create_dedicated_vm_host_details.go
+++ b/core/create_dedicated_vm_host_details.go
@@ -16,18 +16,18 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// CreateDedicatedVmHostDetails The details for creating a new dedicated virtual machine (VM) host.
+// CreateDedicatedVmHostDetails The details for creating a new dedicated virtual machine host.
 type CreateDedicatedVmHostDetails struct {
 
-	// The availability domain of the dedicated VM host.
+	// The availability domain of the dedicated virtual machine host.
 	// Example: `Uocm:PHX-AD-1`
 	AvailabilityDomain *string `mandatory:"true" json:"availabilityDomain"`
 
 	// The OCID of the compartment.
 	CompartmentId *string `mandatory:"true" json:"compartmentId"`
 
-	// The shape of the dedicated VM host. The shape determines the number of CPUs and
-	// other resources available for VMs.
+	// The dedicated virtual machine host shape. The shape determines the number of CPUs and
+	// other resources available for VM instances launched on the dedicated virtual machine host.
 	DedicatedVmHostShape *string `mandatory:"true" json:"dedicatedVmHostShape"`
 
 	// Defined tags for this resource. Each key is predefined and scoped to a
@@ -40,10 +40,12 @@ type CreateDedicatedVmHostDetails struct {
 	// Example: `My dedicated VM host`
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// The fault domain for the dedicated VM host's assigned instances. For more information, see Fault Domains.
-	// If you do not specify the fault domain, the system selects one for you. To change the fault domain for a dedicated VM host,
-	// delete it and create a new dedicated VM host in the preferred fault domain.
-	// To get a list of fault domains, use the ListFaultDomains operation in the Identity and Access Management Service API.
+	// The fault domain for the dedicated virtual machine host's assigned instances.
+	// For more information, see Fault Domains (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/regions.htm#fault).
+	// If you do not specify the fault domain, the system selects one for you. To change the fault domain for a dedicated virtual machine host,
+	// delete it and create a new dedicated virtual machine host in the preferred fault domain.
+	// To get a list of fault domains, use the `ListFaultDomains` operation in
+	// the Identity and Access Management Service API (https://docs.cloud.oracle.com/iaas/api/#/en/identity/20160918/).
 	// Example: `FAULT-DOMAIN-1`
 	FaultDomain *string `mandatory:"false" json:"faultDomain"`
 

--- a/core/create_ip_sec_connection_details.go
+++ b/core/create_ip_sec_connection_details.go
@@ -35,8 +35,10 @@ type CreateIpSecConnectionDetails struct {
 	// you must provide at least one valid static route. If you configure both
 	// tunnels to use BGP dynamic routing, you can provide an empty list for the static routes.
 	// For more information, see the important note in IPSecConnection.
-	//
+	// The CIDR can be either IPv4 or IPv6. Note that IPv6 addressing is currently supported only
+	// in the Government Cloud.
 	// Example: `10.0.1.0/24`
+	// Example: `2001:db8::/32`
 	StaticRoutes []string `mandatory:"true" json:"staticRoutes"`
 
 	// Defined tags for this resource. Each key is predefined and scoped to a

--- a/core/dedicated_vm_host.go
+++ b/core/dedicated_vm_host.go
@@ -16,17 +16,18 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// DedicatedVmHost A dedicated virtual machine (VM) host that enables you to host multiple virtual machine instances on a dedicated host that is not shared with other tenancies.
+// DedicatedVmHost A dedicated virtual machine host that enables you to host multiple VM instances
+// on a dedicated host that is not shared with other tenancies.
 type DedicatedVmHost struct {
 
-	// The availability domain the dedicated VM host is running in.
+	// The availability domain the dedicated virtual machine host is running in.
 	// Example: `Uocm:PHX-AD-1`
 	AvailabilityDomain *string `mandatory:"true" json:"availabilityDomain"`
 
-	// The OCID of the compartment that contains the dedicated VM host.
+	// The OCID of the compartment that contains the dedicated virtual machine host.
 	CompartmentId *string `mandatory:"true" json:"compartmentId"`
 
-	// The shape of the dedicated VM host. The shape determines the number of CPUs and
+	// The dedicated virtual machine host shape. The shape determines the number of CPUs and
 	// other resources available for VMs.
 	DedicatedVmHostShape *string `mandatory:"true" json:"dedicatedVmHostShape"`
 
@@ -56,10 +57,11 @@ type DedicatedVmHost struct {
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
-	// The fault domain for the dedicated VM host's assigned instances. For more information, see Fault Domains.
-	// If you do not specify the fault domain, the system selects one for you. To change the fault domain for a dedicated VM host,
-	// delete it and create a new dedicated VM host in the preferred fault domain.
-	// To get a list of fault domains, use the ListFaultDomains operation in the Identity and Access Management Service API.
+	// The fault domain for the dedicated virtual machine host's assigned instances.
+	// For more information, see Fault Domains (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/regions.htm#fault).
+	// If you do not specify the fault domain, the system selects one for you. To change the fault domain for a dedicated virtual machine host,
+	// delete it, and then create a new dedicated virtual machine host in the preferred fault domain.
+	// To get a list of fault domains, use the `ListFaultDomains` operation in the Identity and Access Management Service API (https://docs.cloud.oracle.com/iaas/api/#/en/identity/20160918/).
 	// Example: `FAULT-DOMAIN-1`
 	FaultDomain *string `mandatory:"false" json:"faultDomain"`
 

--- a/core/ip_sec_connection.go
+++ b/core/ip_sec_connection.go
@@ -59,8 +59,10 @@ type IpSecConnection struct {
 	// is using static routing. If you configure at least one tunnel to use static routing, then
 	// you must provide at least one valid static route. If you configure both
 	// tunnels to use BGP dynamic routing, you can provide an empty list for the static routes.
-	//
+	// The CIDR can be either IPv4 or IPv6. Note that IPv6 addressing is currently supported only
+	// in the Government Cloud.
 	// Example: `10.0.1.0/24`
+	// Example: `2001:db8::/32`
 	StaticRoutes []string `mandatory:"true" json:"staticRoutes"`
 
 	// Defined tags for this resource. Each key is predefined and scoped to a

--- a/core/launch_instance_configuration_request_response.go
+++ b/core/launch_instance_configuration_request_response.go
@@ -62,6 +62,10 @@ type LaunchInstanceConfigurationResponse struct {
 	// Unique Oracle-assigned identifier for the request. If you need to contact
 	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// The OCID of the work request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+	// with this ID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
 }
 
 func (response LaunchInstanceConfigurationResponse) String() string {

--- a/core/list_dedicated_vm_host_shapes_request_response.go
+++ b/core/list_dedicated_vm_host_shapes_request_response.go
@@ -18,7 +18,7 @@ type ListDedicatedVmHostShapesRequest struct {
 	// Example: `Uocm:PHX-AD-1`
 	AvailabilityDomain *string `mandatory:"false" contributesTo:"query" name:"availabilityDomain"`
 
-	// Instance shape name
+	// The name for the instance's shape.
 	InstanceShapeName *string `mandatory:"false" contributesTo:"query" name:"instanceShapeName"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated

--- a/core/list_dedicated_vm_hosts_request_response.go
+++ b/core/list_dedicated_vm_hosts_request_response.go
@@ -24,7 +24,7 @@ type ListDedicatedVmHostsRequest struct {
 	// A filter to return only resources that match the given display name exactly.
 	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
 
-	// Instance shape name
+	// The name for the instance's shape.
 	InstanceShapeName *string `mandatory:"false" contributesTo:"query" name:"instanceShapeName"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated

--- a/core/terminate_cluster_network_request_response.go
+++ b/core/terminate_cluster_network_request_response.go
@@ -51,6 +51,10 @@ type TerminateClusterNetworkResponse struct {
 	// Unique Oracle-assigned identifier for the request. If you need to contact
 	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// The OCID of the work request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+	// with this ID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
 }
 
 func (response TerminateClusterNetworkResponse) String() string {

--- a/core/update_dedicated_vm_host_details.go
+++ b/core/update_dedicated_vm_host_details.go
@@ -16,7 +16,7 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// UpdateDedicatedVmHostDetails Update dedicated VM host details.
+// UpdateDedicatedVmHostDetails Details for updating the dedicated virtual machine host details.
 type UpdateDedicatedVmHostDetails struct {
 
 	// Defined tags for this resource. Each key is predefined and scoped to a

--- a/core/update_ip_sec_connection_details.go
+++ b/core/update_ip_sec_connection_details.go
@@ -48,7 +48,10 @@ type UpdateIpSecConnectionDetails struct {
 
 	// Static routes to the CPE. If you provide this attribute, it replaces the entire current set of
 	// static routes. A static route's CIDR must not be a multicast address or class E address.
+	// The CIDR can be either IPv4 or IPv6. Note that IPv6 addressing is currently supported only
+	// in the Government Cloud.
 	// Example: `10.0.1.0/24`
+	// Example: `2001:db8::/32`
 	StaticRoutes []string `mandatory:"false" json:"staticRoutes"`
 }
 

--- a/database/db_system.go
+++ b/database/db_system.go
@@ -72,6 +72,8 @@ type DbSystem struct {
 	// A list of the OCIDs (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see Security Rules (https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm). Applicable only to Exadata DB systems.
 	BackupNetworkNsgIds []string `mandatory:"false" json:"backupNetworkNsgIds"`
 
+	DbSystemOptions *DbSystemOptions `mandatory:"false" json:"dbSystemOptions"`
+
 	// The time zone of the DB system. For details, see DB System Time Zones (https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
 	TimeZone *string `mandatory:"false" json:"timeZone"`
 

--- a/database/db_system_options.go
+++ b/database/db_system_options.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service.
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DbSystemOptions The DB system options.
+type DbSystemOptions struct {
+
+	// The storage option used in DB system. You can specify either Automatic Storage Management (ASM) (https://www.oracle.com/pls/topic/lookup?ctx=en/database/oracle/oracle-database/19&id=OSTMG-GUID-BC612D35-5399-4A35-843E-CF76E3D3CDB5) or Logical Volume Manager (LVM) (https://www.oracle.com/pls/topic/lookup?ctx=en/database/oracle/oracle-database/19&id=ADMIN-GUID-57C50259-9472-4ED0-8818-DB9ABA96EC8E).
+	StorageManagement DbSystemOptionsStorageManagementEnum `mandatory:"false" json:"storageManagement,omitempty"`
+}
+
+func (m DbSystemOptions) String() string {
+	return common.PointerString(m)
+}
+
+// DbSystemOptionsStorageManagementEnum Enum with underlying type: string
+type DbSystemOptionsStorageManagementEnum string
+
+// Set of constants representing the allowable values for DbSystemOptionsStorageManagementEnum
+const (
+	DbSystemOptionsStorageManagementAsm DbSystemOptionsStorageManagementEnum = "ASM"
+	DbSystemOptionsStorageManagementLvm DbSystemOptionsStorageManagementEnum = "LVM"
+)
+
+var mappingDbSystemOptionsStorageManagement = map[string]DbSystemOptionsStorageManagementEnum{
+	"ASM": DbSystemOptionsStorageManagementAsm,
+	"LVM": DbSystemOptionsStorageManagementLvm,
+}
+
+// GetDbSystemOptionsStorageManagementEnumValues Enumerates the set of values for DbSystemOptionsStorageManagementEnum
+func GetDbSystemOptionsStorageManagementEnumValues() []DbSystemOptionsStorageManagementEnum {
+	values := make([]DbSystemOptionsStorageManagementEnum, 0)
+	for _, v := range mappingDbSystemOptionsStorageManagement {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/db_system_summary.go
+++ b/database/db_system_summary.go
@@ -83,6 +83,8 @@ type DbSystemSummary struct {
 	// A list of the OCIDs (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that the backup network of this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see Security Rules (https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm). Applicable only to Exadata DB systems.
 	BackupNetworkNsgIds []string `mandatory:"false" json:"backupNetworkNsgIds"`
 
+	DbSystemOptions *DbSystemOptions `mandatory:"false" json:"dbSystemOptions"`
+
 	// The time zone of the DB system. For details, see DB System Time Zones (https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
 	TimeZone *string `mandatory:"false" json:"timeZone"`
 

--- a/database/launch_db_system_base.go
+++ b/database/launch_db_system_base.go
@@ -93,6 +93,8 @@ type LaunchDbSystemBase interface {
 	// The time zone to use for the DB system. For details, see DB System Time Zones (https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
 	GetTimeZone() *string
 
+	GetDbSystemOptions() *DbSystemOptions
+
 	// If true, Sparse Diskgroup is configured for Exadata dbsystem. If False, Sparse diskgroup is not configured.
 	GetSparseDiskgroup() *bool
 
@@ -140,6 +142,7 @@ type launchdbsystembase struct {
 	NsgIds                     []string                          `mandatory:"false" json:"nsgIds"`
 	BackupNetworkNsgIds        []string                          `mandatory:"false" json:"backupNetworkNsgIds"`
 	TimeZone                   *string                           `mandatory:"false" json:"timeZone"`
+	DbSystemOptions            *DbSystemOptions                  `mandatory:"false" json:"dbSystemOptions"`
 	SparseDiskgroup            *bool                             `mandatory:"false" json:"sparseDiskgroup"`
 	Domain                     *string                           `mandatory:"false" json:"domain"`
 	ClusterName                *string                           `mandatory:"false" json:"clusterName"`
@@ -175,6 +178,7 @@ func (m *launchdbsystembase) UnmarshalJSON(data []byte) error {
 	m.NsgIds = s.Model.NsgIds
 	m.BackupNetworkNsgIds = s.Model.BackupNetworkNsgIds
 	m.TimeZone = s.Model.TimeZone
+	m.DbSystemOptions = s.Model.DbSystemOptions
 	m.SparseDiskgroup = s.Model.SparseDiskgroup
 	m.Domain = s.Model.Domain
 	m.ClusterName = s.Model.ClusterName
@@ -273,6 +277,11 @@ func (m launchdbsystembase) GetBackupNetworkNsgIds() []string {
 //GetTimeZone returns TimeZone
 func (m launchdbsystembase) GetTimeZone() *string {
 	return m.TimeZone
+}
+
+//GetDbSystemOptions returns DbSystemOptions
+func (m launchdbsystembase) GetDbSystemOptions() *DbSystemOptions {
+	return m.DbSystemOptions
 }
 
 //GetSparseDiskgroup returns SparseDiskgroup

--- a/database/launch_db_system_details.go
+++ b/database/launch_db_system_details.go
@@ -94,6 +94,8 @@ type LaunchDbSystemDetails struct {
 	// The time zone to use for the DB system. For details, see DB System Time Zones (https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
 	TimeZone *string `mandatory:"false" json:"timeZone"`
 
+	DbSystemOptions *DbSystemOptions `mandatory:"false" json:"dbSystemOptions"`
+
 	// If true, Sparse Diskgroup is configured for Exadata dbsystem. If False, Sparse diskgroup is not configured.
 	SparseDiskgroup *bool `mandatory:"false" json:"sparseDiskgroup"`
 
@@ -186,6 +188,11 @@ func (m LaunchDbSystemDetails) GetShape() *string {
 //GetTimeZone returns TimeZone
 func (m LaunchDbSystemDetails) GetTimeZone() *string {
 	return m.TimeZone
+}
+
+//GetDbSystemOptions returns DbSystemOptions
+func (m LaunchDbSystemDetails) GetDbSystemOptions() *DbSystemOptions {
+	return m.DbSystemOptions
 }
 
 //GetSparseDiskgroup returns SparseDiskgroup

--- a/database/launch_db_system_from_backup_details.go
+++ b/database/launch_db_system_from_backup_details.go
@@ -94,6 +94,8 @@ type LaunchDbSystemFromBackupDetails struct {
 	// The time zone to use for the DB system. For details, see DB System Time Zones (https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
 	TimeZone *string `mandatory:"false" json:"timeZone"`
 
+	DbSystemOptions *DbSystemOptions `mandatory:"false" json:"dbSystemOptions"`
+
 	// If true, Sparse Diskgroup is configured for Exadata dbsystem. If False, Sparse diskgroup is not configured.
 	SparseDiskgroup *bool `mandatory:"false" json:"sparseDiskgroup"`
 
@@ -186,6 +188,11 @@ func (m LaunchDbSystemFromBackupDetails) GetShape() *string {
 //GetTimeZone returns TimeZone
 func (m LaunchDbSystemFromBackupDetails) GetTimeZone() *string {
 	return m.TimeZone
+}
+
+//GetDbSystemOptions returns DbSystemOptions
+func (m LaunchDbSystemFromBackupDetails) GetDbSystemOptions() *DbSystemOptions {
+	return m.DbSystemOptions
 }
 
 //GetSparseDiskgroup returns SparseDiskgroup

--- a/dns/create_migrated_dynect_zone_details.go
+++ b/dns/create_migrated_dynect_zone_details.go
@@ -14,9 +14,9 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// CreateZoneDetails The body for defining a new zone.
+// CreateMigratedDynectZoneDetails The body for migrating a zone from DynECT.
 // **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
-type CreateZoneDetails struct {
+type CreateMigratedDynectZoneDetails struct {
 
 	// The name of the zone.
 	Name *string `mandatory:"true" json:"name"`
@@ -36,71 +36,43 @@ type CreateZoneDetails struct {
 	// **Example:** `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
-	// External master servers for the zone. `externalMasters` becomes a
-	// required parameter when the `zoneType` value is `SECONDARY`.
-	ExternalMasters []ExternalMaster `mandatory:"false" json:"externalMasters"`
-
-	// The type of the zone. Must be either `PRIMARY` or `SECONDARY`.
-	ZoneType CreateZoneDetailsZoneTypeEnum `mandatory:"false" json:"zoneType,omitempty"`
+	DynectMigrationDetails *DynectMigrationDetails `mandatory:"false" json:"dynectMigrationDetails"`
 }
 
 //GetName returns Name
-func (m CreateZoneDetails) GetName() *string {
+func (m CreateMigratedDynectZoneDetails) GetName() *string {
 	return m.Name
 }
 
 //GetCompartmentId returns CompartmentId
-func (m CreateZoneDetails) GetCompartmentId() *string {
+func (m CreateMigratedDynectZoneDetails) GetCompartmentId() *string {
 	return m.CompartmentId
 }
 
 //GetFreeformTags returns FreeformTags
-func (m CreateZoneDetails) GetFreeformTags() map[string]string {
+func (m CreateMigratedDynectZoneDetails) GetFreeformTags() map[string]string {
 	return m.FreeformTags
 }
 
 //GetDefinedTags returns DefinedTags
-func (m CreateZoneDetails) GetDefinedTags() map[string]map[string]interface{} {
+func (m CreateMigratedDynectZoneDetails) GetDefinedTags() map[string]map[string]interface{} {
 	return m.DefinedTags
 }
 
-func (m CreateZoneDetails) String() string {
+func (m CreateMigratedDynectZoneDetails) String() string {
 	return common.PointerString(m)
 }
 
 // MarshalJSON marshals to json representation
-func (m CreateZoneDetails) MarshalJSON() (buff []byte, e error) {
-	type MarshalTypeCreateZoneDetails CreateZoneDetails
+func (m CreateMigratedDynectZoneDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateMigratedDynectZoneDetails CreateMigratedDynectZoneDetails
 	s := struct {
 		DiscriminatorParam string `json:"migrationSource"`
-		MarshalTypeCreateZoneDetails
+		MarshalTypeCreateMigratedDynectZoneDetails
 	}{
-		"NONE",
-		(MarshalTypeCreateZoneDetails)(m),
+		"DYNECT",
+		(MarshalTypeCreateMigratedDynectZoneDetails)(m),
 	}
 
 	return json.Marshal(&s)
-}
-
-// CreateZoneDetailsZoneTypeEnum Enum with underlying type: string
-type CreateZoneDetailsZoneTypeEnum string
-
-// Set of constants representing the allowable values for CreateZoneDetailsZoneTypeEnum
-const (
-	CreateZoneDetailsZoneTypePrimary   CreateZoneDetailsZoneTypeEnum = "PRIMARY"
-	CreateZoneDetailsZoneTypeSecondary CreateZoneDetailsZoneTypeEnum = "SECONDARY"
-)
-
-var mappingCreateZoneDetailsZoneType = map[string]CreateZoneDetailsZoneTypeEnum{
-	"PRIMARY":   CreateZoneDetailsZoneTypePrimary,
-	"SECONDARY": CreateZoneDetailsZoneTypeSecondary,
-}
-
-// GetCreateZoneDetailsZoneTypeEnumValues Enumerates the set of values for CreateZoneDetailsZoneTypeEnum
-func GetCreateZoneDetailsZoneTypeEnumValues() []CreateZoneDetailsZoneTypeEnum {
-	values := make([]CreateZoneDetailsZoneTypeEnum, 0)
-	for _, v := range mappingCreateZoneDetailsZoneType {
-		values = append(values, v)
-	}
-	return values
 }

--- a/dns/create_zone_base_details.go
+++ b/dns/create_zone_base_details.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// DNS API
+//
+// API for the DNS service. Use this API to manage DNS zones, records, and other DNS resources.
+// For more information, see Overview of the DNS Service (https://docs.cloud.oracle.com/iaas/Content/DNS/Concepts/dnszonemanagement.htm).
+//
+
+package dns
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateZoneBaseDetails The body for either defining a new zone or migrating a zone from migrationSource. This is determined by the migrationSource discriminator.
+// NONE indicates creation of a new zone (default). DYNECT indicates migration from a DynECT zone.
+// **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+type CreateZoneBaseDetails interface {
+
+	// The name of the zone.
+	GetName() *string
+
+	// The OCID of the compartment containing the zone.
+	GetCompartmentId() *string
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	//
+	// **Example:** `{"Department": "Finance"}`
+	GetFreeformTags() map[string]string
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	//
+	// **Example:** `{"Operations": {"CostCenter": "42"}}`
+	GetDefinedTags() map[string]map[string]interface{}
+}
+
+type createzonebasedetails struct {
+	JsonData        []byte
+	Name            *string                           `mandatory:"true" json:"name"`
+	CompartmentId   *string                           `mandatory:"true" json:"compartmentId"`
+	FreeformTags    map[string]string                 `mandatory:"false" json:"freeformTags"`
+	DefinedTags     map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+	MigrationSource string                            `json:"migrationSource"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *createzonebasedetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalercreatezonebasedetails createzonebasedetails
+	s := struct {
+		Model Unmarshalercreatezonebasedetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Name = s.Model.Name
+	m.CompartmentId = s.Model.CompartmentId
+	m.FreeformTags = s.Model.FreeformTags
+	m.DefinedTags = s.Model.DefinedTags
+	m.MigrationSource = s.Model.MigrationSource
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *createzonebasedetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.MigrationSource {
+	case "NONE":
+		mm := CreateZoneDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "DYNECT":
+		mm := CreateMigratedDynectZoneDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetName returns Name
+func (m createzonebasedetails) GetName() *string {
+	return m.Name
+}
+
+//GetCompartmentId returns CompartmentId
+func (m createzonebasedetails) GetCompartmentId() *string {
+	return m.CompartmentId
+}
+
+//GetFreeformTags returns FreeformTags
+func (m createzonebasedetails) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m createzonebasedetails) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
+}
+
+func (m createzonebasedetails) String() string {
+	return common.PointerString(m)
+}

--- a/dns/dynect_migration_details.go
+++ b/dns/dynect_migration_details.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// DNS API
+//
+// API for the DNS service. Use this API to manage DNS zones, records, and other DNS resources.
+// For more information, see Overview of the DNS Service (https://docs.cloud.oracle.com/iaas/Content/DNS/Concepts/dnszonemanagement.htm).
+//
+
+package dns
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DynectMigrationDetails Details specific to performing a DynECT zone migration.
+type DynectMigrationDetails struct {
+
+	// DynECT customer name the zone belongs to.
+	CustomerName *string `mandatory:"true" json:"customerName"`
+
+	// DynECT API username to perform the migration with.
+	Username *string `mandatory:"true" json:"username"`
+
+	// DynECT API password for the provided username.
+	Password *string `mandatory:"true" json:"password"`
+}
+
+func (m DynectMigrationDetails) String() string {
+	return common.PointerString(m)
+}

--- a/functions/functions_functionsmanagement_client.go
+++ b/functions/functions_functionsmanagement_client.go
@@ -37,7 +37,7 @@ func NewFunctionsManagementClientWithConfigurationProvider(configProvider common
 
 // SetRegion overrides the region of this client.
 func (client *FunctionsManagementClient) SetRegion(region string) {
-	client.Host = common.StringToRegion(region).EndpointForTemplate("functions", "https://functions.{region}.{secondLevelDomain}")
+	client.Host = common.StringToRegion(region).EndpointForTemplate("functions", "https://functions.{region}.oci.{secondLevelDomain}")
 }
 
 // SetConfigurationProvider sets the configuration provider including the region, returns an error if is not valid

--- a/identity/assemble_effective_tag_set_request_response.go
+++ b/identity/assemble_effective_tag_set_request_response.go
@@ -8,17 +8,14 @@ import (
 	"net/http"
 )
 
-// ListCostTrackingTagsRequest wrapper for the ListCostTrackingTags operation
-type ListCostTrackingTagsRequest struct {
+// AssembleEffectiveTagSetRequest wrapper for the AssembleEffectiveTagSet operation
+type AssembleEffectiveTagSetRequest struct {
 
 	// The OCID of the compartment (remember that the tenancy is simply the root compartment).
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
-	// The value of the `opc-next-page` response header from the previous "List" call.
-	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
-
-	// The maximum number of items to return in a paginated "List" call.
-	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+	// A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+	LifecycleState TagDefaultSummaryLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// Unique Oracle-assigned identifier for the request.
 	// If you need to contact Oracle about a particular request, please provide the request ID.
@@ -29,45 +26,44 @@ type ListCostTrackingTagsRequest struct {
 	RequestMetadata common.RequestMetadata
 }
 
-func (request ListCostTrackingTagsRequest) String() string {
+func (request AssembleEffectiveTagSetRequest) String() string {
 	return common.PointerString(request)
 }
 
 // HTTPRequest implements the OCIRequest interface
-func (request ListCostTrackingTagsRequest) HTTPRequest(method, path string) (http.Request, error) {
+func (request AssembleEffectiveTagSetRequest) HTTPRequest(method, path string) (http.Request, error) {
 	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
 }
 
 // RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
-func (request ListCostTrackingTagsRequest) RetryPolicy() *common.RetryPolicy {
+func (request AssembleEffectiveTagSetRequest) RetryPolicy() *common.RetryPolicy {
 	return request.RequestMetadata.RetryPolicy
 }
 
-// ListCostTrackingTagsResponse wrapper for the ListCostTrackingTags operation
-type ListCostTrackingTagsResponse struct {
+// AssembleEffectiveTagSetResponse wrapper for the AssembleEffectiveTagSet operation
+type AssembleEffectiveTagSetResponse struct {
 
 	// The underlying http response
 	RawResponse *http.Response
 
-	// A list of []Tag instances
-	Items []Tag `presentIn:"body"`
+	// The []TagDefaultSummary instance
+	Items []TagDefaultSummary `presentIn:"body"`
 
 	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
 	// particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 
-	// For pagination of a list of cost tracking tag. When paging through a list, if this header appears in the response,
-	// then a partial list might have been returned. Include this value as the `page` parameter for the
-	// subsequent GET request to get the next batch of items. For important details about how pagination works,
-	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// For pagination of a list of tag default values. When paging through a list, if this header appears in
+	// the response, then a partial list might have been returned. Include this value as the `page` parameter
+	// for the subsequent GET request to get the next batch of items.
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 }
 
-func (response ListCostTrackingTagsResponse) String() string {
+func (response AssembleEffectiveTagSetResponse) String() string {
 	return common.PointerString(response)
 }
 
 // HTTPResponse implements the OCIResponse interface
-func (response ListCostTrackingTagsResponse) HTTPResponse() *http.Response {
+func (response AssembleEffectiveTagSetResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
 }

--- a/identity/base_tag_definition_validator.go
+++ b/identity/base_tag_definition_validator.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Identity and Access Management Service API
+//
+// APIs for managing users, groups, compartments, and policies.
+//
+
+package identity
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// BaseTagDefinitionValidator Validates a definedTag value. Each validator performs validation steps in addition to the standard validation
+// for definedTag values (See Limits on Tags (https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm#Limits).
+// If a validator is defined after a value has been set for a definedTag, then any UPDATE operation that attempts
+// to change the value must pass the additional validation defined by this rule. Previously set values, that would
+// fail validation, are not updated and it is possible to update other attributes of an OCI resource that contains
+// a non-valid definedTag.
+// To clear the validator call the UPDATE operation with DefaultTagDefinitionValidator.
+type BaseTagDefinitionValidator interface {
+}
+
+type basetagdefinitionvalidator struct {
+	JsonData      []byte
+	ValidatorType string `json:"validatorType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *basetagdefinitionvalidator) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerbasetagdefinitionvalidator basetagdefinitionvalidator
+	s := struct {
+		Model Unmarshalerbasetagdefinitionvalidator
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.ValidatorType = s.Model.ValidatorType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *basetagdefinitionvalidator) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ValidatorType {
+	case "DEFAULT":
+		mm := DefaultTagDefinitionValidator{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ENUM":
+		mm := EnumTagDefinitionValidator{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m basetagdefinitionvalidator) String() string {
+	return common.PointerString(m)
+}

--- a/identity/compartment.go
+++ b/identity/compartment.go
@@ -26,6 +26,8 @@ import (
 // To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
 // talk to an administrator. If you're an administrator who needs to write policies to give users access,
 // see Getting Started with Policies (https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+// **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values
+// using the API.
 type Compartment struct {
 
 	// The OCID of the compartment.

--- a/identity/create_region_subscription_details.go
+++ b/identity/create_region_subscription_details.go
@@ -21,6 +21,9 @@ type CreateRegionSubscriptionDetails struct {
 	// - `IAD`
 	// - `FRA`
 	// - `LHR`
+	// - `YYZ`
+	// - `NRT`
+	// - `ICN`
 	// Example: `PHX`
 	RegionKey *string `mandatory:"true" json:"regionKey"`
 }

--- a/identity/create_tag_default_details.go
+++ b/identity/create_tag_default_details.go
@@ -23,6 +23,14 @@ type CreateTagDefaultDetails struct {
 
 	// The default value for the tag definition. This will be applied to all new resources created in the compartment.
 	Value *string `mandatory:"true" json:"value"`
+
+	// If you specify that a value is required, a value is set during resource creation (either by
+	// the user creating the resource or another tag defualt). If no value is set, resource
+	// creation is blocked.
+	// * If the `isRequired` flag is set to "true", the value is set during resource creation.
+	// * If the `isRequired` flag is set to "false", the value you enter is set during resource creation.
+	// Example: `false`
+	IsRequired *bool `mandatory:"false" json:"isRequired"`
 }
 
 func (m CreateTagDefaultDetails) String() string {

--- a/identity/create_tag_details.go
+++ b/identity/create_tag_details.go
@@ -9,13 +9,15 @@
 package identity
 
 import (
+	"encoding/json"
 	"github.com/oracle/oci-go-sdk/common"
 )
 
 // CreateTagDetails The representation of CreateTagDetails
 type CreateTagDetails struct {
 
-	// The name you assign to the tag during creation. The name must be unique within the tag namespace and cannot be changed.
+	// The name you assign to the tag during creation. This is the tag key definition.
+	// The name must be unique within the tag namespace and cannot be changed.
 	Name *string `mandatory:"true" json:"name"`
 
 	// The description you assign to the tag during creation.
@@ -33,8 +35,45 @@ type CreateTagDetails struct {
 
 	// Indicates whether the tag is enabled for cost tracking.
 	IsCostTracking *bool `mandatory:"false" json:"isCostTracking"`
+
+	// Additional validation rule for values specified for the tag definition.
+	// If no validator is defined for a tag definition, then any (valid) value will be accepted.
+	// The default value for `validator` is an empty map (no additional validation).
+	Validator BaseTagDefinitionValidator `mandatory:"false" json:"validator"`
 }
 
 func (m CreateTagDetails) String() string {
 	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *CreateTagDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		FreeformTags   map[string]string                 `json:"freeformTags"`
+		DefinedTags    map[string]map[string]interface{} `json:"definedTags"`
+		IsCostTracking *bool                             `json:"isCostTracking"`
+		Validator      basetagdefinitionvalidator        `json:"validator"`
+		Name           *string                           `json:"name"`
+		Description    *string                           `json:"description"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	m.FreeformTags = model.FreeformTags
+	m.DefinedTags = model.DefinedTags
+	m.IsCostTracking = model.IsCostTracking
+	nn, e := model.Validator.UnmarshalPolymorphicJSON(model.Validator.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.Validator = nn.(BaseTagDefinitionValidator)
+	} else {
+		m.Validator = nil
+	}
+	m.Name = model.Name
+	m.Description = model.Description
+	return
 }

--- a/identity/default_tag_definition_validator.go
+++ b/identity/default_tag_definition_validator.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Identity and Access Management Service API
+//
+// APIs for managing users, groups, compartments, and policies.
+//
+
+package identity
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DefaultTagDefinitionValidator This is the default validatorType for definedTag. This is same as not setting any value on the validator field.
+// By default only string value can be set for this definedTag.
+type DefaultTagDefinitionValidator struct {
+}
+
+func (m DefaultTagDefinitionValidator) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DefaultTagDefinitionValidator) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDefaultTagDefinitionValidator DefaultTagDefinitionValidator
+	s := struct {
+		DiscriminatorParam string `json:"validatorType"`
+		MarshalTypeDefaultTagDefinitionValidator
+	}{
+		"DEFAULT",
+		(MarshalTypeDefaultTagDefinitionValidator)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/identity/dynamic_group.go
+++ b/identity/dynamic_group.go
@@ -20,6 +20,8 @@ import (
 // This works like regular user/group membership. But in that case, the membership is a static relationship, whereas
 // in a dynamic group, the membership of an instance certificate to a dynamic group is determined during runtime.
 // For more information, see Managing Dynamic Groups (https://docs.cloud.oracle.com/Content/Identity/Tasks/managingdynamicgroups.htm).
+// **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using
+// the API.
 type DynamicGroup struct {
 
 	// The OCID of the group.

--- a/identity/enum_tag_definition_validator.go
+++ b/identity/enum_tag_definition_validator.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Identity and Access Management Service API
+//
+// APIs for managing users, groups, compartments, and policies.
+//
+
+package identity
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// EnumTagDefinitionValidator Validates the 'value' set for a definedTag is contained in the list of allowable 'values'.
+// If the 'validatorType' is 'ENUM', then at least one valid value must be specified in the 'values' array.
+type EnumTagDefinitionValidator struct {
+
+	// The list of allowed values for a definedTag value.
+	Values []string `mandatory:"false" json:"values"`
+}
+
+func (m EnumTagDefinitionValidator) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m EnumTagDefinitionValidator) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeEnumTagDefinitionValidator EnumTagDefinitionValidator
+	s := struct {
+		DiscriminatorParam string `json:"validatorType"`
+		MarshalTypeEnumTagDefinitionValidator
+	}{
+		"ENUM",
+		(MarshalTypeEnumTagDefinitionValidator)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/identity/get_tagging_work_request_request_response.go
+++ b/identity/get_tagging_work_request_request_response.go
@@ -1,21 +1,18 @@
 // Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 // Code generated. DO NOT EDIT.
 
-package dns
+package identity
 
 import (
 	"github.com/oracle/oci-go-sdk/common"
 	"net/http"
 )
 
-// CreateZoneRequest wrapper for the CreateZone operation
-type CreateZoneRequest struct {
+// GetTaggingWorkRequestRequest wrapper for the GetTaggingWorkRequest operation
+type GetTaggingWorkRequestRequest struct {
 
-	// Details for creating a new zone.
-	CreateZoneDetails CreateZoneBaseDetails `contributesTo:"body"`
-
-	// The OCID of the compartment the resource belongs to.
-	CompartmentId *string `mandatory:"false" contributesTo:"query" name:"compartmentId"`
+	// The OCID of the work request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
 
 	// Unique Oracle-assigned identifier for the request.
 	// If you need to contact Oracle about a particular request, please provide the request ID.
@@ -26,44 +23,42 @@ type CreateZoneRequest struct {
 	RequestMetadata common.RequestMetadata
 }
 
-func (request CreateZoneRequest) String() string {
+func (request GetTaggingWorkRequestRequest) String() string {
 	return common.PointerString(request)
 }
 
 // HTTPRequest implements the OCIRequest interface
-func (request CreateZoneRequest) HTTPRequest(method, path string) (http.Request, error) {
+func (request GetTaggingWorkRequestRequest) HTTPRequest(method, path string) (http.Request, error) {
 	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
 }
 
 // RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
-func (request CreateZoneRequest) RetryPolicy() *common.RetryPolicy {
+func (request GetTaggingWorkRequestRequest) RetryPolicy() *common.RetryPolicy {
 	return request.RequestMetadata.RetryPolicy
 }
 
-// CreateZoneResponse wrapper for the CreateZone operation
-type CreateZoneResponse struct {
+// GetTaggingWorkRequestResponse wrapper for the GetTaggingWorkRequest operation
+type GetTaggingWorkRequestResponse struct {
 
 	// The underlying http response
 	RawResponse *http.Response
 
-	// The Zone instance
-	Zone `presentIn:"body"`
+	// The TaggingWorkRequest instance
+	TaggingWorkRequest `presentIn:"body"`
 
-	// Unique Oracle-assigned identifier for the request. If you need to
-	// contact Oracle about a particular request, please provide the request ID.
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 
-	// The current version of the zone, ending with a
-	// representation-specific suffix. This value may be used in If-Match
-	// and If-None-Match headers for later requests of the same resource.
-	ETag *string `presentIn:"header" name:"etag"`
+	// The number of seconds that the client should wait before polling again.
+	RetryAfter *float32 `presentIn:"header" name:"retry-after"`
 }
 
-func (response CreateZoneResponse) String() string {
+func (response GetTaggingWorkRequestResponse) String() string {
 	return common.PointerString(response)
 }
 
 // HTTPResponse implements the OCIResponse interface
-func (response CreateZoneResponse) HTTPResponse() *http.Response {
+func (response GetTaggingWorkRequestResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
 }

--- a/identity/group.go
+++ b/identity/group.go
@@ -23,6 +23,8 @@ import (
 // To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
 // talk to an administrator. If you're an administrator who needs to write policies to give users access,
 // see Getting Started with Policies (https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+// **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values
+// using the API.
 type Group struct {
 
 	// The OCID of the group.

--- a/identity/identity_provider.go
+++ b/identity/identity_provider.go
@@ -21,6 +21,8 @@ import (
 // To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
 // talk to an administrator. If you're an administrator who needs to write policies to give users access,
 // see Getting Started with Policies (https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+// **Warning:** Oracle recommends that you avoid using any confidential information when you supply string
+// values using the API.
 type IdentityProvider interface {
 
 	// The OCID of the `IdentityProvider`.

--- a/identity/list_tagging_work_request_errors_request_response.go
+++ b/identity/list_tagging_work_request_errors_request_response.go
@@ -8,11 +8,11 @@ import (
 	"net/http"
 )
 
-// ListCostTrackingTagsRequest wrapper for the ListCostTrackingTags operation
-type ListCostTrackingTagsRequest struct {
+// ListTaggingWorkRequestErrorsRequest wrapper for the ListTaggingWorkRequestErrors operation
+type ListTaggingWorkRequestErrorsRequest struct {
 
-	// The OCID of the compartment (remember that the tenancy is simply the root compartment).
-	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+	// The OCID of the work request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
 
 	// The value of the `opc-next-page` response header from the previous "List" call.
 	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
@@ -29,45 +29,47 @@ type ListCostTrackingTagsRequest struct {
 	RequestMetadata common.RequestMetadata
 }
 
-func (request ListCostTrackingTagsRequest) String() string {
+func (request ListTaggingWorkRequestErrorsRequest) String() string {
 	return common.PointerString(request)
 }
 
 // HTTPRequest implements the OCIRequest interface
-func (request ListCostTrackingTagsRequest) HTTPRequest(method, path string) (http.Request, error) {
+func (request ListTaggingWorkRequestErrorsRequest) HTTPRequest(method, path string) (http.Request, error) {
 	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
 }
 
 // RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
-func (request ListCostTrackingTagsRequest) RetryPolicy() *common.RetryPolicy {
+func (request ListTaggingWorkRequestErrorsRequest) RetryPolicy() *common.RetryPolicy {
 	return request.RequestMetadata.RetryPolicy
 }
 
-// ListCostTrackingTagsResponse wrapper for the ListCostTrackingTags operation
-type ListCostTrackingTagsResponse struct {
+// ListTaggingWorkRequestErrorsResponse wrapper for the ListTaggingWorkRequestErrors operation
+type ListTaggingWorkRequestErrorsResponse struct {
 
 	// The underlying http response
 	RawResponse *http.Response
 
-	// A list of []Tag instances
-	Items []Tag `presentIn:"body"`
+	// A list of []TaggingWorkRequestErrorSummary instances
+	Items []TaggingWorkRequestErrorSummary `presentIn:"body"`
 
 	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
 	// particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 
-	// For pagination of a list of cost tracking tag. When paging through a list, if this header appears in the response,
+	// The number of seconds that the client should wait before polling again.
+	RetryAfter *float32 `presentIn:"header" name:"retry-after"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
 	// then a partial list might have been returned. Include this value as the `page` parameter for the
-	// subsequent GET request to get the next batch of items. For important details about how pagination works,
-	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// subsequent GET request to get the next batch of items.
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 }
 
-func (response ListCostTrackingTagsResponse) String() string {
+func (response ListTaggingWorkRequestErrorsResponse) String() string {
 	return common.PointerString(response)
 }
 
 // HTTPResponse implements the OCIResponse interface
-func (response ListCostTrackingTagsResponse) HTTPResponse() *http.Response {
+func (response ListTaggingWorkRequestErrorsResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
 }

--- a/identity/list_tagging_work_request_logs_request_response.go
+++ b/identity/list_tagging_work_request_logs_request_response.go
@@ -8,11 +8,11 @@ import (
 	"net/http"
 )
 
-// ListCostTrackingTagsRequest wrapper for the ListCostTrackingTags operation
-type ListCostTrackingTagsRequest struct {
+// ListTaggingWorkRequestLogsRequest wrapper for the ListTaggingWorkRequestLogs operation
+type ListTaggingWorkRequestLogsRequest struct {
 
-	// The OCID of the compartment (remember that the tenancy is simply the root compartment).
-	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+	// The OCID of the work request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
 
 	// The value of the `opc-next-page` response header from the previous "List" call.
 	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
@@ -29,45 +29,47 @@ type ListCostTrackingTagsRequest struct {
 	RequestMetadata common.RequestMetadata
 }
 
-func (request ListCostTrackingTagsRequest) String() string {
+func (request ListTaggingWorkRequestLogsRequest) String() string {
 	return common.PointerString(request)
 }
 
 // HTTPRequest implements the OCIRequest interface
-func (request ListCostTrackingTagsRequest) HTTPRequest(method, path string) (http.Request, error) {
+func (request ListTaggingWorkRequestLogsRequest) HTTPRequest(method, path string) (http.Request, error) {
 	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
 }
 
 // RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
-func (request ListCostTrackingTagsRequest) RetryPolicy() *common.RetryPolicy {
+func (request ListTaggingWorkRequestLogsRequest) RetryPolicy() *common.RetryPolicy {
 	return request.RequestMetadata.RetryPolicy
 }
 
-// ListCostTrackingTagsResponse wrapper for the ListCostTrackingTags operation
-type ListCostTrackingTagsResponse struct {
+// ListTaggingWorkRequestLogsResponse wrapper for the ListTaggingWorkRequestLogs operation
+type ListTaggingWorkRequestLogsResponse struct {
 
 	// The underlying http response
 	RawResponse *http.Response
 
-	// A list of []Tag instances
-	Items []Tag `presentIn:"body"`
+	// A list of []TaggingWorkRequestLogSummary instances
+	Items []TaggingWorkRequestLogSummary `presentIn:"body"`
 
 	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
 	// particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 
-	// For pagination of a list of cost tracking tag. When paging through a list, if this header appears in the response,
+	// The number of seconds that the client should wait before polling again.
+	RetryAfter *float32 `presentIn:"header" name:"retry-after"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
 	// then a partial list might have been returned. Include this value as the `page` parameter for the
-	// subsequent GET request to get the next batch of items. For important details about how pagination works,
-	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// subsequent GET request to get the next batch of items.
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 }
 
-func (response ListCostTrackingTagsResponse) String() string {
+func (response ListTaggingWorkRequestLogsResponse) String() string {
 	return common.PointerString(response)
 }
 
 // HTTPResponse implements the OCIResponse interface
-func (response ListCostTrackingTagsResponse) HTTPResponse() *http.Response {
+func (response ListTaggingWorkRequestLogsResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
 }

--- a/identity/list_tagging_work_requests_request_response.go
+++ b/identity/list_tagging_work_requests_request_response.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 )
 
-// ListCostTrackingTagsRequest wrapper for the ListCostTrackingTags operation
-type ListCostTrackingTagsRequest struct {
+// ListTaggingWorkRequestsRequest wrapper for the ListTaggingWorkRequests operation
+type ListTaggingWorkRequestsRequest struct {
 
 	// The OCID of the compartment (remember that the tenancy is simply the root compartment).
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
@@ -20,6 +20,9 @@ type ListCostTrackingTagsRequest struct {
 	// The maximum number of items to return in a paginated "List" call.
 	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
 
+	// The identifier of the resource the work request affects.
+	ResourceIdentifier *string `mandatory:"false" contributesTo:"query" name:"resourceIdentifier"`
+
 	// Unique Oracle-assigned identifier for the request.
 	// If you need to contact Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
@@ -29,45 +32,44 @@ type ListCostTrackingTagsRequest struct {
 	RequestMetadata common.RequestMetadata
 }
 
-func (request ListCostTrackingTagsRequest) String() string {
+func (request ListTaggingWorkRequestsRequest) String() string {
 	return common.PointerString(request)
 }
 
 // HTTPRequest implements the OCIRequest interface
-func (request ListCostTrackingTagsRequest) HTTPRequest(method, path string) (http.Request, error) {
+func (request ListTaggingWorkRequestsRequest) HTTPRequest(method, path string) (http.Request, error) {
 	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
 }
 
 // RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
-func (request ListCostTrackingTagsRequest) RetryPolicy() *common.RetryPolicy {
+func (request ListTaggingWorkRequestsRequest) RetryPolicy() *common.RetryPolicy {
 	return request.RequestMetadata.RetryPolicy
 }
 
-// ListCostTrackingTagsResponse wrapper for the ListCostTrackingTags operation
-type ListCostTrackingTagsResponse struct {
+// ListTaggingWorkRequestsResponse wrapper for the ListTaggingWorkRequests operation
+type ListTaggingWorkRequestsResponse struct {
 
 	// The underlying http response
 	RawResponse *http.Response
 
-	// A list of []Tag instances
-	Items []Tag `presentIn:"body"`
+	// A list of []TaggingWorkRequestSummary instances
+	Items []TaggingWorkRequestSummary `presentIn:"body"`
 
 	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
 	// particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 
-	// For pagination of a list of cost tracking tag. When paging through a list, if this header appears in the response,
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
 	// then a partial list might have been returned. Include this value as the `page` parameter for the
-	// subsequent GET request to get the next batch of items. For important details about how pagination works,
-	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// subsequent GET request to get the next batch of items.
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 }
 
-func (response ListCostTrackingTagsResponse) String() string {
+func (response ListTaggingWorkRequestsResponse) String() string {
 	return common.PointerString(response)
 }
 
 // HTTPResponse implements the OCIResponse interface
-func (response ListCostTrackingTagsResponse) HTTPResponse() *http.Response {
+func (response ListTaggingWorkRequestsResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
 }

--- a/identity/move_compartment_details.go
+++ b/identity/move_compartment_details.go
@@ -15,8 +15,8 @@ import (
 // MoveCompartmentDetails The representation of MoveCompartmentDetails
 type MoveCompartmentDetails struct {
 
-	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the parent compartment
-	// into which the compartment should be moved.
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the destination compartment
+	// into which to move the compartment.
 	TargetCompartmentId *string `mandatory:"true" json:"targetCompartmentId"`
 }
 

--- a/identity/policy.go
+++ b/identity/policy.go
@@ -22,6 +22,8 @@ import (
 //   * The overall body of policies your organization uses to control access to resources
 // To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
 // talk to an administrator.
+// **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values
+// using the API.
 type Policy struct {
 
 	// The OCID of the policy.

--- a/identity/region.go
+++ b/identity/region.go
@@ -26,14 +26,20 @@ type Region struct {
 	// - `IAD`
 	// - `FRA`
 	// - `LHR`
+	// - `YYZ`
+	// - `NRT`
+	// - `ICN`
 	Key *string `mandatory:"false" json:"key"`
 
 	// The name of the region.
 	// Allowed values are:
-	// - `us-phoenix-1`
-	// - `us-ashburn-1`
-	// - `eu-frankfurt-1`
+	// - `ap-seoul-1`
+	// - `ap-tokyo-1`
+	// - `ca-toronto-1`
+	// - `eu-frankurt-1`
 	// - `uk-london-1`
+	// - `us-ashburn-1`
+	// - `us-phoenix-1`
 	Name *string `mandatory:"false" json:"name"`
 }
 

--- a/identity/region_subscription.go
+++ b/identity/region_subscription.go
@@ -25,14 +25,20 @@ type RegionSubscription struct {
 	// - `IAD`
 	// - `FRA`
 	// - `LHR`
+	// - `YYZ`
+	// - `NRT`
+	// - `ICN`
 	RegionKey *string `mandatory:"true" json:"regionKey"`
 
 	// The region's name.
 	// Allowed values are:
-	// - `us-phoenix-1`
-	// - `us-ashburn-1`
+	// - `ap-seoul-1`
+	// - `ap-tokyo-1`
+	// - `ca-toronto-1`
 	// - `eu-frankurt-1`
 	// - `uk-london-1`
+	// - `us-ashburn-1`
+	// - `us-phoenix-1`
 	RegionName *string `mandatory:"true" json:"regionName"`
 
 	// The region subscription status.

--- a/identity/tag.go
+++ b/identity/tag.go
@@ -9,12 +9,15 @@
 package identity
 
 import (
+	"encoding/json"
 	"github.com/oracle/oci-go-sdk/common"
 )
 
 // Tag A tag definition that belongs to a specific tag namespace.  "Defined tags" must be set up in your tenancy before
 // you can apply them to resources.
 // For more information, see Managing Tags and Tag Namespaces (https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm).
+// **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values
+// using the API.
 type Tag struct {
 
 	// The OCID of the compartment that contains the tag definition.
@@ -29,7 +32,8 @@ type Tag struct {
 	// The OCID of the tag definition.
 	Id *string `mandatory:"true" json:"id"`
 
-	// The name of the tag. The name must be unique across all tags in the namespace and can't be changed.
+	// The name assigned to the tag during creation. This is the tag key definition.
+	// The name must be unique within the tag namespace and cannot be changed.
 	Name *string `mandatory:"true" json:"name"`
 
 	// The description you assign to the tag.
@@ -53,15 +57,66 @@ type Tag struct {
 	// Example: `{"Operations": {"CostCenter": "42"}}``
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
-	// The tag's current state. After creating a tag, make sure its `lifecycleState` is ACTIVE before using it. After retiring a tag, make sure its `lifecycleState` is INACTIVE before using it.
+	// The tag's current state. After creating a tag, make sure its `lifecycleState` is ACTIVE before using it. After retiring a tag, make sure its `lifecycleState` is INACTIVE before using it. If you delete a tag, you cannot delete another tag until the deleted tag's `lifecycleState` changes from DELETING to DELETED.
 	LifecycleState TagLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
 
 	// Indicates whether the tag is enabled for cost tracking.
 	IsCostTracking *bool `mandatory:"false" json:"isCostTracking"`
+
+	// Additional validation rule for values specified for the tag definition.
+	// If no validator is defined for a tag definition, then any (valid) value will be accepted.
+	// To clear the validator call the UPDATE operation with DefaultTagDefinitionValidator
+	Validator BaseTagDefinitionValidator `mandatory:"false" json:"validator"`
 }
 
 func (m Tag) String() string {
 	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *Tag) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		FreeformTags     map[string]string                 `json:"freeformTags"`
+		DefinedTags      map[string]map[string]interface{} `json:"definedTags"`
+		LifecycleState   TagLifecycleStateEnum             `json:"lifecycleState"`
+		IsCostTracking   *bool                             `json:"isCostTracking"`
+		Validator        basetagdefinitionvalidator        `json:"validator"`
+		CompartmentId    *string                           `json:"compartmentId"`
+		TagNamespaceId   *string                           `json:"tagNamespaceId"`
+		TagNamespaceName *string                           `json:"tagNamespaceName"`
+		Id               *string                           `json:"id"`
+		Name             *string                           `json:"name"`
+		Description      *string                           `json:"description"`
+		IsRetired        *bool                             `json:"isRetired"`
+		TimeCreated      *common.SDKTime                   `json:"timeCreated"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	m.FreeformTags = model.FreeformTags
+	m.DefinedTags = model.DefinedTags
+	m.LifecycleState = model.LifecycleState
+	m.IsCostTracking = model.IsCostTracking
+	nn, e := model.Validator.UnmarshalPolymorphicJSON(model.Validator.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.Validator = nn.(BaseTagDefinitionValidator)
+	} else {
+		m.Validator = nil
+	}
+	m.CompartmentId = model.CompartmentId
+	m.TagNamespaceId = model.TagNamespaceId
+	m.TagNamespaceName = model.TagNamespaceName
+	m.Id = model.Id
+	m.Name = model.Name
+	m.Description = model.Description
+	m.IsRetired = model.IsRetired
+	m.TimeCreated = model.TimeCreated
+	return
 }
 
 // TagLifecycleStateEnum Enum with underlying type: string

--- a/identity/tag_default.go
+++ b/identity/tag_default.go
@@ -46,6 +46,14 @@ type TagDefault struct {
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
+	// If you specify that a value is required, a value is set during resource creation (either by the
+	// user creating the resource or another tag defualt). If no value is set, resource creation is
+	// blocked.
+	// * If the `isRequired` flag is set to "true", the value is set during resource creation.
+	// * If the `isRequired` flag is set to "false", the value you enter is set during resource creation.
+	// Example: `false`
+	IsRequired *bool `mandatory:"true" json:"isRequired"`
+
 	// The tag default's current state. After creating a `TagDefault`, make sure its `lifecycleState` is ACTIVE before using it.
 	LifecycleState TagDefaultLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
 }

--- a/identity/tag_default_summary.go
+++ b/identity/tag_default_summary.go
@@ -37,6 +37,14 @@ type TagDefaultSummary struct {
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
+	// If you specify that a value is required, a value is set during resource creation (either by
+	// the user creating the resource or another tag defualt). If no value is set, resource
+	// creation is blocked.
+	// * If the `isRequired` flag is set to "true", the value is set during resource creation.
+	// * If the `isRequired` flag is set to "false", the value you enter is set during resource creation.
+	// Example: `false`
+	IsRequired *bool `mandatory:"true" json:"isRequired"`
+
 	// The tag default's current state. After creating a `TagDefault`, make sure its `lifecycleState` is ACTIVE before using it.
 	LifecycleState TagDefaultSummaryLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
 }

--- a/identity/tag_namespace.go
+++ b/identity/tag_namespace.go
@@ -12,8 +12,10 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// TagNamespace A managed container for defined tags. A tag namespace is unique in a tenancy. A tag namespace can't be deleted.
-// For more information, see Managing Tags and Tag Namespaces (https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm).
+// TagNamespace A managed container for defined tags. A tag namespace is unique in a tenancy. For more information,
+// see Managing Tags and Tag Namespaces (https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm).
+// **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values
+// using the API.
 type TagNamespace struct {
 
 	// The OCID of the tag namespace.

--- a/identity/tag_summary.go
+++ b/identity/tag_summary.go
@@ -21,7 +21,8 @@ type TagSummary struct {
 	// The OCID of the tag definition.
 	Id *string `mandatory:"false" json:"id"`
 
-	// The name of the tag. The name must be unique across all tags in the tag namespace and can't be changed.
+	// The name assigned to the tag during creation. This is the tag key definition.
+	// The name must be unique within the tag namespace and cannot be changed.
 	Name *string `mandatory:"false" json:"name"`
 
 	// The description you assign to the tag.
@@ -41,7 +42,7 @@ type TagSummary struct {
 	// See Retiring Key Definitions and Namespace Definitions (https://docs.cloud.oracle.com/Content/Identity/Concepts/taggingoverview.htm#Retiring).
 	IsRetired *bool `mandatory:"false" json:"isRetired"`
 
-	// The tag's current state. After creating a tag, make sure its `lifecycleState` is ACTIVE before using it. After retiring a tag, make sure its `lifecycleState` is INACTIVE before using it.
+	// The tag's current state. After creating a tag, make sure its `lifecycleState` is ACTIVE before using it. After retiring a tag, make sure its `lifecycleState` is INACTIVE before using it. If you delete a tag, you cannot delete another tag until the deleted tag's `lifecycleState` changes from DELETING to DELETED.
 	LifecycleState TagLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
 
 	// Date and time the tag was created, in the format defined by RFC3339.

--- a/identity/tagging_work_request.go
+++ b/identity/tagging_work_request.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Identity and Access Management Service API
+//
+// APIs for managing users, groups, compartments, and policies.
+//
+
+package identity
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TaggingWorkRequest The asynchronous API request does not take effect immediately. This request spawns an asynchronous
+// workflow to fulfill the request. WorkRequest objects provide visibility for in-progress workflows.
+type TaggingWorkRequest struct {
+
+	// The OCID of the work request.
+	Id *string `mandatory:"true" json:"id"`
+
+	// An enum-like description of the type of work the work request is doing.
+	OperationType TaggingWorkRequestOperationTypeEnum `mandatory:"true" json:"operationType"`
+
+	// The current status of the work request.
+	Status TaggingWorkRequestStatusEnum `mandatory:"true" json:"status"`
+
+	// The OCID of the compartment that contains the work request.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The resources this work request affects.
+	Resources []WorkRequestResource `mandatory:"false" json:"resources"`
+
+	// Date and time the work was accepted, in the format defined by RFC3339.
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeAccepted *common.SDKTime `mandatory:"false" json:"timeAccepted"`
+
+	// Date and time the work started, in the format defined by RFC3339.
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeStarted *common.SDKTime `mandatory:"false" json:"timeStarted"`
+
+	// Date and time the work completed, in the format defined by RFC3339.
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeFinished *common.SDKTime `mandatory:"false" json:"timeFinished"`
+
+	// How much progress the operation has made.
+	PercentComplete *float32 `mandatory:"false" json:"percentComplete"`
+}
+
+func (m TaggingWorkRequest) String() string {
+	return common.PointerString(m)
+}
+
+// TaggingWorkRequestOperationTypeEnum Enum with underlying type: string
+type TaggingWorkRequestOperationTypeEnum string
+
+// Set of constants representing the allowable values for TaggingWorkRequestOperationTypeEnum
+const (
+	TaggingWorkRequestOperationTypeDeleteTagDefinition TaggingWorkRequestOperationTypeEnum = "DELETE_TAG_DEFINITION"
+)
+
+var mappingTaggingWorkRequestOperationType = map[string]TaggingWorkRequestOperationTypeEnum{
+	"DELETE_TAG_DEFINITION": TaggingWorkRequestOperationTypeDeleteTagDefinition,
+}
+
+// GetTaggingWorkRequestOperationTypeEnumValues Enumerates the set of values for TaggingWorkRequestOperationTypeEnum
+func GetTaggingWorkRequestOperationTypeEnumValues() []TaggingWorkRequestOperationTypeEnum {
+	values := make([]TaggingWorkRequestOperationTypeEnum, 0)
+	for _, v := range mappingTaggingWorkRequestOperationType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// TaggingWorkRequestStatusEnum Enum with underlying type: string
+type TaggingWorkRequestStatusEnum string
+
+// Set of constants representing the allowable values for TaggingWorkRequestStatusEnum
+const (
+	TaggingWorkRequestStatusAccepted   TaggingWorkRequestStatusEnum = "ACCEPTED"
+	TaggingWorkRequestStatusInProgress TaggingWorkRequestStatusEnum = "IN_PROGRESS"
+	TaggingWorkRequestStatusFailed     TaggingWorkRequestStatusEnum = "FAILED"
+	TaggingWorkRequestStatusSucceeded  TaggingWorkRequestStatusEnum = "SUCCEEDED"
+	TaggingWorkRequestStatusCanceling  TaggingWorkRequestStatusEnum = "CANCELING"
+	TaggingWorkRequestStatusCanceled   TaggingWorkRequestStatusEnum = "CANCELED"
+)
+
+var mappingTaggingWorkRequestStatus = map[string]TaggingWorkRequestStatusEnum{
+	"ACCEPTED":    TaggingWorkRequestStatusAccepted,
+	"IN_PROGRESS": TaggingWorkRequestStatusInProgress,
+	"FAILED":      TaggingWorkRequestStatusFailed,
+	"SUCCEEDED":   TaggingWorkRequestStatusSucceeded,
+	"CANCELING":   TaggingWorkRequestStatusCanceling,
+	"CANCELED":    TaggingWorkRequestStatusCanceled,
+}
+
+// GetTaggingWorkRequestStatusEnumValues Enumerates the set of values for TaggingWorkRequestStatusEnum
+func GetTaggingWorkRequestStatusEnumValues() []TaggingWorkRequestStatusEnum {
+	values := make([]TaggingWorkRequestStatusEnum, 0)
+	for _, v := range mappingTaggingWorkRequestStatus {
+		values = append(values, v)
+	}
+	return values
+}

--- a/identity/tagging_work_request_error_summary.go
+++ b/identity/tagging_work_request_error_summary.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Identity and Access Management Service API
+//
+// APIs for managing users, groups, compartments, and policies.
+//
+
+package identity
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TaggingWorkRequestErrorSummary The error entity.
+type TaggingWorkRequestErrorSummary struct {
+
+	// A machine-usable code for the error that occured.
+	Code *string `mandatory:"true" json:"code"`
+
+	// A human-readable error string.
+	Message *string `mandatory:"true" json:"message"`
+
+	// Date and time the error happened, in the format defined by RFC3339.
+	// Example: `2016-08-25T21:10:29.600Z`
+	Timestamp *common.SDKTime `mandatory:"false" json:"timestamp"`
+}
+
+func (m TaggingWorkRequestErrorSummary) String() string {
+	return common.PointerString(m)
+}

--- a/identity/tagging_work_request_log_summary.go
+++ b/identity/tagging_work_request_log_summary.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Identity and Access Management Service API
+//
+// APIs for managing users, groups, compartments, and policies.
+//
+
+package identity
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TaggingWorkRequestLogSummary The log entity.
+type TaggingWorkRequestLogSummary struct {
+
+	// A human-readable error string.
+	Message *string `mandatory:"true" json:"message"`
+
+	// Date and time the log was written, in the format defined by RFC3339.
+	// Example: `2016-08-25T21:10:29.600Z`
+	Timestamp *common.SDKTime `mandatory:"false" json:"timestamp"`
+}
+
+func (m TaggingWorkRequestLogSummary) String() string {
+	return common.PointerString(m)
+}

--- a/identity/tagging_work_request_summary.go
+++ b/identity/tagging_work_request_summary.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Identity and Access Management Service API
+//
+// APIs for managing users, groups, compartments, and policies.
+//
+
+package identity
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TaggingWorkRequestSummary The work request summary. Tracks the status of the asynchronous operation.
+type TaggingWorkRequestSummary struct {
+
+	// The OCID of the work request.
+	Id *string `mandatory:"true" json:"id"`
+
+	// An enum-like description of the type of work the work request is doing.
+	OperationType TaggingWorkRequestSummaryOperationTypeEnum `mandatory:"true" json:"operationType"`
+
+	// The current status of the work request.
+	Status TaggingWorkRequestSummaryStatusEnum `mandatory:"true" json:"status"`
+
+	// The OCID of the compartment that contains the work request.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The resources this work request affects.
+	Resources []WorkRequestResource `mandatory:"false" json:"resources"`
+
+	// Date and time the work was accepted, in the format defined by RFC3339.
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeAccepted *common.SDKTime `mandatory:"false" json:"timeAccepted"`
+
+	// Date and time the work started, in the format defined by RFC3339.
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeStarted *common.SDKTime `mandatory:"false" json:"timeStarted"`
+
+	// Date and time the work completed, in the format defined by RFC3339.
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeFinished *common.SDKTime `mandatory:"false" json:"timeFinished"`
+
+	// How much progress the operation has made.
+	PercentComplete *float32 `mandatory:"false" json:"percentComplete"`
+}
+
+func (m TaggingWorkRequestSummary) String() string {
+	return common.PointerString(m)
+}
+
+// TaggingWorkRequestSummaryOperationTypeEnum Enum with underlying type: string
+type TaggingWorkRequestSummaryOperationTypeEnum string
+
+// Set of constants representing the allowable values for TaggingWorkRequestSummaryOperationTypeEnum
+const (
+	TaggingWorkRequestSummaryOperationTypeDeleteTagDefinition TaggingWorkRequestSummaryOperationTypeEnum = "DELETE_TAG_DEFINITION"
+)
+
+var mappingTaggingWorkRequestSummaryOperationType = map[string]TaggingWorkRequestSummaryOperationTypeEnum{
+	"DELETE_TAG_DEFINITION": TaggingWorkRequestSummaryOperationTypeDeleteTagDefinition,
+}
+
+// GetTaggingWorkRequestSummaryOperationTypeEnumValues Enumerates the set of values for TaggingWorkRequestSummaryOperationTypeEnum
+func GetTaggingWorkRequestSummaryOperationTypeEnumValues() []TaggingWorkRequestSummaryOperationTypeEnum {
+	values := make([]TaggingWorkRequestSummaryOperationTypeEnum, 0)
+	for _, v := range mappingTaggingWorkRequestSummaryOperationType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// TaggingWorkRequestSummaryStatusEnum Enum with underlying type: string
+type TaggingWorkRequestSummaryStatusEnum string
+
+// Set of constants representing the allowable values for TaggingWorkRequestSummaryStatusEnum
+const (
+	TaggingWorkRequestSummaryStatusAccepted   TaggingWorkRequestSummaryStatusEnum = "ACCEPTED"
+	TaggingWorkRequestSummaryStatusInProgress TaggingWorkRequestSummaryStatusEnum = "IN_PROGRESS"
+	TaggingWorkRequestSummaryStatusFailed     TaggingWorkRequestSummaryStatusEnum = "FAILED"
+	TaggingWorkRequestSummaryStatusSucceeded  TaggingWorkRequestSummaryStatusEnum = "SUCCEEDED"
+	TaggingWorkRequestSummaryStatusCanceling  TaggingWorkRequestSummaryStatusEnum = "CANCELING"
+	TaggingWorkRequestSummaryStatusCanceled   TaggingWorkRequestSummaryStatusEnum = "CANCELED"
+)
+
+var mappingTaggingWorkRequestSummaryStatus = map[string]TaggingWorkRequestSummaryStatusEnum{
+	"ACCEPTED":    TaggingWorkRequestSummaryStatusAccepted,
+	"IN_PROGRESS": TaggingWorkRequestSummaryStatusInProgress,
+	"FAILED":      TaggingWorkRequestSummaryStatusFailed,
+	"SUCCEEDED":   TaggingWorkRequestSummaryStatusSucceeded,
+	"CANCELING":   TaggingWorkRequestSummaryStatusCanceling,
+	"CANCELED":    TaggingWorkRequestSummaryStatusCanceled,
+}
+
+// GetTaggingWorkRequestSummaryStatusEnumValues Enumerates the set of values for TaggingWorkRequestSummaryStatusEnum
+func GetTaggingWorkRequestSummaryStatusEnumValues() []TaggingWorkRequestSummaryStatusEnum {
+	values := make([]TaggingWorkRequestSummaryStatusEnum, 0)
+	for _, v := range mappingTaggingWorkRequestSummaryStatus {
+		values = append(values, v)
+	}
+	return values
+}

--- a/identity/tenancy.go
+++ b/identity/tenancy.go
@@ -37,6 +37,9 @@ type Tenancy struct {
 	// - `PHX`
 	// - `FRA`
 	// - `LHR`
+	// - `ICN`
+	// - `YYZ`
+	// - `NRT`
 	HomeRegionKey *string `mandatory:"false" json:"homeRegionKey"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.

--- a/identity/update_tag_default_details.go
+++ b/identity/update_tag_default_details.go
@@ -17,6 +17,14 @@ type UpdateTagDefaultDetails struct {
 
 	// The default value for the tag definition. This will be applied to all resources created in the Compartment.
 	Value *string `mandatory:"true" json:"value"`
+
+	// If you specify that a value is required, a value is set during resource creation (either by
+	// the user creating the resource or another tag defualt). If no value is set, resource
+	// creation is blocked.
+	// * If the `isRequired` flag is set to "true", the value is set during resource creation.
+	// * If the `isRequired` flag is set to "false", the value you enter is set during resource creation.
+	// Example: `false`
+	IsRequired *bool `mandatory:"false" json:"isRequired"`
 }
 
 func (m UpdateTagDefaultDetails) String() string {

--- a/identity/update_tag_details.go
+++ b/identity/update_tag_details.go
@@ -9,6 +9,7 @@
 package identity
 
 import (
+	"encoding/json"
 	"github.com/oracle/oci-go-sdk/common"
 )
 
@@ -34,8 +35,45 @@ type UpdateTagDetails struct {
 
 	// Indicates whether the tag is enabled for cost tracking.
 	IsCostTracking *bool `mandatory:"false" json:"isCostTracking"`
+
+	// Additional validation rule for values specified for the tag definition.
+	// If no validator is defined for a tag definition, then any (valid) value will be accepted.
+	// The default value for `validator` is an empty map (no additional validation).
+	Validator BaseTagDefinitionValidator `mandatory:"false" json:"validator"`
 }
 
 func (m UpdateTagDetails) String() string {
 	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *UpdateTagDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Description    *string                           `json:"description"`
+		IsRetired      *bool                             `json:"isRetired"`
+		FreeformTags   map[string]string                 `json:"freeformTags"`
+		DefinedTags    map[string]map[string]interface{} `json:"definedTags"`
+		IsCostTracking *bool                             `json:"isCostTracking"`
+		Validator      basetagdefinitionvalidator        `json:"validator"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	m.Description = model.Description
+	m.IsRetired = model.IsRetired
+	m.FreeformTags = model.FreeformTags
+	m.DefinedTags = model.DefinedTags
+	m.IsCostTracking = model.IsCostTracking
+	nn, e := model.Validator.UnmarshalPolymorphicJSON(model.Validator.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.Validator = nn.(BaseTagDefinitionValidator)
+	} else {
+		m.Validator = nil
+	}
+	return
 }

--- a/identity/user.go
+++ b/identity/user.go
@@ -27,6 +27,8 @@ import (
 // To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
 // talk to an administrator. If you're an administrator who needs to write policies to give users access,
 // see Getting Started with Policies (https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+// **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values
+// using the API.
 type User struct {
 
 	// The OCID of the user.


### PR DESCRIPTION
### Added

- Support for required tags in the Identity service

- Support for work requests on tagging operations in the Identity service

- Support for enumerated tag values in the Identity service

- Support for moving dynamic routing gateway resources across compartments in the Networking service

- Support for migrating zones from Dyn managed DNS to OCI in the DNS service

- Support for fast provisioning for virtual machine databases in the Database service



### Breaking changes

- The field``CreateZoneDetails`` is no longer an anonymous field and the type changed from struct to interface in struct ``CreateZoneRequest``. Here is sample code that shows how to update your code to incorporate this change. 





    - Before



    ```golang

    // There were two ways to initialize the CreateZoneRequest struct.

    // This breaking change only impact option #2

    request := dns.CreateZoneRequest{}



    // #1. Instantiate CreateZoneDetails directly: no impact

    details := dns.CreateZoneDetails{}

    details.Name = common.String('some name')

    // ... other properties

    // Set it to the request class

    request.CreateZoneDetails = details



    // #2. Instantiate CreateZoneDetails through anonymous fields: will break

    request.Name = common.String('some name')

    // ... other properties

    ```



    - After



    ```golang

    // #2 no longer supported. Create CreateZoneDetails directly

    details := dns.CreateZoneDetails{}

    details.Name = common.String('some name')

    // ... other properties



    request := dns.CreateZoneRequest{

        CreateZoneDetails: details

    }

    // ...

    ```
