### PR TITLE
Releasing version 15.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## 15.8.0 - 2020-03-03
+### Added
+- Support for updating the shape of a Database System in the Database service
+- Support for generating CPE configurations for download in the Networking service
+- Support for private IPs and fault domains of cluster nodes in the Container Engine for Kubernetes service
+- Support for calling Oracle Cloud Infrastructure services in the ca-montreal-1 region
+- Support for exposing error after retrying failed in all services.
+
 ## 15.7.0 - 2020-02-25
 ### Added
 - Support for restarting autonomous databases in the Database service

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ clean-generate:
 pre-doc:
 	@echo "Rendering doc server to ${DOC_SERVER_URL}"
 	find . -name \*.go |xargs sed -i '' 's/{{DOC_SERVER_URL}}/${DOC_SERVER_URL}/g'
-	find . -name \*.go |xargs sed -i '' 's/https:\/\/docs.us-phoenix-1.oraclecloud.com/${DOC_SERVER_URL}/g'
+	find . -name \*.go |xargs sed -i '' 's/https:\/\/docs.cloud.oracle.com/${DOC_SERVER_URL}/g'
 
 gen-version:
 	go generate -x

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Alternatively you can git clone this repo.
 To start working with the Go SDK, you import the service package, create a client, and then use that client to make calls.
 
 ### Configuring 
-Before using the SDK, set up a config file with the required credentials. See [SDK and Tool Configuration](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm) for instructions.
+Before using the SDK, set up a config file with the required credentials. See [SDK and Tool Configuration](https://docs.cloud.oracle.com/Content/API/Concepts/sdkconfig.htm) for instructions.
 
 Note that the Go SDK does not support profile inheritance or defining custom values in the configuration file.
 

--- a/common/client.go
+++ b/common/client.go
@@ -191,11 +191,13 @@ func DefaultConfigProvider() ConfigurationProvider {
 // string TF_VAR. If the same configuration is found in multiple places the provider will prefer the first one.
 func CustomProfileConfigProvider(customConfigPath string, profile string) ConfigurationProvider {
 	homeFolder := getHomeFolder()
-	defaultFileProvider, _ := ConfigurationProviderFromFileWithProfile(customConfigPath, profile, "")
-	secondaryConfigFile := path.Join(homeFolder, defaultConfigDirName, defaultConfigFileName)
-	secondaryFileProvider, _ := ConfigurationProviderFromFileWithProfile(secondaryConfigFile, profile, "")
+	if customConfigPath == "" {
+		customConfigPath = path.Join(homeFolder, defaultConfigDirName, defaultConfigFileName)
+	}
+	customFileProvider, _ := ConfigurationProviderFromFileWithProfile(customConfigPath, profile, "")
+	defaultFileProvider, _ := ConfigurationProviderFromFileWithProfile(customConfigPath, "DEFAULT", "")
 	environmentProvider := environmentConfigurationProvider{EnvironmentVariablePrefix: "TF_VAR"}
-	provider, _ := ComposingConfigurationProvider([]ConfigurationProvider{defaultFileProvider, secondaryFileProvider, environmentProvider})
+	provider, _ := ComposingConfigurationProvider([]ConfigurationProvider{customFileProvider, defaultFileProvider, environmentProvider})
 	Debugf("Configuration provided by: %s", provider)
 	return provider
 }

--- a/common/common.go
+++ b/common/common.go
@@ -16,6 +16,8 @@ const (
 	RegionSEA Region = "sea"
 	//RegionCAToronto1 region for toronto
 	RegionCAToronto1 Region = "ca-toronto-1"
+	//RegionCAMontreal1 region for Montreal
+	RegionCAMontreal1 Region = "ca-montreal-1"
 	//RegionPHX region PHX
 	RegionPHX Region = "us-phoenix-1"
 	//RegionIAD region IAD
@@ -72,6 +74,7 @@ var regionRealm = map[Region]string{
 	RegionFRA:          "oc1",
 	RegionLHR:          "oc1",
 	RegionCAToronto1:   "oc1",
+	RegionCAMontreal1:  "oc1",
 	RegionAPTokyo1:     "oc1",
 	RegionAPOsaka1:     "oc1",
 	RegionAPSeoul1:     "oc1",
@@ -132,6 +135,8 @@ func StringToRegion(stringRegion string) (r Region) {
 		r = RegionSEA
 	case "yyz", "ca-toronto-1":
 		r = RegionCAToronto1
+	case "yul", "ca-montreal-1":
+		r = RegionCAMontreal1
 	case "phx", "us-phoenix-1":
 		r = RegionPHX
 	case "iad", "us-ashburn-1":

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -82,6 +82,13 @@ func TestEndpointForTemplate(t *testing.T) {
 			expected:         "https://foo.region.oraclecloud.com",
 		},
 		{
+			// template with second level domain
+			region:           StringToRegion("ca-montreal-1"),
+			service:          "test",
+			endpointTemplate: "https://foo.region.{secondLevelDomain}",
+			expected:         "https://foo.region.oraclecloud.com",
+		},
+		{
 			// template with everything for OC2
 			region:           StringToRegion("us-langley-1"),
 			service:          "test",
@@ -143,4 +150,7 @@ func TestStringToRegion(t *testing.T) {
 
 	region = StringToRegion("ltn")
 	assert.Equal(t, RegionUKGovLondon1, region)
+
+	region = StringToRegion("yul")
+	assert.Equal(t, RegionCAMontreal1, region)
 }

--- a/common/retry.go
+++ b/common/retry.go
@@ -147,7 +147,7 @@ func Retry(ctx context.Context, request OCIRetryableRequest, operation OCIOperat
 			<-time.After(duration)
 		}
 
-		retrierChannel <- retrierResult{nil, fmt.Errorf("maximum number of attempts exceeded (%v)", policy.MaximumNumberAttempts)}
+		retrierChannel <- retrierResult{response, err}
 	}()
 
 	select {

--- a/common/version.go
+++ b/common/version.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	major = "15"
-	minor = "7"
+	minor = "8"
 	patch = "0"
 	tag   = ""
 )

--- a/containerengine/node.go
+++ b/containerengine/node.go
@@ -32,6 +32,12 @@ type Node struct {
 	// The OCID of the node pool to which this node belongs.
 	NodePoolId *string `mandatory:"false" json:"nodePoolId"`
 
+	// The fault domain of this node.
+	FaultDomain *string `mandatory:"false" json:"faultDomain"`
+
+	// The private IP address of this node.
+	PrivateIp *string `mandatory:"false" json:"privateIp"`
+
 	// The public IP address of this node.
 	PublicIp *string `mandatory:"false" json:"publicIp"`
 

--- a/core/add_security_rule_details.go
+++ b/core/add_security_rule_details.go
@@ -35,7 +35,8 @@ type AddSecurityRuleDetails struct {
 	// can go to.
 	// Allowed values:
 	//   * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-	//     Note that IPv6 addressing is currently supported only in the Government Cloud.
+	//     Note that IPv6 addressing is currently supported only in certain regions. See
+	//     IPv6 Addresses (https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
 	//   * The `cidrBlock` value for a Service, if you're
 	//     setting up a security rule for traffic destined for a particular `Service` through
 	//     a service gateway. For example: `oci-phx-objectstorage`.
@@ -76,7 +77,8 @@ type AddSecurityRuleDetails struct {
 	// can come from.
 	// Allowed values:
 	//   * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-	//     Note that IPv6 addressing is currently supported only in the Government Cloud.
+	//     Note that IPv6 addressing is currently supported only in certain regions. See
+	//     IPv6 Addresses (https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
 	//   * The `cidrBlock` value for a Service, if you're
 	//     setting up a security rule for traffic coming from a particular `Service` through
 	//     a service gateway. For example: `oci-phx-objectstorage`.

--- a/core/core_compute_client.go
+++ b/core/core_compute_client.go
@@ -1576,8 +1576,8 @@ func (client ComputeClient) getVolumeAttachment(ctx context.Context, request com
 	return response, err
 }
 
-// GetWindowsInstanceInitialCredentials Gets the generated credentials for the instance. Only works for instances that require password to log in (E.g. Windows).
-// For certain OS'es, users will be forced to change the initial credentials.
+// GetWindowsInstanceInitialCredentials Gets the generated credentials for the instance. Only works for instances that require a password to log in, such as Windows.
+// For certain operating systems, users will be forced to change the initial credentials.
 func (client ComputeClient) GetWindowsInstanceInitialCredentials(ctx context.Context, request GetWindowsInstanceInitialCredentialsRequest) (response GetWindowsInstanceInitialCredentialsResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()
@@ -1622,10 +1622,14 @@ func (client ComputeClient) getWindowsInstanceInitialCredentials(ctx context.Con
 // InstanceAction Performs one of the following power actions on the specified instance:
 // - **START** - Powers on the instance.
 // - **STOP** - Powers off the instance.
-// - **SOFTRESET** - Gracefully reboots instance by sending a shutdown command to the operating system and then powers the instance back on.
-// - **SOFTSTOP** - Gracefully shuts down instance by sending a shutdown command to the operating system.
 // - **RESET** - Powers off the instance and then powers it back on.
-// For more information see Stopping and Starting an Instance (https://docs.cloud.oracle.com/Content/Compute/Tasks/restartinginstance.htm).
+// - **SOFTSTOP** - Gracefully shuts down the instance by sending a shutdown command to the operating system.
+// If the applications that run on the instance take a long time to shut down, they could be improperly stopped, resulting
+// in data corruption. To avoid this, shut down the instance using the commands available in the OS before you softstop the
+// instance.
+// - **SOFTRESET** - Gracefully reboots the instance by sending a shutdown command to the operating system, and
+// then powers the instance back on.
+// For more information, see Stopping and Starting an Instance (https://docs.cloud.oracle.com/Content/Compute/Tasks/restartinginstance.htm).
 func (client ComputeClient) InstanceAction(ctx context.Context, request InstanceActionRequest) (response InstanceActionResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()

--- a/core/core_virtualnetwork_client.go
+++ b/core/core_virtualnetwork_client.go
@@ -3467,6 +3467,110 @@ func (client VirtualNetworkClient) getCpe(ctx context.Context, request common.OC
 	return response, err
 }
 
+// GetCpeDeviceConfigContent Renders a set of CPE configuration content that can help a network engineer configure the actual
+// CPE device (for example, a hardware router) represented by the specified Cpe
+// object.
+// The rendered content is specific to the type of CPE device (for example, Cisco ASA). Therefore the
+// Cpe must have the CPE's device type specified by the `cpeDeviceShapeId`
+// attribute. The content optionally includes answers that the customer provides (see
+// UpdateTunnelCpeDeviceConfig),
+// merged with a template of other information specific to the CPE device type.
+// The operation returns configuration information for *all* of the
+// IPSecConnection objects that use the specified CPE.
+// Here are similar operations:
+//   * GetIpsecCpeDeviceConfigContent
+//   returns CPE configuration content for all tunnels in a single IPSec connection.
+//   * GetTunnelCpeDeviceConfigContent
+//   returns CPE configuration content for a specific tunnel within an IPSec connection.
+func (client VirtualNetworkClient) GetCpeDeviceConfigContent(ctx context.Context, request GetCpeDeviceConfigContentRequest) (response GetCpeDeviceConfigContentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getCpeDeviceConfigContent, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = GetCpeDeviceConfigContentResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetCpeDeviceConfigContentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetCpeDeviceConfigContentResponse")
+	}
+	return
+}
+
+// getCpeDeviceConfigContent implements the OCIOperation interface (enables retrying operations)
+func (client VirtualNetworkClient) getCpeDeviceConfigContent(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/cpes/{cpeId}/cpeConfigContent")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetCpeDeviceConfigContentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetCpeDeviceShape Gets the detailed information about the specified CPE device type. This might include a set of questions
+// that are specific to the particular CPE device type. The customer must supply answers to those questions
+// (see UpdateTunnelCpeDeviceConfig).
+// The service merges the answers with a template of other information for the CPE device type. The following
+// operations return the merged content:
+//   * GetCpeDeviceConfigContent
+//   * GetIpsecCpeDeviceConfigContent
+//   * GetTunnelCpeDeviceConfigContent
+func (client VirtualNetworkClient) GetCpeDeviceShape(ctx context.Context, request GetCpeDeviceShapeRequest) (response GetCpeDeviceShapeResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getCpeDeviceShape, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = GetCpeDeviceShapeResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetCpeDeviceShapeResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetCpeDeviceShapeResponse")
+	}
+	return
+}
+
+// getCpeDeviceShape implements the OCIOperation interface (enables retrying operations)
+func (client VirtualNetworkClient) getCpeDeviceShape(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/cpeDeviceShapes/{cpeDeviceShapeId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetCpeDeviceShapeResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // GetCrossConnect Gets the specified cross-connect's information.
 func (client VirtualNetworkClient) GetCrossConnect(ctx context.Context, request GetCrossConnectRequest) (response GetCrossConnectResponse, err error) {
 	var ociResponse common.OCIResponse
@@ -3761,7 +3865,8 @@ func (client VirtualNetworkClient) getDrgAttachment(ctx context.Context, request
 	return response, err
 }
 
-// GetDrgRedundancyStatus Get redundancy status of single DRG object on Oracle side.
+// GetDrgRedundancyStatus Gets the redundancy status for the specified DRG. For more information, see
+// Redundancy Remedies (https://docs.cloud.oracle.com/Content/Network/Troubleshoot/drgredundancy.htm).
 func (client VirtualNetworkClient) GetDrgRedundancyStatus(ctx context.Context, request GetDrgRedundancyStatusRequest) (response GetDrgRedundancyStatusResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()
@@ -4140,6 +4245,62 @@ func (client VirtualNetworkClient) getInternetGateway(ctx context.Context, reque
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetIpsecCpeDeviceConfigContent Renders a set of CPE configuration content for the specified IPSec connection (for all the
+// tunnels in the connection). The content helps a network engineer configure the actual CPE
+// device (for example, a hardware router) that the specified IPSec connection terminates on.
+// The rendered content is specific to the type of CPE device (for example, Cisco ASA). Therefore the
+// Cpe used by the specified IPSecConnection
+// must have the CPE's device type specified by the `cpeDeviceShapeId` attribute. The content
+// optionally includes answers that the customer provides (see
+// UpdateTunnelCpeDeviceConfig),
+// merged with a template of other information specific to the CPE device type.
+// The operation returns configuration information for all tunnels in the single specified
+// IPSecConnection object. Here are other similar
+// operations:
+//   * GetTunnelCpeDeviceConfigContent
+//   returns CPE configuration content for a specific tunnel within an IPSec connection.
+//   * GetCpeDeviceConfigContent
+//   returns CPE configuration content for *all* IPSec connections that use a specific CPE.
+func (client VirtualNetworkClient) GetIpsecCpeDeviceConfigContent(ctx context.Context, request GetIpsecCpeDeviceConfigContentRequest) (response GetIpsecCpeDeviceConfigContentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getIpsecCpeDeviceConfigContent, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = GetIpsecCpeDeviceConfigContentResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetIpsecCpeDeviceConfigContentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetIpsecCpeDeviceConfigContentResponse")
+	}
+	return
+}
+
+// getIpsecCpeDeviceConfigContent implements the OCIOperation interface (enables retrying operations)
+func (client VirtualNetworkClient) getIpsecCpeDeviceConfigContent(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/ipsecConnections/{ipscId}/cpeConfigContent")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetIpsecCpeDeviceConfigContentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
 	response.RawResponse = httpResponse
 	if err != nil {
 		return response, err
@@ -4766,6 +4927,107 @@ func (client VirtualNetworkClient) getSubnet(ctx context.Context, request common
 	return response, err
 }
 
+// GetTunnelCpeDeviceConfig Gets the set of CPE configuration answers for the tunnel, which the customer provided in
+// UpdateTunnelCpeDeviceConfig.
+// To get the full set of content for the tunnel (any answers merged with the template of other
+// information specific to the CPE device type), use
+// GetTunnelCpeDeviceConfigContent.
+func (client VirtualNetworkClient) GetTunnelCpeDeviceConfig(ctx context.Context, request GetTunnelCpeDeviceConfigRequest) (response GetTunnelCpeDeviceConfigResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getTunnelCpeDeviceConfig, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = GetTunnelCpeDeviceConfigResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetTunnelCpeDeviceConfigResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetTunnelCpeDeviceConfigResponse")
+	}
+	return
+}
+
+// getTunnelCpeDeviceConfig implements the OCIOperation interface (enables retrying operations)
+func (client VirtualNetworkClient) getTunnelCpeDeviceConfig(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/ipsecConnections/{ipscId}/tunnels/{tunnelId}/tunnelDeviceConfig")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetTunnelCpeDeviceConfigResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetTunnelCpeDeviceConfigContent Renders a set of CPE configuration content for the specified IPSec tunnel. The content helps a
+// network engineer configure the actual CPE device (for example, a hardware router) that the specified
+// IPSec tunnel terminates on.
+// The rendered content is specific to the type of CPE device (for example, Cisco ASA). Therefore the
+// Cpe used by the specified IPSecConnection
+// must have the CPE's device type specified by the `cpeDeviceShapeId` attribute. The content
+// optionally includes answers that the customer provides (see
+// UpdateTunnelCpeDeviceConfig),
+// merged with a template of other information specific to the CPE device type.
+// The operation returns configuration information for only the specified IPSec tunnel.
+// Here are other similar operations:
+//   * GetIpsecCpeDeviceConfigContent
+//   returns CPE configuration content for all tunnels in a single IPSec connection.
+//   * GetCpeDeviceConfigContent
+//   returns CPE configuration content for *all* IPSec connections that use a specific CPE.
+func (client VirtualNetworkClient) GetTunnelCpeDeviceConfigContent(ctx context.Context, request GetTunnelCpeDeviceConfigContentRequest) (response GetTunnelCpeDeviceConfigContentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getTunnelCpeDeviceConfigContent, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = GetTunnelCpeDeviceConfigContentResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetTunnelCpeDeviceConfigContentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetTunnelCpeDeviceConfigContentResponse")
+	}
+	return
+}
+
+// getTunnelCpeDeviceConfigContent implements the OCIOperation interface (enables retrying operations)
+func (client VirtualNetworkClient) getTunnelCpeDeviceConfigContent(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/ipsecConnections/{ipscId}/tunnels/{tunnelId}/tunnelDeviceConfig/content")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetTunnelCpeDeviceConfigContentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // GetVcn Gets the specified VCN's information.
 func (client VirtualNetworkClient) GetVcn(ctx context.Context, request GetVcnRequest) (response GetVcnResponse, err error) {
 	var ociResponse common.OCIResponse
@@ -4926,6 +5188,57 @@ func (client VirtualNetworkClient) listAllowedPeerRegionsForRemotePeering(ctx co
 	}
 
 	var response ListAllowedPeerRegionsForRemotePeeringResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListCpeDeviceShapes Lists the CPE device types that the Networking service provides CPE configuration
+// content for (example: Cisco ASA). The content helps a network engineer configure
+// the actual CPE device represented by a Cpe object.
+// If you want to generate CPE configuration content for one of the returned CPE device types,
+// ensure that the Cpe object's `cpeDeviceShapeId` attribute is set
+// to the CPE device type's OCID (returned by this operation).
+// For information about generating CPE configuration content, see these operations:
+//   * GetCpeDeviceConfigContent
+//   * GetIpsecCpeDeviceConfigContent
+//   * GetTunnelCpeDeviceConfigContent
+func (client VirtualNetworkClient) ListCpeDeviceShapes(ctx context.Context, request ListCpeDeviceShapesRequest) (response ListCpeDeviceShapesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listCpeDeviceShapes, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = ListCpeDeviceShapesResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListCpeDeviceShapesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListCpeDeviceShapesResponse")
+	}
+	return
+}
+
+// listCpeDeviceShapes implements the OCIOperation interface (enables retrying operations)
+func (client VirtualNetworkClient) listCpeDeviceShapes(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/cpeDeviceShapes")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListCpeDeviceShapesResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -7325,6 +7638,55 @@ func (client VirtualNetworkClient) updateSubnet(ctx context.Context, request com
 	}
 
 	var response UpdateSubnetResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateTunnelCpeDeviceConfig Creates or updates the set of CPE configuration answers for the specified tunnel.
+// The answers correlate to the questions that are specific to the CPE device type (see the
+// `parameters` attribute of CpeDeviceShapeDetail).
+func (client VirtualNetworkClient) UpdateTunnelCpeDeviceConfig(ctx context.Context, request UpdateTunnelCpeDeviceConfigRequest) (response UpdateTunnelCpeDeviceConfigResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.updateTunnelCpeDeviceConfig, policy)
+	if err != nil {
+		if ociResponse != nil {
+			response = UpdateTunnelCpeDeviceConfigResponse{RawResponse: ociResponse.HTTPResponse()}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateTunnelCpeDeviceConfigResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateTunnelCpeDeviceConfigResponse")
+	}
+	return
+}
+
+// updateTunnelCpeDeviceConfig implements the OCIOperation interface (enables retrying operations)
+func (client VirtualNetworkClient) updateTunnelCpeDeviceConfig(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/ipsecConnections/{ipscId}/tunnels/{tunnelId}/tunnelDeviceConfig")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateTunnelCpeDeviceConfigResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)

--- a/core/cpe.go
+++ b/core/cpe.go
@@ -51,6 +51,20 @@ type Cpe struct {
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the CPE's device type.
+	// The Networking service maintains a general list of CPE device types (for example,
+	// Cisco ASA). For each type, Oracle provides CPE configuration content that can help
+	// a network engineer configure the CPE. The OCID uniquely identifies the type of
+	// device. To get the OCIDs for the device types on the list, see
+	// ListCpeDeviceShapes.
+	// For information about how to generate CPE configuration content for a
+	// CPE device type, see:
+	//   * GetCpeDeviceConfigContent
+	//   * GetIpsecCpeDeviceConfigContent
+	//   * GetTunnelCpeDeviceConfigContent
+	//   * GetTunnelCpeDeviceConfig
+	CpeDeviceShapeId *string `mandatory:"false" json:"cpeDeviceShapeId"`
+
 	// The date and time the CPE was created, in the format defined by RFC3339.
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`

--- a/core/cpe_device_config_answer.go
+++ b/core/cpe_device_config_answer.go
@@ -16,14 +16,19 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// CreateVirtualCircuitPublicPrefixDetails The representation of CreateVirtualCircuitPublicPrefixDetails
-type CreateVirtualCircuitPublicPrefixDetails struct {
+// CpeDeviceConfigAnswer An individual answer to a CPE device question.
+// The answers correlate to the questions that are specific to the CPE device type (see the
+// `parameters` attribute of CpeDeviceShapeDetail).
+type CpeDeviceConfigAnswer struct {
 
-	// An individual public IP prefix (CIDR) to add to the public virtual circuit.
-	// All prefix sizes are allowed.
-	CidrBlock *string `mandatory:"true" json:"cidrBlock"`
+	// A string that identifies the question to be answered. See the `key` attribute in
+	// CpeDeviceConfigQuestion.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The answer to the question.
+	Value *string `mandatory:"false" json:"value"`
 }
 
-func (m CreateVirtualCircuitPublicPrefixDetails) String() string {
+func (m CpeDeviceConfigAnswer) String() string {
 	return common.PointerString(m)
 }

--- a/core/cpe_device_config_question.go
+++ b/core/cpe_device_config_question.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CpeDeviceConfigQuestion An individual question that the customer can answer about the CPE device.
+// The customer provides answers to these questions in
+// UpdateTunnelCpeDeviceConfig.
+type CpeDeviceConfigQuestion struct {
+
+	// A string that identifies the question.
+	Key *string `mandatory:"false" json:"key"`
+
+	// A descriptive label for the question (for example, to display in a form in a graphical interface).
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// A description or explanation of the question, to help the customer answer accurately.
+	Explanation *string `mandatory:"false" json:"explanation"`
+}
+
+func (m CpeDeviceConfigQuestion) String() string {
+	return common.PointerString(m)
+}

--- a/core/cpe_device_info.go
+++ b/core/cpe_device_info.go
@@ -16,14 +16,16 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// CreateVirtualCircuitPublicPrefixDetails The representation of CreateVirtualCircuitPublicPrefixDetails
-type CreateVirtualCircuitPublicPrefixDetails struct {
+// CpeDeviceInfo Basic information about a particular CPE device type.
+type CpeDeviceInfo struct {
 
-	// An individual public IP prefix (CIDR) to add to the public virtual circuit.
-	// All prefix sizes are allowed.
-	CidrBlock *string `mandatory:"true" json:"cidrBlock"`
+	// The vendor that makes the CPE device.
+	Vendor *string `mandatory:"false" json:"vendor"`
+
+	// The platform or software version of the CPE device.
+	PlatformSoftwareVersion *string `mandatory:"false" json:"platformSoftwareVersion"`
 }
 
-func (m CreateVirtualCircuitPublicPrefixDetails) String() string {
+func (m CpeDeviceInfo) String() string {
 	return common.PointerString(m)
 }

--- a/core/cpe_device_shape_detail.go
+++ b/core/cpe_device_shape_detail.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CpeDeviceShapeDetail The detailed information about a particular CPE device type. Compare with
+// CpeDeviceShapeSummary.
+type CpeDeviceShapeDetail struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the CPE device shape.
+	// This value uniquely identifies the type of CPE device.
+	CpeDeviceShapeId *string `mandatory:"false" json:"cpeDeviceShapeId"`
+
+	// Basic information about this particular CPE device type.
+	CpeDeviceInfo *CpeDeviceInfo `mandatory:"false" json:"cpeDeviceInfo"`
+
+	// For certain CPE devices types, the customer can provide answers to
+	// questions that are specific to the device type. This attribute contains
+	// a list of those questions. The Networking service merges the answers with
+	// other information and renders a set of CPE configuration content. To
+	// provide the answers, use
+	// UpdateTunnelCpeDeviceConfig.
+	Parameters []CpeDeviceConfigQuestion `mandatory:"false" json:"parameters"`
+
+	// A template of CPE device configuration information that will be merged with the customer's
+	// answers to the questions to render the final CPE device configuration content. Also see:
+	//   * GetCpeDeviceConfigContent
+	//   * GetIpsecCpeDeviceConfigContent
+	//   * GetTunnelCpeDeviceConfigContent
+	Template *string `mandatory:"false" json:"template"`
+}
+
+func (m CpeDeviceShapeDetail) String() string {
+	return common.PointerString(m)
+}

--- a/core/cpe_device_shape_summary.go
+++ b/core/cpe_device_shape_summary.go
@@ -16,14 +16,18 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// CreateVirtualCircuitPublicPrefixDetails The representation of CreateVirtualCircuitPublicPrefixDetails
-type CreateVirtualCircuitPublicPrefixDetails struct {
+// CpeDeviceShapeSummary A summary of information about a particular CPE device type. Compare with
+// CpeDeviceShapeDetail.
+type CpeDeviceShapeSummary struct {
 
-	// An individual public IP prefix (CIDR) to add to the public virtual circuit.
-	// All prefix sizes are allowed.
-	CidrBlock *string `mandatory:"true" json:"cidrBlock"`
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the CPE device shape.
+	// This value uniquely identifies the type of CPE device.
+	Id *string `mandatory:"false" json:"id"`
+
+	// Basic information about this particular CPE device type.
+	CpeDeviceInfo *CpeDeviceInfo `mandatory:"false" json:"cpeDeviceInfo"`
 }
 
-func (m CreateVirtualCircuitPublicPrefixDetails) String() string {
+func (m CpeDeviceShapeSummary) String() string {
 	return common.PointerString(m)
 }

--- a/core/create_cpe_details.go
+++ b/core/create_cpe_details.go
@@ -38,6 +38,18 @@ type CreateCpeDetails struct {
 	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the CPE device type. You can provide
+	// a value if you want to later generate CPE device configuration content for IPSec connections
+	// that use this CPE. You can also call UpdateCpe later to
+	// provide a value. For a list of possible values, see
+	// ListCpeDeviceShapes.
+	// For more information about generating CPE device configuration content, see:
+	//   * GetCpeDeviceConfigContent
+	//   * GetIpsecCpeDeviceConfigContent
+	//   * GetTunnelCpeDeviceConfigContent
+	//   * GetTunnelCpeDeviceConfig
+	CpeDeviceShapeId *string `mandatory:"false" json:"cpeDeviceShapeId"`
 }
 
 func (m CreateCpeDetails) String() string {

--- a/core/create_ip_sec_connection_details.go
+++ b/core/create_ip_sec_connection_details.go
@@ -36,7 +36,7 @@ type CreateIpSecConnectionDetails struct {
 	// tunnels to use BGP dynamic routing, you can provide an empty list for the static routes.
 	// For more information, see the important note in IPSecConnection.
 	// The CIDR can be either IPv4 or IPv6. Note that IPv6 addressing is currently supported only
-	// in the Government Cloud.
+	// in certain regions. See IPv6 Addresses (https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
 	// Example: `10.0.1.0/24`
 	// Example: `2001:db8::/32`
 	StaticRoutes []string `mandatory:"true" json:"staticRoutes"`

--- a/core/create_vnic_details.go
+++ b/core/create_vnic_details.go
@@ -25,7 +25,10 @@ type CreateVnicDetails struct {
 	// The OCID of the subnet to create the VNIC in. When launching an instance,
 	// use this `subnetId` instead of the deprecated `subnetId` in
 	// LaunchInstanceDetails.
-	// At least one of them is required; if you provide both, the values must match.
+	// Alternatively, the `vlanId` can be used instead of a `subnetId`.
+	// At least one `subnetId` value is required if this field is populated; if
+	// you provide both, the values must match. If both the `vlanId` and `subnetId`
+	// fields are provided, the launch will fail.
 	SubnetId *string `mandatory:"true" json:"subnetId"`
 
 	// Whether the VNIC should be assigned a public IP address. Defaults to whether
@@ -85,12 +88,12 @@ type CreateVnicDetails struct {
 	// NetworkSecurityGroup.
 	NsgIds []string `mandatory:"false" json:"nsgIds"`
 
-	// A private IP address of your choice to assign to the VNIC. Must be an
-	// available IP address within the subnet's CIDR. If you don't specify a
-	// value, Oracle automatically assigns a private IP address from the subnet.
-	// This is the VNIC's *primary* private IP address. The value appears in
-	// the Vnic object and also the
-	// PrivateIp object returned by
+	// A private IP address of your choice to assign to the VNIC. Value is ignored
+	// if a `vlanId` value is specified. Must be an available IP address within
+	// the subnet's CIDR. If you don't specify a value, Oracle automatically assigns
+	// a private IP address from the subnet. This is the VNIC's *primary* private IP
+	// address. The value appears in the Vnic object and
+	// also the PrivateIp object returned by
 	// ListPrivateIps and
 	// GetPrivateIp.
 	// Example: `10.0.3.3`

--- a/core/cross_connect_mapping.go
+++ b/core/cross_connect_mapping.go
@@ -76,7 +76,8 @@ type CrossConnectMapping struct {
 	// session goes from Oracle to a provider, this is the BGP IPv6 address of the
 	// provider's edge router. Only subnet masks from /64 up to /127 are allowed.
 	// There's one exception: for a public virtual circuit, Oracle specifies the BGP IPv6 addresses.
-	// Note that IPv6 addressing is currently supported only in the Government Cloud.
+	// Note that IPv6 addressing is currently supported only in certain regions. See
+	// IPv6 Addresses (https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
 	// Example: `2001:db8::1/64`
 	CustomerBgpPeeringIpv6 *string `mandatory:"false" json:"customerBgpPeeringIpv6"`
 
@@ -85,7 +86,8 @@ type CrossConnectMapping struct {
 	// the customer specifies this information. If the session goes from Oracle to
 	// a provider's edge router, the provider specifies this.
 	// There's one exception: for a public virtual circuit, Oracle specifies the BGP IPv6 addresses.
-	// Note that IPv6 addressing is currently supported only in the Government Cloud.
+	// Note that IPv6 addressing is currently supported only in certain regions. See
+	// IPv6 Addresses (https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
 	// Example: `2001:db8::2/64`
 	OracleBgpPeeringIpv6 *string `mandatory:"false" json:"oracleBgpPeeringIpv6"`
 

--- a/core/drg_redundancy_status.go
+++ b/core/drg_redundancy_status.go
@@ -16,13 +16,14 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// DrgRedundancyStatus Redundancy status of the DRG object identified by ID
+// DrgRedundancyStatus The redundancy status of the DRG. For more information, see
+// Redundancy Remedies (https://docs.cloud.oracle.com/Content/Network/Troubleshoot/drgredundancy.htm).
 type DrgRedundancyStatus struct {
 
-	// The DRG's unique identifier.
+	// The OCID of the DRG.
 	Id *string `mandatory:"false" json:"id"`
 
-	// The redudancy status of the DRG specified.
+	// The redundancy status of the DRG.
 	Status DrgRedundancyStatusStatusEnum `mandatory:"false" json:"status,omitempty"`
 }
 

--- a/core/egress_security_rule.go
+++ b/core/egress_security_rule.go
@@ -23,7 +23,8 @@ type EgressSecurityRule struct {
 	// can go to.
 	// Allowed values:
 	//   * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-	//     Note that IPv6 addressing is currently supported only in the Government Cloud.
+	//     Note that IPv6 addressing is currently supported only in certain regions. See
+	//     IPv6 Addresses (https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
 	//   * The `cidrBlock` value for a Service, if you're
 	//     setting up a security list rule for traffic destined for a particular `Service` through
 	//     a service gateway. For example: `oci-phx-objectstorage`.

--- a/core/get_cpe_device_config_content_request_response.go
+++ b/core/get_cpe_device_config_content_request_response.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"io"
+	"net/http"
+)
+
+// GetCpeDeviceConfigContentRequest wrapper for the GetCpeDeviceConfigContent operation
+type GetCpeDeviceConfigContentRequest struct {
+
+	// The OCID of the CPE.
+	CpeId *string `mandatory:"true" contributesTo:"path" name:"cpeId"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetCpeDeviceConfigContentRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetCpeDeviceConfigContentRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetCpeDeviceConfigContentRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetCpeDeviceConfigContentResponse wrapper for the GetCpeDeviceConfigContent operation
+type GetCpeDeviceConfigContentResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The io.ReadCloser instance
+	Content io.ReadCloser `presentIn:"body" encoding:"binary"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetCpeDeviceConfigContentResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetCpeDeviceConfigContentResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/core/get_cpe_device_shape_request_response.go
+++ b/core/get_cpe_device_shape_request_response.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetCpeDeviceShapeRequest wrapper for the GetCpeDeviceShape operation
+type GetCpeDeviceShapeRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the CPE device shape.
+	CpeDeviceShapeId *string `mandatory:"true" contributesTo:"path" name:"cpeDeviceShapeId"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetCpeDeviceShapeRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetCpeDeviceShapeRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetCpeDeviceShapeRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetCpeDeviceShapeResponse wrapper for the GetCpeDeviceShape operation
+type GetCpeDeviceShapeResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The CpeDeviceShapeDetail instance
+	CpeDeviceShapeDetail `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetCpeDeviceShapeResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetCpeDeviceShapeResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/core/get_ipsec_cpe_device_config_content_request_response.go
+++ b/core/get_ipsec_cpe_device_config_content_request_response.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"io"
+	"net/http"
+)
+
+// GetIpsecCpeDeviceConfigContentRequest wrapper for the GetIpsecCpeDeviceConfigContent operation
+type GetIpsecCpeDeviceConfigContentRequest struct {
+
+	// The OCID of the IPSec connection.
+	IpscId *string `mandatory:"true" contributesTo:"path" name:"ipscId"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetIpsecCpeDeviceConfigContentRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetIpsecCpeDeviceConfigContentRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetIpsecCpeDeviceConfigContentRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetIpsecCpeDeviceConfigContentResponse wrapper for the GetIpsecCpeDeviceConfigContent operation
+type GetIpsecCpeDeviceConfigContentResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The io.ReadCloser instance
+	Content io.ReadCloser `presentIn:"body" encoding:"binary"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetIpsecCpeDeviceConfigContentResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetIpsecCpeDeviceConfigContentResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/core/get_tunnel_cpe_device_config_content_request_response.go
+++ b/core/get_tunnel_cpe_device_config_content_request_response.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"io"
+	"net/http"
+)
+
+// GetTunnelCpeDeviceConfigContentRequest wrapper for the GetTunnelCpeDeviceConfigContent operation
+type GetTunnelCpeDeviceConfigContentRequest struct {
+
+	// The OCID of the IPSec connection.
+	IpscId *string `mandatory:"true" contributesTo:"path" name:"ipscId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the tunnel.
+	TunnelId *string `mandatory:"true" contributesTo:"path" name:"tunnelId"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetTunnelCpeDeviceConfigContentRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetTunnelCpeDeviceConfigContentRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetTunnelCpeDeviceConfigContentRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetTunnelCpeDeviceConfigContentResponse wrapper for the GetTunnelCpeDeviceConfigContent operation
+type GetTunnelCpeDeviceConfigContentResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The io.ReadCloser instance
+	Content io.ReadCloser `presentIn:"body" encoding:"binary"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetTunnelCpeDeviceConfigContentResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetTunnelCpeDeviceConfigContentResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/core/get_tunnel_cpe_device_config_request_response.go
+++ b/core/get_tunnel_cpe_device_config_request_response.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetTunnelCpeDeviceConfigRequest wrapper for the GetTunnelCpeDeviceConfig operation
+type GetTunnelCpeDeviceConfigRequest struct {
+
+	// The OCID of the IPSec connection.
+	IpscId *string `mandatory:"true" contributesTo:"path" name:"ipscId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the tunnel.
+	TunnelId *string `mandatory:"true" contributesTo:"path" name:"tunnelId"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetTunnelCpeDeviceConfigRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetTunnelCpeDeviceConfigRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetTunnelCpeDeviceConfigRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetTunnelCpeDeviceConfigResponse wrapper for the GetTunnelCpeDeviceConfig operation
+type GetTunnelCpeDeviceConfigResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The TunnelCpeDeviceConfig instance
+	TunnelCpeDeviceConfig `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetTunnelCpeDeviceConfigResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetTunnelCpeDeviceConfigResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/core/ingress_security_rule.go
+++ b/core/ingress_security_rule.go
@@ -29,7 +29,8 @@ type IngressSecurityRule struct {
 	// can come from.
 	// Allowed values:
 	//   * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
-	//     Note that IPv6 addressing is currently supported only in the Government Cloud.
+	//     Note that IPv6 addressing is currently supported only in certain regions. See
+	//     IPv6 Addresses (https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
 	//   * The `cidrBlock` value for a Service, if you're
 	//     setting up a security list rule for traffic coming from a particular `Service` through
 	//     a service gateway. For example: `oci-phx-objectstorage`.

--- a/core/ip_sec_connection.go
+++ b/core/ip_sec_connection.go
@@ -60,7 +60,7 @@ type IpSecConnection struct {
 	// you must provide at least one valid static route. If you configure both
 	// tunnels to use BGP dynamic routing, you can provide an empty list for the static routes.
 	// The CIDR can be either IPv4 or IPv6. Note that IPv6 addressing is currently supported only
-	// in the Government Cloud.
+	// in certain regions. See IPv6 Addresses (https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
 	// Example: `10.0.1.0/24`
 	// Example: `2001:db8::/32`
 	StaticRoutes []string `mandatory:"true" json:"staticRoutes"`

--- a/core/ipv6.go
+++ b/core/ipv6.go
@@ -20,8 +20,8 @@ import (
 // The `IPv6` object is the API representation of an IPv6.
 // You can create and assign an IPv6 to any VNIC that is in an IPv6-enabled subnet in an
 // IPv6-enabled VCN.
-// **Note:** IPv6 addressing is currently supported only in the Government Cloud.
-// For important details about IPv6 addressing in a VCN, see IPv6 Addresses (https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+// **Note:** IPv6 addressing is currently supported only in certain regions. For important
+// details about IPv6 addressing in a VCN, see IPv6 Addresses (https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
 type Ipv6 struct {
 
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment containing the IPv6.

--- a/core/list_cpe_device_shapes_request_response.go
+++ b/core/list_cpe_device_shapes_request_response.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListCpeDeviceShapesRequest wrapper for the ListCpeDeviceShapes operation
+type ListCpeDeviceShapesRequest struct {
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated
+	// "List" call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// Example: `50`
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List"
+	// call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListCpeDeviceShapesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListCpeDeviceShapesRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListCpeDeviceShapesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListCpeDeviceShapesResponse wrapper for the ListCpeDeviceShapes operation
+type ListCpeDeviceShapesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []CpeDeviceShapeSummary instances
+	Items []CpeDeviceShapeSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListCpeDeviceShapesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListCpeDeviceShapesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/core/route_rule.go
+++ b/core/route_rule.go
@@ -38,8 +38,8 @@ type RouteRule struct {
 	// Allowed values:
 	//   * IP address range in CIDR notation. Can be an IPv4 or IPv6 CIDR. For example: `192.168.1.0/24`
 	//   or `2001:0db8:0123:45::/56`. If you set this to an IPv6 CIDR, the route rule's target
-	//   can only be a DRG or internet gateway. Note that IPv6 addressing is currently supported only
-	//   in the Government Cloud.
+	//   can only be a DRG or internet gateway. Note that IPv6 addressing is currently supported
+	//   only in certain regions. See IPv6 Addresses (https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
 	//   * The `cidrBlock` value for a Service, if you're
 	//     setting up a route rule for traffic destined for a particular `Service` through
 	//     a service gateway. For example: `oci-phx-objectstorage`.

--- a/core/security_rule.go
+++ b/core/security_rule.go
@@ -37,7 +37,8 @@ type SecurityRule struct {
 	// can go to.
 	// Allowed values:
 	//   * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-	//     Note that IPv6 addressing is currently supported only in the Government Cloud.
+	//     Note that IPv6 addressing is currently supported only in certain regions. See
+	//     IPv6 Addresses (https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
 	//   * The `cidrBlock` value for a Service, if you're
 	//     setting up a security rule for traffic destined for a particular `Service` through
 	//     a service gateway. For example: `oci-phx-objectstorage`.
@@ -88,7 +89,8 @@ type SecurityRule struct {
 	// can come from.
 	// Allowed values:
 	//   * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-	//     Note that IPv6 addressing is currently supported only in the Government Cloud.
+	//     Note that IPv6 addressing is currently supported only in certain regions. See
+	//     IPv6 Addresses (https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
 	//   * The `cidrBlock` value for a Service, if you're
 	//     setting up a security rule for traffic coming from a particular `Service` through
 	//     a service gateway. For example: `oci-phx-objectstorage`.

--- a/core/subnet.go
+++ b/core/subnet.go
@@ -16,7 +16,7 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// Subnet A logical subdivision of a VCN. Each subnet exists in a single availability domain and
+// Subnet A logical subdivision of a VCN. Each subnet
 // consists of a contiguous range of IP addresses that do not overlap with
 // other subnets in the VCN. Example: 172.16.1.0/24. For more information, see
 // Overview of the Networking Service (https://docs.cloud.oracle.com/Content/Network/Concepts/overview.htm) and
@@ -91,7 +91,7 @@ type Subnet struct {
 
 	// For an IPv6-enabled subnet, this is the IPv6 CIDR block for the subnet's private IP address
 	// space. The subnet size is always /64. Note that IPv6 addressing is currently supported only
-	// in the Government Cloud.
+	// in certain regions. See IPv6 Addresses (https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
 	// Example: `2001:0db8:0123:1111::/64`
 	Ipv6CidrBlock *string `mandatory:"false" json:"ipv6CidrBlock"`
 

--- a/core/tunnel_cpe_device_config.go
+++ b/core/tunnel_cpe_device_config.go
@@ -16,14 +16,19 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// CreateVirtualCircuitPublicPrefixDetails The representation of CreateVirtualCircuitPublicPrefixDetails
-type CreateVirtualCircuitPublicPrefixDetails struct {
-
-	// An individual public IP prefix (CIDR) to add to the public virtual circuit.
-	// All prefix sizes are allowed.
-	CidrBlock *string `mandatory:"true" json:"cidrBlock"`
+// TunnelCpeDeviceConfig The set of CPE configuration answers for the tunnel, which the customer provides in
+// UpdateTunnelCpeDeviceConfig.
+// The answers correlate to the questions that are specific to the CPE device type (see the
+// `parameters` attribute of CpeDeviceShapeDetail).
+// See these related operations:
+//   * GetTunnelCpeDeviceConfig
+//   * GetTunnelCpeDeviceConfigContent
+//   * GetIpsecCpeDeviceConfigContent
+//   * GetCpeDeviceConfigContent
+type TunnelCpeDeviceConfig struct {
+	TunnelCpeDeviceConfigParameter []CpeDeviceConfigAnswer `mandatory:"false" json:"tunnelCpeDeviceConfigParameter"`
 }
 
-func (m CreateVirtualCircuitPublicPrefixDetails) String() string {
+func (m TunnelCpeDeviceConfig) String() string {
 	return common.PointerString(m)
 }

--- a/core/update_cpe_details.go
+++ b/core/update_cpe_details.go
@@ -32,6 +32,17 @@ type UpdateCpeDetails struct {
 	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the CPE device type. You can provide
+	// a value if you want to generate CPE device configuration content for IPSec connections
+	// that use this CPE. For a list of possible values, see
+	// ListCpeDeviceShapes.
+	// For more information about generating CPE device configuration content, see:
+	//   * GetCpeDeviceConfigContent
+	//   * GetIpsecCpeDeviceConfigContent
+	//   * GetTunnelCpeDeviceConfigContent
+	//   * GetTunnelCpeDeviceConfig
+	CpeDeviceShapeId *string `mandatory:"false" json:"cpeDeviceShapeId"`
 }
 
 func (m UpdateCpeDetails) String() string {

--- a/core/update_instance_details.go
+++ b/core/update_instance_details.go
@@ -57,9 +57,16 @@ type UpdateInstanceDetails struct {
 	ExtendedMetadata map[string]interface{} `mandatory:"false" json:"extendedMetadata"`
 
 	// The shape of the instance. The shape determines the number of CPUs and the amount of memory
-	// allocated to the instance. You can enumerate all available shapes by calling
+	// allocated to the instance. For more information about how to change shapes, and a list of
+	// shapes that are supported, see
+	// Changing the Shape of an Instance (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/resizinginstances.htm).
+	// For details about the CPUs, memory, and other properties of each shape, see
+	// Compute Shapes (https://docs.cloud.oracle.com/iaas/Content/Compute/References/computeshapes.htm).
+	// The new shape must be compatible with the image that was used to launch the instance. You
+	// can enumerate all available shapes and determine image compatibility by calling
 	// ListShapes.
-	// Example: `VM.Standard1.1`
+	// If the instance is running when you change the shape, the instance is rebooted.
+	// Example: `VM.Standard2.1`
 	Shape *string `mandatory:"false" json:"shape"`
 }
 

--- a/core/update_ip_sec_connection_details.go
+++ b/core/update_ip_sec_connection_details.go
@@ -49,7 +49,7 @@ type UpdateIpSecConnectionDetails struct {
 	// Static routes to the CPE. If you provide this attribute, it replaces the entire current set of
 	// static routes. A static route's CIDR must not be a multicast address or class E address.
 	// The CIDR can be either IPv4 or IPv6. Note that IPv6 addressing is currently supported only
-	// in the Government Cloud.
+	// in certain regions. See IPv6 Addresses (https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
 	// Example: `10.0.1.0/24`
 	// Example: `2001:db8::/32`
 	StaticRoutes []string `mandatory:"false" json:"staticRoutes"`

--- a/core/update_security_rule_details.go
+++ b/core/update_security_rule_details.go
@@ -40,7 +40,8 @@ type UpdateSecurityRuleDetails struct {
 	// can go to.
 	// Allowed values:
 	//   * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-	//     Note that IPv6 addressing is currently supported only in the Government Cloud.
+	//     Note that IPv6 addressing is currently supported only in certain regions. See
+	//     IPv6 Addresses (https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
 	//   * The `cidrBlock` value for a Service, if you're
 	//     setting up a security rule for traffic destined for a particular `Service` through
 	//     a service gateway. For example: `oci-phx-objectstorage`.
@@ -81,7 +82,8 @@ type UpdateSecurityRuleDetails struct {
 	// can come from.
 	// Allowed values:
 	//   * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-	//     Note that IPv6 addressing is currently supported only in the Government Cloud.
+	//     Note that IPv6 addressing is currently supported only in certain regions. See
+	//     IPv6 Addresses (https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
 	//   * The `cidrBlock` value for a Service, if you're
 	//     setting up a security rule for traffic coming from a particular `Service` through
 	//     a service gateway. For example: `oci-phx-objectstorage`.

--- a/core/update_tunnel_cpe_device_config_details.go
+++ b/core/update_tunnel_cpe_device_config_details.go
@@ -16,14 +16,13 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// CreateVirtualCircuitPublicPrefixDetails The representation of CreateVirtualCircuitPublicPrefixDetails
-type CreateVirtualCircuitPublicPrefixDetails struct {
+// UpdateTunnelCpeDeviceConfigDetails The representation of UpdateTunnelCpeDeviceConfigDetails
+type UpdateTunnelCpeDeviceConfigDetails struct {
 
-	// An individual public IP prefix (CIDR) to add to the public virtual circuit.
-	// All prefix sizes are allowed.
-	CidrBlock *string `mandatory:"true" json:"cidrBlock"`
+	// The set of configuration answers for a CPE device.
+	TunnelCpeDeviceConfig []CpeDeviceConfigAnswer `mandatory:"false" json:"tunnelCpeDeviceConfig"`
 }
 
-func (m CreateVirtualCircuitPublicPrefixDetails) String() string {
+func (m UpdateTunnelCpeDeviceConfigDetails) String() string {
 	return common.PointerString(m)
 }

--- a/core/update_tunnel_cpe_device_config_request_response.go
+++ b/core/update_tunnel_cpe_device_config_request_response.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2016, 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateTunnelCpeDeviceConfigRequest wrapper for the UpdateTunnelCpeDeviceConfig operation
+type UpdateTunnelCpeDeviceConfigRequest struct {
+
+	// The OCID of the IPSec connection.
+	IpscId *string `mandatory:"true" contributesTo:"path" name:"ipscId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the tunnel.
+	TunnelId *string `mandatory:"true" contributesTo:"path" name:"tunnelId"`
+
+	// Request to input the tunnel's cpe configuration parameters
+	UpdateTunnelCpeDeviceConfigDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateTunnelCpeDeviceConfigRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateTunnelCpeDeviceConfigRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateTunnelCpeDeviceConfigRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateTunnelCpeDeviceConfigResponse wrapper for the UpdateTunnelCpeDeviceConfig operation
+type UpdateTunnelCpeDeviceConfigResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The TunnelCpeDeviceConfig instance
+	TunnelCpeDeviceConfig `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateTunnelCpeDeviceConfigResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateTunnelCpeDeviceConfigResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/core/update_vnic_details.go
+++ b/core/update_vnic_details.go
@@ -48,14 +48,16 @@ type UpdateVnicDetails struct {
 	HostnameLabel *string `mandatory:"false" json:"hostnameLabel"`
 
 	// A list of the OCIDs of the network security groups (NSGs) to add the VNIC to. Setting this as
-	// an empty array removes the VNIC from all network security groups.
+	// an empty array removes the VNIC from all network security groups. If the VNIC contains an
+	// vlanId, the value of this field will be ignored.
 	// For more information about NSGs, see
 	// NetworkSecurityGroup.
 	NsgIds []string `mandatory:"false" json:"nsgIds"`
 
 	// Whether the source/destination check is disabled on the VNIC.
-	// Defaults to `false`, which means the check is performed. For information
-	// about why you would skip the source/destination check, see
+	// Defaults to `false`, which means the check is performed. If the VNIC
+	// contains an vlanId, the value of this field will be ignored.
+	// For information about why you would skip the source/destination check, see
 	// Using a Private IP as a Route Target (https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm#privateip).
 	// Example: `true`
 	SkipSourceDestCheck *bool `mandatory:"false" json:"skipSourceDestCheck"`

--- a/core/vcn.go
+++ b/core/vcn.go
@@ -77,7 +77,8 @@ type Vcn struct {
 	// The VCN size is always /48. If you don't provide a value when creating the VCN, Oracle
 	// provides one and uses that *same* CIDR for the `ipv6PublicCidrBlock`. If you do provide a
 	// value, Oracle provides a *different* CIDR for the `ipv6PublicCidrBlock`. Note that IPv6
-	// addressing is currently supported only in the Government Cloud.
+	// addressing is currently supported only in certain regions. See
+	// IPv6 Addresses (https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
 	// Example: `2001:0db8:0123::/48`
 	Ipv6CidrBlock *string `mandatory:"false" json:"ipv6CidrBlock"`
 

--- a/core/virtual_circuit.go
+++ b/core/virtual_circuit.go
@@ -118,7 +118,7 @@ type VirtualCircuit struct {
 	ProviderState VirtualCircuitProviderStateEnum `mandatory:"false" json:"providerState,omitempty"`
 
 	// For a public virtual circuit. The public IP prefixes (CIDRs) the customer wants to
-	// advertise across the connection. Each prefix must be /31 or less specific.
+	// advertise across the connection. All prefix sizes are allowed.
 	PublicPrefixes []string `mandatory:"false" json:"publicPrefixes"`
 
 	// Provider-supplied reference information about this virtual circuit

--- a/core/vnic_attachment.go
+++ b/core/vnic_attachment.go
@@ -39,7 +39,7 @@ type VnicAttachment struct {
 	// The current state of the VNIC attachment.
 	LifecycleState VnicAttachmentLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
 
-	// The OCID of the VNIC's subnet.
+	// The OCID of the subnet to create the VNIC in.
 	SubnetId *string `mandatory:"true" json:"subnetId"`
 
 	// The date and time the VNIC attachment was created, in the format defined by RFC3339.

--- a/database/update_db_system_details.go
+++ b/database/update_db_system_details.go
@@ -36,6 +36,11 @@ type UpdateDbSystemDetails struct {
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
+	// The shape of the DB system. The shape determines resources allocated to the DB system.
+	// - For virtual machine shapes, the number of CPU cores and memory
+	// To get a list of shapes, use the ListDbSystemShapes operation.
+	Shape *string `mandatory:"false" json:"shape"`
+
 	// A list of the OCIDs (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this DB system belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see Security Rules (https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
 	NsgIds []string `mandatory:"false" json:"nsgIds"`
 


### PR DESCRIPTION
### Added

- Support for updating the shape of a Database System in the Database service

- Support for generating CPE configurations for download in the Networking service

- Support for private IPs and fault domains of cluster nodes in the Container Engine for Kubernetes service

- Support for calling Oracle Cloud Infrastructure services in the ca-montreal-1 region

- Support for exposing error after retrying failed in all services.