### PR TITLE
Releasing version 21.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## 21.0.0 - 2020-06-23
+### Added
+- Support for the Data Integration service
+- Support for updating database home IDs on databases in the Database service
+- Support for backing up autonomous databases on Cloud at Customer in the Database service
+- Support for managing autonomous VM clusters on Cloud at Customer in the Database service
+- Support for accessing data assets via private endpoints in the Data Catalog service
+- Support for dependency archive zip files to be specified for use by applications in the Data Flow service
+
+### Breaking changes
+- Property `LifecycleState` type changed from `JobLifecycleStateEnum` to `ListJobsLifecycleStateEnum` in the Data Catalog service
+- Property `JobType` type changed from `JobTypeEnum` to `ListJobsJobTypeEnum` in the Data Catalog service
+
 ## 20.1.0 - 2020-06-16
 ### Added
 - Support for creating a new database from an existing database based on a given timestamp in the Database service

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOC_SERVER_URL=https:\/\/docs.cloud.oracle.com
 
-GEN_TARGETS = identity core objectstorage loadbalancer database audit dns filestorage email containerengine resourcesearch keymanagement announcementsservice healthchecks waas autoscaling streaming ons monitoring resourcemanager budget workrequests functions limits events dts oce oda analytics integration osmanagement marketplace apigateway applicationmigration datacatalog dataflow datascience nosql secrets vault bds cims datasafe mysql ##SPECNAME##
+GEN_TARGETS = identity core objectstorage loadbalancer database audit dns filestorage email containerengine resourcesearch keymanagement announcementsservice healthchecks waas autoscaling streaming ons monitoring resourcemanager budget workrequests functions limits events dts oce oda analytics integration osmanagement marketplace apigateway applicationmigration datacatalog dataflow datascience nosql secrets vault bds cims datasafe mysql dataintegration ##SPECNAME##
 NON_GEN_TARGETS = common common/auth objectstorage/transfer example
 TARGETS = $(NON_GEN_TARGETS) $(GEN_TARGETS)
 

--- a/common/version.go
+++ b/common/version.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	major = "20"
-	minor = "1"
+	major = "21"
+	minor = "0"
 	patch = "0"
 	tag   = ""
 )

--- a/database/automated_mount_details.go
+++ b/database/automated_mount_details.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// AutomatedMountDetails Used for creating NFS Auto Mount backup destinations for autonomous on ExaCC.
+type AutomatedMountDetails struct {
+
+	// IP addresses for NFS Auto mount.
+	NfsServer []string `mandatory:"true" json:"nfsServer"`
+
+	// Specifies the directory on which to mount the file system
+	NfsServerExport *string `mandatory:"true" json:"nfsServerExport"`
+}
+
+func (m AutomatedMountDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m AutomatedMountDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeAutomatedMountDetails AutomatedMountDetails
+	s := struct {
+		DiscriminatorParam string `json:"mountType"`
+		MarshalTypeAutomatedMountDetails
+	}{
+		"AUTOMATED_MOUNT",
+		(MarshalTypeAutomatedMountDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/database/autonomous_container_database.go
+++ b/database/autonomous_container_database.go
@@ -28,14 +28,23 @@ type AutonomousContainerDatabase struct {
 	// The service level agreement type of the container database. The default is STANDARD.
 	ServiceLevelAgreementType AutonomousContainerDatabaseServiceLevelAgreementTypeEnum `mandatory:"true" json:"serviceLevelAgreementType"`
 
-	// The OCID of the Autonomous Exadata Infrastructure.
-	AutonomousExadataInfrastructureId *string `mandatory:"true" json:"autonomousExadataInfrastructureId"`
-
 	// The current state of the Autonomous Container Database.
 	LifecycleState AutonomousContainerDatabaseLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
 
 	// Database patch model preference.
 	PatchModel AutonomousContainerDatabasePatchModelEnum `mandatory:"true" json:"patchModel"`
+
+	// The `DB_UNIQUE_NAME` of the Oracle Database being backed up.
+	DbUniqueName *string `mandatory:"false" json:"dbUniqueName"`
+
+	// The OCID of the Autonomous Exadata Infrastructure.
+	AutonomousExadataInfrastructureId *string `mandatory:"false" json:"autonomousExadataInfrastructureId"`
+
+	// The OCID of the Autonomous VM Cluster.
+	AutonomousVmClusterId *string `mandatory:"false" json:"autonomousVmClusterId"`
+
+	// The infrastructure type this resource belongs to.
+	InfrastructureType AutonomousContainerDatabaseInfrastructureTypeEnum `mandatory:"false" json:"infrastructureType,omitempty"`
 
 	// Additional information about the current lifecycleState.
 	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
@@ -91,6 +100,29 @@ var mappingAutonomousContainerDatabaseServiceLevelAgreementType = map[string]Aut
 func GetAutonomousContainerDatabaseServiceLevelAgreementTypeEnumValues() []AutonomousContainerDatabaseServiceLevelAgreementTypeEnum {
 	values := make([]AutonomousContainerDatabaseServiceLevelAgreementTypeEnum, 0)
 	for _, v := range mappingAutonomousContainerDatabaseServiceLevelAgreementType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// AutonomousContainerDatabaseInfrastructureTypeEnum Enum with underlying type: string
+type AutonomousContainerDatabaseInfrastructureTypeEnum string
+
+// Set of constants representing the allowable values for AutonomousContainerDatabaseInfrastructureTypeEnum
+const (
+	AutonomousContainerDatabaseInfrastructureTypeCloud           AutonomousContainerDatabaseInfrastructureTypeEnum = "CLOUD"
+	AutonomousContainerDatabaseInfrastructureTypeCloudAtCustomer AutonomousContainerDatabaseInfrastructureTypeEnum = "CLOUD_AT_CUSTOMER"
+)
+
+var mappingAutonomousContainerDatabaseInfrastructureType = map[string]AutonomousContainerDatabaseInfrastructureTypeEnum{
+	"CLOUD":             AutonomousContainerDatabaseInfrastructureTypeCloud,
+	"CLOUD_AT_CUSTOMER": AutonomousContainerDatabaseInfrastructureTypeCloudAtCustomer,
+}
+
+// GetAutonomousContainerDatabaseInfrastructureTypeEnumValues Enumerates the set of values for AutonomousContainerDatabaseInfrastructureTypeEnum
+func GetAutonomousContainerDatabaseInfrastructureTypeEnumValues() []AutonomousContainerDatabaseInfrastructureTypeEnum {
+	values := make([]AutonomousContainerDatabaseInfrastructureTypeEnum, 0)
+	for _, v := range mappingAutonomousContainerDatabaseInfrastructureType {
 		values = append(values, v)
 	}
 	return values

--- a/database/autonomous_container_database_backup_config.go
+++ b/database/autonomous_container_database_backup_config.go
@@ -16,6 +16,9 @@ import (
 // AutonomousContainerDatabaseBackupConfig Backup options for the Autonomous Container Database.
 type AutonomousContainerDatabaseBackupConfig struct {
 
+	// Backup destination details.
+	BackupDestinationDetails []BackupDestinationDetails `mandatory:"false" json:"backupDestinationDetails"`
+
 	// Number of days between the current and the earliest point of recoverability covered by automatic backups.
 	// This value applies to automatic backups. After a new automatic backup has been created, Oracle removes old automatic backups that are created before the window.
 	// When the value is updated, it is applied to all existing automatic backups.

--- a/database/autonomous_container_database_summary.go
+++ b/database/autonomous_container_database_summary.go
@@ -28,14 +28,23 @@ type AutonomousContainerDatabaseSummary struct {
 	// The service level agreement type of the container database. The default is STANDARD.
 	ServiceLevelAgreementType AutonomousContainerDatabaseSummaryServiceLevelAgreementTypeEnum `mandatory:"true" json:"serviceLevelAgreementType"`
 
-	// The OCID of the Autonomous Exadata Infrastructure.
-	AutonomousExadataInfrastructureId *string `mandatory:"true" json:"autonomousExadataInfrastructureId"`
-
 	// The current state of the Autonomous Container Database.
 	LifecycleState AutonomousContainerDatabaseSummaryLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
 
 	// Database patch model preference.
 	PatchModel AutonomousContainerDatabaseSummaryPatchModelEnum `mandatory:"true" json:"patchModel"`
+
+	// The `DB_UNIQUE_NAME` of the Oracle Database being backed up.
+	DbUniqueName *string `mandatory:"false" json:"dbUniqueName"`
+
+	// The OCID of the Autonomous Exadata Infrastructure.
+	AutonomousExadataInfrastructureId *string `mandatory:"false" json:"autonomousExadataInfrastructureId"`
+
+	// The OCID of the Autonomous VM Cluster.
+	AutonomousVmClusterId *string `mandatory:"false" json:"autonomousVmClusterId"`
+
+	// The infrastructure type this resource belongs to.
+	InfrastructureType AutonomousContainerDatabaseSummaryInfrastructureTypeEnum `mandatory:"false" json:"infrastructureType,omitempty"`
 
 	// Additional information about the current lifecycleState.
 	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
@@ -91,6 +100,29 @@ var mappingAutonomousContainerDatabaseSummaryServiceLevelAgreementType = map[str
 func GetAutonomousContainerDatabaseSummaryServiceLevelAgreementTypeEnumValues() []AutonomousContainerDatabaseSummaryServiceLevelAgreementTypeEnum {
 	values := make([]AutonomousContainerDatabaseSummaryServiceLevelAgreementTypeEnum, 0)
 	for _, v := range mappingAutonomousContainerDatabaseSummaryServiceLevelAgreementType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// AutonomousContainerDatabaseSummaryInfrastructureTypeEnum Enum with underlying type: string
+type AutonomousContainerDatabaseSummaryInfrastructureTypeEnum string
+
+// Set of constants representing the allowable values for AutonomousContainerDatabaseSummaryInfrastructureTypeEnum
+const (
+	AutonomousContainerDatabaseSummaryInfrastructureTypeCloud           AutonomousContainerDatabaseSummaryInfrastructureTypeEnum = "CLOUD"
+	AutonomousContainerDatabaseSummaryInfrastructureTypeCloudAtCustomer AutonomousContainerDatabaseSummaryInfrastructureTypeEnum = "CLOUD_AT_CUSTOMER"
+)
+
+var mappingAutonomousContainerDatabaseSummaryInfrastructureType = map[string]AutonomousContainerDatabaseSummaryInfrastructureTypeEnum{
+	"CLOUD":             AutonomousContainerDatabaseSummaryInfrastructureTypeCloud,
+	"CLOUD_AT_CUSTOMER": AutonomousContainerDatabaseSummaryInfrastructureTypeCloudAtCustomer,
+}
+
+// GetAutonomousContainerDatabaseSummaryInfrastructureTypeEnumValues Enumerates the set of values for AutonomousContainerDatabaseSummaryInfrastructureTypeEnum
+func GetAutonomousContainerDatabaseSummaryInfrastructureTypeEnumValues() []AutonomousContainerDatabaseSummaryInfrastructureTypeEnum {
+	values := make([]AutonomousContainerDatabaseSummaryInfrastructureTypeEnum, 0)
+	for _, v := range mappingAutonomousContainerDatabaseSummaryInfrastructureType {
 		values = append(values, v)
 	}
 	return values

--- a/database/autonomous_database.go
+++ b/database/autonomous_database.go
@@ -50,6 +50,9 @@ type AutonomousDatabase struct {
 	// The date and time the Always Free database will be automatically deleted because of inactivity. If the database is in the STOPPED state and without activity until this time, it will be deleted.
 	TimeDeletionOfFreeAutonomousDatabase *common.SDKTime `mandatory:"false" json:"timeDeletionOfFreeAutonomousDatabase"`
 
+	// The infrastructure type this resource belongs to.
+	InfrastructureType AutonomousDatabaseInfrastructureTypeEnum `mandatory:"false" json:"infrastructureType,omitempty"`
+
 	// True if the database uses dedicated Exadata infrastructure (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm).
 	IsDedicated *bool `mandatory:"false" json:"isDedicated"`
 
@@ -195,6 +198,29 @@ var mappingAutonomousDatabaseLifecycleState = map[string]AutonomousDatabaseLifec
 func GetAutonomousDatabaseLifecycleStateEnumValues() []AutonomousDatabaseLifecycleStateEnum {
 	values := make([]AutonomousDatabaseLifecycleStateEnum, 0)
 	for _, v := range mappingAutonomousDatabaseLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}
+
+// AutonomousDatabaseInfrastructureTypeEnum Enum with underlying type: string
+type AutonomousDatabaseInfrastructureTypeEnum string
+
+// Set of constants representing the allowable values for AutonomousDatabaseInfrastructureTypeEnum
+const (
+	AutonomousDatabaseInfrastructureTypeCloud           AutonomousDatabaseInfrastructureTypeEnum = "CLOUD"
+	AutonomousDatabaseInfrastructureTypeCloudAtCustomer AutonomousDatabaseInfrastructureTypeEnum = "CLOUD_AT_CUSTOMER"
+)
+
+var mappingAutonomousDatabaseInfrastructureType = map[string]AutonomousDatabaseInfrastructureTypeEnum{
+	"CLOUD":             AutonomousDatabaseInfrastructureTypeCloud,
+	"CLOUD_AT_CUSTOMER": AutonomousDatabaseInfrastructureTypeCloudAtCustomer,
+}
+
+// GetAutonomousDatabaseInfrastructureTypeEnumValues Enumerates the set of values for AutonomousDatabaseInfrastructureTypeEnum
+func GetAutonomousDatabaseInfrastructureTypeEnumValues() []AutonomousDatabaseInfrastructureTypeEnum {
+	values := make([]AutonomousDatabaseInfrastructureTypeEnum, 0)
+	for _, v := range mappingAutonomousDatabaseInfrastructureType {
 		values = append(values, v)
 	}
 	return values

--- a/database/autonomous_database_summary.go
+++ b/database/autonomous_database_summary.go
@@ -51,6 +51,9 @@ type AutonomousDatabaseSummary struct {
 	// The date and time the Always Free database will be automatically deleted because of inactivity. If the database is in the STOPPED state and without activity until this time, it will be deleted.
 	TimeDeletionOfFreeAutonomousDatabase *common.SDKTime `mandatory:"false" json:"timeDeletionOfFreeAutonomousDatabase"`
 
+	// The infrastructure type this resource belongs to.
+	InfrastructureType AutonomousDatabaseSummaryInfrastructureTypeEnum `mandatory:"false" json:"infrastructureType,omitempty"`
+
 	// True if the database uses dedicated Exadata infrastructure (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm).
 	IsDedicated *bool `mandatory:"false" json:"isDedicated"`
 
@@ -196,6 +199,29 @@ var mappingAutonomousDatabaseSummaryLifecycleState = map[string]AutonomousDataba
 func GetAutonomousDatabaseSummaryLifecycleStateEnumValues() []AutonomousDatabaseSummaryLifecycleStateEnum {
 	values := make([]AutonomousDatabaseSummaryLifecycleStateEnum, 0)
 	for _, v := range mappingAutonomousDatabaseSummaryLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}
+
+// AutonomousDatabaseSummaryInfrastructureTypeEnum Enum with underlying type: string
+type AutonomousDatabaseSummaryInfrastructureTypeEnum string
+
+// Set of constants representing the allowable values for AutonomousDatabaseSummaryInfrastructureTypeEnum
+const (
+	AutonomousDatabaseSummaryInfrastructureTypeCloud           AutonomousDatabaseSummaryInfrastructureTypeEnum = "CLOUD"
+	AutonomousDatabaseSummaryInfrastructureTypeCloudAtCustomer AutonomousDatabaseSummaryInfrastructureTypeEnum = "CLOUD_AT_CUSTOMER"
+)
+
+var mappingAutonomousDatabaseSummaryInfrastructureType = map[string]AutonomousDatabaseSummaryInfrastructureTypeEnum{
+	"CLOUD":             AutonomousDatabaseSummaryInfrastructureTypeCloud,
+	"CLOUD_AT_CUSTOMER": AutonomousDatabaseSummaryInfrastructureTypeCloudAtCustomer,
+}
+
+// GetAutonomousDatabaseSummaryInfrastructureTypeEnumValues Enumerates the set of values for AutonomousDatabaseSummaryInfrastructureTypeEnum
+func GetAutonomousDatabaseSummaryInfrastructureTypeEnumValues() []AutonomousDatabaseSummaryInfrastructureTypeEnum {
+	values := make([]AutonomousDatabaseSummaryInfrastructureTypeEnum, 0)
+	for _, v := range mappingAutonomousDatabaseSummaryInfrastructureType {
 		values = append(values, v)
 	}
 	return values

--- a/database/autonomous_vm_cluster.go
+++ b/database/autonomous_vm_cluster.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// AutonomousVmCluster Details of the Autonomous VM cluster.
+type AutonomousVmCluster struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Autonomous VM cluster.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The user-friendly name for the Autonomous VM cluster. The name does not need to be unique.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The current state of the Autonomous VM cluster.
+	LifecycleState AutonomousVmClusterLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+	ExadataInfrastructureId *string `mandatory:"true" json:"exadataInfrastructureId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster network.
+	VmClusterNetworkId *string `mandatory:"true" json:"vmClusterNetworkId"`
+
+	// The date and time that the Autonomous VM cluster was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// Additional information about the current lifecycle state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The time zone to use for the Autonomous VM cluster. For details, see DB System Time Zones (https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
+	TimeZone *string `mandatory:"false" json:"timeZone"`
+
+	// If true, database backup on local Exadata storage is configured for the Autonomous VM cluster. If false, database backup on local Exadata storage is not available in the Autonomous VM cluster.
+	IsLocalBackupEnabled *bool `mandatory:"false" json:"isLocalBackupEnabled"`
+
+	// The number of enabled CPU cores.
+	CpusEnabled *int `mandatory:"false" json:"cpusEnabled"`
+
+	// The numnber of CPU cores available.
+	AvailableCpus *int `mandatory:"false" json:"availableCpus"`
+
+	// The memory allocated in GBs.
+	MemorySizeInGBs *int `mandatory:"false" json:"memorySizeInGBs"`
+
+	// The local node storage allocated in GBs.
+	DbNodeStorageSizeInGBs *int `mandatory:"false" json:"dbNodeStorageSizeInGBs"`
+
+	// The total data storage allocated in TBs
+	DataStorageSizeInTBs *float64 `mandatory:"false" json:"dataStorageSizeInTBs"`
+
+	// The data storage available in TBs
+	AvailableDataStorageSizeInTBs *float64 `mandatory:"false" json:"availableDataStorageSizeInTBs"`
+
+	// The Oracle license model that applies to the Autonomous VM cluster. The default is LICENSE_INCLUDED.
+	LicenseModel AutonomousVmClusterLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m AutonomousVmCluster) String() string {
+	return common.PointerString(m)
+}
+
+// AutonomousVmClusterLifecycleStateEnum Enum with underlying type: string
+type AutonomousVmClusterLifecycleStateEnum string
+
+// Set of constants representing the allowable values for AutonomousVmClusterLifecycleStateEnum
+const (
+	AutonomousVmClusterLifecycleStateProvisioning          AutonomousVmClusterLifecycleStateEnum = "PROVISIONING"
+	AutonomousVmClusterLifecycleStateAvailable             AutonomousVmClusterLifecycleStateEnum = "AVAILABLE"
+	AutonomousVmClusterLifecycleStateUpdating              AutonomousVmClusterLifecycleStateEnum = "UPDATING"
+	AutonomousVmClusterLifecycleStateTerminating           AutonomousVmClusterLifecycleStateEnum = "TERMINATING"
+	AutonomousVmClusterLifecycleStateTerminated            AutonomousVmClusterLifecycleStateEnum = "TERMINATED"
+	AutonomousVmClusterLifecycleStateFailed                AutonomousVmClusterLifecycleStateEnum = "FAILED"
+	AutonomousVmClusterLifecycleStateMaintenanceInProgress AutonomousVmClusterLifecycleStateEnum = "MAINTENANCE_IN_PROGRESS"
+)
+
+var mappingAutonomousVmClusterLifecycleState = map[string]AutonomousVmClusterLifecycleStateEnum{
+	"PROVISIONING":            AutonomousVmClusterLifecycleStateProvisioning,
+	"AVAILABLE":               AutonomousVmClusterLifecycleStateAvailable,
+	"UPDATING":                AutonomousVmClusterLifecycleStateUpdating,
+	"TERMINATING":             AutonomousVmClusterLifecycleStateTerminating,
+	"TERMINATED":              AutonomousVmClusterLifecycleStateTerminated,
+	"FAILED":                  AutonomousVmClusterLifecycleStateFailed,
+	"MAINTENANCE_IN_PROGRESS": AutonomousVmClusterLifecycleStateMaintenanceInProgress,
+}
+
+// GetAutonomousVmClusterLifecycleStateEnumValues Enumerates the set of values for AutonomousVmClusterLifecycleStateEnum
+func GetAutonomousVmClusterLifecycleStateEnumValues() []AutonomousVmClusterLifecycleStateEnum {
+	values := make([]AutonomousVmClusterLifecycleStateEnum, 0)
+	for _, v := range mappingAutonomousVmClusterLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}
+
+// AutonomousVmClusterLicenseModelEnum Enum with underlying type: string
+type AutonomousVmClusterLicenseModelEnum string
+
+// Set of constants representing the allowable values for AutonomousVmClusterLicenseModelEnum
+const (
+	AutonomousVmClusterLicenseModelLicenseIncluded     AutonomousVmClusterLicenseModelEnum = "LICENSE_INCLUDED"
+	AutonomousVmClusterLicenseModelBringYourOwnLicense AutonomousVmClusterLicenseModelEnum = "BRING_YOUR_OWN_LICENSE"
+)
+
+var mappingAutonomousVmClusterLicenseModel = map[string]AutonomousVmClusterLicenseModelEnum{
+	"LICENSE_INCLUDED":       AutonomousVmClusterLicenseModelLicenseIncluded,
+	"BRING_YOUR_OWN_LICENSE": AutonomousVmClusterLicenseModelBringYourOwnLicense,
+}
+
+// GetAutonomousVmClusterLicenseModelEnumValues Enumerates the set of values for AutonomousVmClusterLicenseModelEnum
+func GetAutonomousVmClusterLicenseModelEnumValues() []AutonomousVmClusterLicenseModelEnum {
+	values := make([]AutonomousVmClusterLicenseModelEnum, 0)
+	for _, v := range mappingAutonomousVmClusterLicenseModel {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/autonomous_vm_cluster_summary.go
+++ b/database/autonomous_vm_cluster_summary.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// AutonomousVmClusterSummary Details of the Autonomous VM cluster.
+type AutonomousVmClusterSummary struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Autonomous VM cluster.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The user-friendly name for the Autonomous VM cluster. The name does not need to be unique.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The current state of the Autonomous VM cluster.
+	LifecycleState AutonomousVmClusterSummaryLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+	ExadataInfrastructureId *string `mandatory:"true" json:"exadataInfrastructureId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster network.
+	VmClusterNetworkId *string `mandatory:"true" json:"vmClusterNetworkId"`
+
+	// The date and time that the Autonomous VM cluster was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// Additional information about the current lifecycle state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The time zone to use for the Autonomous VM cluster. For details, see DB System Time Zones (https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
+	TimeZone *string `mandatory:"false" json:"timeZone"`
+
+	// If true, database backup on local Exadata storage is configured for the Autonomous VM cluster. If false, database backup on local Exadata storage is not available in the Autonomous VM cluster.
+	IsLocalBackupEnabled *bool `mandatory:"false" json:"isLocalBackupEnabled"`
+
+	// The number of enabled CPU cores.
+	CpusEnabled *int `mandatory:"false" json:"cpusEnabled"`
+
+	// The numnber of CPU cores available.
+	AvailableCpus *int `mandatory:"false" json:"availableCpus"`
+
+	// The memory allocated in GBs.
+	MemorySizeInGBs *int `mandatory:"false" json:"memorySizeInGBs"`
+
+	// The local node storage allocated in GBs.
+	DbNodeStorageSizeInGBs *int `mandatory:"false" json:"dbNodeStorageSizeInGBs"`
+
+	// The total data storage allocated in TBs
+	DataStorageSizeInTBs *float64 `mandatory:"false" json:"dataStorageSizeInTBs"`
+
+	// The data storage available in TBs
+	AvailableDataStorageSizeInTBs *float64 `mandatory:"false" json:"availableDataStorageSizeInTBs"`
+
+	// The Oracle license model that applies to the Autonomous VM cluster. The default is LICENSE_INCLUDED.
+	LicenseModel AutonomousVmClusterSummaryLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m AutonomousVmClusterSummary) String() string {
+	return common.PointerString(m)
+}
+
+// AutonomousVmClusterSummaryLifecycleStateEnum Enum with underlying type: string
+type AutonomousVmClusterSummaryLifecycleStateEnum string
+
+// Set of constants representing the allowable values for AutonomousVmClusterSummaryLifecycleStateEnum
+const (
+	AutonomousVmClusterSummaryLifecycleStateProvisioning          AutonomousVmClusterSummaryLifecycleStateEnum = "PROVISIONING"
+	AutonomousVmClusterSummaryLifecycleStateAvailable             AutonomousVmClusterSummaryLifecycleStateEnum = "AVAILABLE"
+	AutonomousVmClusterSummaryLifecycleStateUpdating              AutonomousVmClusterSummaryLifecycleStateEnum = "UPDATING"
+	AutonomousVmClusterSummaryLifecycleStateTerminating           AutonomousVmClusterSummaryLifecycleStateEnum = "TERMINATING"
+	AutonomousVmClusterSummaryLifecycleStateTerminated            AutonomousVmClusterSummaryLifecycleStateEnum = "TERMINATED"
+	AutonomousVmClusterSummaryLifecycleStateFailed                AutonomousVmClusterSummaryLifecycleStateEnum = "FAILED"
+	AutonomousVmClusterSummaryLifecycleStateMaintenanceInProgress AutonomousVmClusterSummaryLifecycleStateEnum = "MAINTENANCE_IN_PROGRESS"
+)
+
+var mappingAutonomousVmClusterSummaryLifecycleState = map[string]AutonomousVmClusterSummaryLifecycleStateEnum{
+	"PROVISIONING":            AutonomousVmClusterSummaryLifecycleStateProvisioning,
+	"AVAILABLE":               AutonomousVmClusterSummaryLifecycleStateAvailable,
+	"UPDATING":                AutonomousVmClusterSummaryLifecycleStateUpdating,
+	"TERMINATING":             AutonomousVmClusterSummaryLifecycleStateTerminating,
+	"TERMINATED":              AutonomousVmClusterSummaryLifecycleStateTerminated,
+	"FAILED":                  AutonomousVmClusterSummaryLifecycleStateFailed,
+	"MAINTENANCE_IN_PROGRESS": AutonomousVmClusterSummaryLifecycleStateMaintenanceInProgress,
+}
+
+// GetAutonomousVmClusterSummaryLifecycleStateEnumValues Enumerates the set of values for AutonomousVmClusterSummaryLifecycleStateEnum
+func GetAutonomousVmClusterSummaryLifecycleStateEnumValues() []AutonomousVmClusterSummaryLifecycleStateEnum {
+	values := make([]AutonomousVmClusterSummaryLifecycleStateEnum, 0)
+	for _, v := range mappingAutonomousVmClusterSummaryLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}
+
+// AutonomousVmClusterSummaryLicenseModelEnum Enum with underlying type: string
+type AutonomousVmClusterSummaryLicenseModelEnum string
+
+// Set of constants representing the allowable values for AutonomousVmClusterSummaryLicenseModelEnum
+const (
+	AutonomousVmClusterSummaryLicenseModelLicenseIncluded     AutonomousVmClusterSummaryLicenseModelEnum = "LICENSE_INCLUDED"
+	AutonomousVmClusterSummaryLicenseModelBringYourOwnLicense AutonomousVmClusterSummaryLicenseModelEnum = "BRING_YOUR_OWN_LICENSE"
+)
+
+var mappingAutonomousVmClusterSummaryLicenseModel = map[string]AutonomousVmClusterSummaryLicenseModelEnum{
+	"LICENSE_INCLUDED":       AutonomousVmClusterSummaryLicenseModelLicenseIncluded,
+	"BRING_YOUR_OWN_LICENSE": AutonomousVmClusterSummaryLicenseModelBringYourOwnLicense,
+}
+
+// GetAutonomousVmClusterSummaryLicenseModelEnumValues Enumerates the set of values for AutonomousVmClusterSummaryLicenseModelEnum
+func GetAutonomousVmClusterSummaryLicenseModelEnumValues() []AutonomousVmClusterSummaryLicenseModelEnum {
+	values := make([]AutonomousVmClusterSummaryLicenseModelEnum, 0)
+	for _, v := range mappingAutonomousVmClusterSummaryLicenseModel {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/backup_destination.go
+++ b/database/backup_destination.go
@@ -40,6 +40,15 @@ type BackupDestination struct {
 	// The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
 	LocalMountPointPath *string `mandatory:"false" json:"localMountPointPath"`
 
+	// NFS Mount type for backup destination.
+	NfsMountType BackupDestinationNfsMountTypeEnum `mandatory:"false" json:"nfsMountType,omitempty"`
+
+	// Host names or IP addresses for NFS Auto mount.
+	NfsServer []string `mandatory:"false" json:"nfsServer"`
+
+	// Specifies the directory on which to mount the file system
+	NfsServerExport *string `mandatory:"false" json:"nfsServerExport"`
+
 	// The current lifecycle state of the backup destination.
 	LifecycleState BackupDestinationLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
 
@@ -82,6 +91,29 @@ var mappingBackupDestinationType = map[string]BackupDestinationTypeEnum{
 func GetBackupDestinationTypeEnumValues() []BackupDestinationTypeEnum {
 	values := make([]BackupDestinationTypeEnum, 0)
 	for _, v := range mappingBackupDestinationType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// BackupDestinationNfsMountTypeEnum Enum with underlying type: string
+type BackupDestinationNfsMountTypeEnum string
+
+// Set of constants representing the allowable values for BackupDestinationNfsMountTypeEnum
+const (
+	BackupDestinationNfsMountTypeSelfMount      BackupDestinationNfsMountTypeEnum = "SELF_MOUNT"
+	BackupDestinationNfsMountTypeAutomatedMount BackupDestinationNfsMountTypeEnum = "AUTOMATED_MOUNT"
+)
+
+var mappingBackupDestinationNfsMountType = map[string]BackupDestinationNfsMountTypeEnum{
+	"SELF_MOUNT":      BackupDestinationNfsMountTypeSelfMount,
+	"AUTOMATED_MOUNT": BackupDestinationNfsMountTypeAutomatedMount,
+}
+
+// GetBackupDestinationNfsMountTypeEnumValues Enumerates the set of values for BackupDestinationNfsMountTypeEnum
+func GetBackupDestinationNfsMountTypeEnumValues() []BackupDestinationNfsMountTypeEnum {
+	values := make([]BackupDestinationNfsMountTypeEnum, 0)
+	for _, v := range mappingBackupDestinationNfsMountType {
 		values = append(values, v)
 	}
 	return values

--- a/database/backup_destination_details.go
+++ b/database/backup_destination_details.go
@@ -27,6 +27,9 @@ type BackupDestinationDetails struct {
 
 	// For a RECOVERY_APPLIANCE backup destination, the password for the VPC user that is used to access the Recovery Appliance.
 	VpcPassword *string `mandatory:"false" json:"vpcPassword"`
+
+	// Proxy URL to connect to object store.
+	InternetProxy *string `mandatory:"false" json:"internetProxy"`
 }
 
 func (m BackupDestinationDetails) String() string {

--- a/database/backup_destination_summary.go
+++ b/database/backup_destination_summary.go
@@ -40,6 +40,15 @@ type BackupDestinationSummary struct {
 	// The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
 	LocalMountPointPath *string `mandatory:"false" json:"localMountPointPath"`
 
+	// NFS Mount type for backup destination.
+	NfsMountType BackupDestinationSummaryNfsMountTypeEnum `mandatory:"false" json:"nfsMountType,omitempty"`
+
+	// Host names or IP addresses for NFS Auto mount.
+	NfsServer []string `mandatory:"false" json:"nfsServer"`
+
+	// Specifies the directory on which to mount the file system
+	NfsServerExport *string `mandatory:"false" json:"nfsServerExport"`
+
 	// The current lifecycle state of the backup destination.
 	LifecycleState BackupDestinationSummaryLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
 
@@ -82,6 +91,29 @@ var mappingBackupDestinationSummaryType = map[string]BackupDestinationSummaryTyp
 func GetBackupDestinationSummaryTypeEnumValues() []BackupDestinationSummaryTypeEnum {
 	values := make([]BackupDestinationSummaryTypeEnum, 0)
 	for _, v := range mappingBackupDestinationSummaryType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// BackupDestinationSummaryNfsMountTypeEnum Enum with underlying type: string
+type BackupDestinationSummaryNfsMountTypeEnum string
+
+// Set of constants representing the allowable values for BackupDestinationSummaryNfsMountTypeEnum
+const (
+	BackupDestinationSummaryNfsMountTypeSelfMount      BackupDestinationSummaryNfsMountTypeEnum = "SELF_MOUNT"
+	BackupDestinationSummaryNfsMountTypeAutomatedMount BackupDestinationSummaryNfsMountTypeEnum = "AUTOMATED_MOUNT"
+)
+
+var mappingBackupDestinationSummaryNfsMountType = map[string]BackupDestinationSummaryNfsMountTypeEnum{
+	"SELF_MOUNT":      BackupDestinationSummaryNfsMountTypeSelfMount,
+	"AUTOMATED_MOUNT": BackupDestinationSummaryNfsMountTypeAutomatedMount,
+}
+
+// GetBackupDestinationSummaryNfsMountTypeEnumValues Enumerates the set of values for BackupDestinationSummaryNfsMountTypeEnum
+func GetBackupDestinationSummaryNfsMountTypeEnumValues() []BackupDestinationSummaryNfsMountTypeEnum {
+	values := make([]BackupDestinationSummaryNfsMountTypeEnum, 0)
+	for _, v := range mappingBackupDestinationSummaryNfsMountType {
 		values = append(values, v)
 	}
 	return values

--- a/database/change_autonomous_vm_cluster_compartment_details.go
+++ b/database/change_autonomous_vm_cluster_compartment_details.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ChangeAutonomousVmClusterCompartmentDetails The configuration details for moving the Autonomous VM cluster.
+type ChangeAutonomousVmClusterCompartmentDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the Autonomous VM cluster to.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+}
+
+func (m ChangeAutonomousVmClusterCompartmentDetails) String() string {
+	return common.PointerString(m)
+}

--- a/database/change_autonomous_vm_cluster_compartment_request_response.go
+++ b/database/change_autonomous_vm_cluster_compartment_request_response.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ChangeAutonomousVmClusterCompartmentRequest wrapper for the ChangeAutonomousVmClusterCompartment operation
+type ChangeAutonomousVmClusterCompartmentRequest struct {
+
+	// Request to move Autonomous VM cluster to a different compartment
+	ChangeAutonomousVmClusterCompartmentDetails `contributesTo:"body"`
+
+	// The autonomous VM cluster OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	AutonomousVmClusterId *string `mandatory:"true" contributesTo:"path" name:"autonomousVmClusterId"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ChangeAutonomousVmClusterCompartmentRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ChangeAutonomousVmClusterCompartmentRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ChangeAutonomousVmClusterCompartmentRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ChangeAutonomousVmClusterCompartmentResponse wrapper for the ChangeAutonomousVmClusterCompartment operation
+type ChangeAutonomousVmClusterCompartmentResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier of the work request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ChangeAutonomousVmClusterCompartmentResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ChangeAutonomousVmClusterCompartmentResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/create_autonomous_container_database_details.go
+++ b/database/create_autonomous_container_database_details.go
@@ -19,14 +19,20 @@ type CreateAutonomousContainerDatabaseDetails struct {
 	// The display name for the Autonomous Container Database.
 	DisplayName *string `mandatory:"true" json:"displayName"`
 
-	// The OCID of the Autonomous Exadata Infrastructure.
-	AutonomousExadataInfrastructureId *string `mandatory:"true" json:"autonomousExadataInfrastructureId"`
-
 	// Database Patch model preference.
 	PatchModel CreateAutonomousContainerDatabaseDetailsPatchModelEnum `mandatory:"true" json:"patchModel"`
 
+	// The `DB_UNIQUE_NAME` of the Oracle Database being backed up.
+	DbUniqueName *string `mandatory:"false" json:"dbUniqueName"`
+
 	// The service level agreement type of the Autonomous Container Database. The default is STANDARD. For a mission critical Autonomous Container Database, the specified Autonomous Exadata Infrastructure must be associated with a remote Autonomous Exadata Infrastructure.
 	ServiceLevelAgreementType CreateAutonomousContainerDatabaseDetailsServiceLevelAgreementTypeEnum `mandatory:"false" json:"serviceLevelAgreementType,omitempty"`
+
+	// The OCID of the Autonomous Exadata Infrastructure.
+	AutonomousExadataInfrastructureId *string `mandatory:"false" json:"autonomousExadataInfrastructureId"`
+
+	// The OCID of the Autonomous VM Cluster.
+	AutonomousVmClusterId *string `mandatory:"false" json:"autonomousVmClusterId"`
 
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment containing the Autonomous Container Database.
 	CompartmentId *string `mandatory:"false" json:"compartmentId"`

--- a/database/create_autonomous_vm_cluster_details.go
+++ b/database/create_autonomous_vm_cluster_details.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateAutonomousVmClusterDetails Details for the create Autonomous VM cluster operation.
+type CreateAutonomousVmClusterDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The user-friendly name for the Autonomous VM cluster. The name does not need to be unique.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+	ExadataInfrastructureId *string `mandatory:"true" json:"exadataInfrastructureId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster network.
+	VmClusterNetworkId *string `mandatory:"true" json:"vmClusterNetworkId"`
+
+	// The time zone to use for the Autonomous VM cluster. For details, see DB System Time Zones (https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
+	TimeZone *string `mandatory:"false" json:"timeZone"`
+
+	// If true, database backup on local Exadata storage is configured for the Autonomous VM cluster. If false, database backup on local Exadata storage is not available in the Autonomous VM cluster.
+	IsLocalBackupEnabled *bool `mandatory:"false" json:"isLocalBackupEnabled"`
+
+	// The Oracle license model that applies to the Autonomous VM cluster. The default is BRING_YOUR_OWN_LICENSE.
+	LicenseModel CreateAutonomousVmClusterDetailsLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m CreateAutonomousVmClusterDetails) String() string {
+	return common.PointerString(m)
+}
+
+// CreateAutonomousVmClusterDetailsLicenseModelEnum Enum with underlying type: string
+type CreateAutonomousVmClusterDetailsLicenseModelEnum string
+
+// Set of constants representing the allowable values for CreateAutonomousVmClusterDetailsLicenseModelEnum
+const (
+	CreateAutonomousVmClusterDetailsLicenseModelLicenseIncluded     CreateAutonomousVmClusterDetailsLicenseModelEnum = "LICENSE_INCLUDED"
+	CreateAutonomousVmClusterDetailsLicenseModelBringYourOwnLicense CreateAutonomousVmClusterDetailsLicenseModelEnum = "BRING_YOUR_OWN_LICENSE"
+)
+
+var mappingCreateAutonomousVmClusterDetailsLicenseModel = map[string]CreateAutonomousVmClusterDetailsLicenseModelEnum{
+	"LICENSE_INCLUDED":       CreateAutonomousVmClusterDetailsLicenseModelLicenseIncluded,
+	"BRING_YOUR_OWN_LICENSE": CreateAutonomousVmClusterDetailsLicenseModelBringYourOwnLicense,
+}
+
+// GetCreateAutonomousVmClusterDetailsLicenseModelEnumValues Enumerates the set of values for CreateAutonomousVmClusterDetailsLicenseModelEnum
+func GetCreateAutonomousVmClusterDetailsLicenseModelEnumValues() []CreateAutonomousVmClusterDetailsLicenseModelEnum {
+	values := make([]CreateAutonomousVmClusterDetailsLicenseModelEnum, 0)
+	for _, v := range mappingCreateAutonomousVmClusterDetailsLicenseModel {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/create_autonomous_vm_cluster_request_response.go
+++ b/database/create_autonomous_vm_cluster_request_response.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateAutonomousVmClusterRequest wrapper for the CreateAutonomousVmCluster operation
+type CreateAutonomousVmClusterRequest struct {
+
+	// Request to create an Autonomous VM cluster.
+	CreateAutonomousVmClusterDetails `contributesTo:"body"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateAutonomousVmClusterRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateAutonomousVmClusterRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateAutonomousVmClusterRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateAutonomousVmClusterResponse wrapper for the CreateAutonomousVmCluster operation
+type CreateAutonomousVmClusterResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The AutonomousVmCluster instance
+	AutonomousVmCluster `presentIn:"body"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request. Multiple OCID values are returned in a comma-separated list. Use GetWorkRequest with a work request OCID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateAutonomousVmClusterResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateAutonomousVmClusterResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/create_db_home_base.go
+++ b/database/create_db_home_base.go
@@ -20,12 +20,23 @@ type CreateDbHomeBase interface {
 
 	// The user-provided name of the Database Home.
 	GetDisplayName() *string
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	GetFreeformTags() map[string]string
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	GetDefinedTags() map[string]map[string]interface{}
 }
 
 type createdbhomebase struct {
-	JsonData    []byte
-	DisplayName *string `mandatory:"false" json:"displayName"`
-	Source      string  `json:"source"`
+	JsonData     []byte
+	DisplayName  *string                           `mandatory:"false" json:"displayName"`
+	FreeformTags map[string]string                 `mandatory:"false" json:"freeformTags"`
+	DefinedTags  map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+	Source       string                            `json:"source"`
 }
 
 // UnmarshalJSON unmarshals json
@@ -40,6 +51,8 @@ func (m *createdbhomebase) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	m.DisplayName = s.Model.DisplayName
+	m.FreeformTags = s.Model.FreeformTags
+	m.DefinedTags = s.Model.DefinedTags
 	m.Source = s.Model.Source
 
 	return err
@@ -78,6 +91,16 @@ func (m *createdbhomebase) UnmarshalPolymorphicJSON(data []byte) (interface{}, e
 //GetDisplayName returns DisplayName
 func (m createdbhomebase) GetDisplayName() *string {
 	return m.DisplayName
+}
+
+//GetFreeformTags returns FreeformTags
+func (m createdbhomebase) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m createdbhomebase) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
 }
 
 func (m createdbhomebase) String() string {

--- a/database/create_db_home_details.go
+++ b/database/create_db_home_details.go
@@ -24,6 +24,15 @@ type CreateDbHomeDetails struct {
 
 	// The user-provided name of the Database Home.
 	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 }
 
 func (m CreateDbHomeDetails) String() string {

--- a/database/create_db_home_from_backup_details.go
+++ b/database/create_db_home_from_backup_details.go
@@ -20,6 +20,15 @@ type CreateDbHomeFromBackupDetails struct {
 
 	// The user-provided name of the Database Home.
 	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 }
 
 func (m CreateDbHomeFromBackupDetails) String() string {

--- a/database/create_db_home_from_database_details.go
+++ b/database/create_db_home_from_database_details.go
@@ -20,6 +20,15 @@ type CreateDbHomeFromDatabaseDetails struct {
 
 	// The user-provided name of the Database Home.
 	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 }
 
 func (m CreateDbHomeFromDatabaseDetails) String() string {

--- a/database/create_db_home_with_db_system_id_details.go
+++ b/database/create_db_home_with_db_system_id_details.go
@@ -26,12 +26,31 @@ type CreateDbHomeWithDbSystemIdDetails struct {
 	// The user-provided name of the Database Home.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
 	Database *CreateDatabaseDetails `mandatory:"false" json:"database"`
 }
 
 //GetDisplayName returns DisplayName
 func (m CreateDbHomeWithDbSystemIdDetails) GetDisplayName() *string {
 	return m.DisplayName
+}
+
+//GetFreeformTags returns FreeformTags
+func (m CreateDbHomeWithDbSystemIdDetails) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m CreateDbHomeWithDbSystemIdDetails) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
 }
 
 func (m CreateDbHomeWithDbSystemIdDetails) String() string {

--- a/database/create_db_home_with_db_system_id_from_backup_details.go
+++ b/database/create_db_home_with_db_system_id_from_backup_details.go
@@ -24,11 +24,30 @@ type CreateDbHomeWithDbSystemIdFromBackupDetails struct {
 
 	// The user-provided name of the Database Home.
 	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 }
 
 //GetDisplayName returns DisplayName
 func (m CreateDbHomeWithDbSystemIdFromBackupDetails) GetDisplayName() *string {
 	return m.DisplayName
+}
+
+//GetFreeformTags returns FreeformTags
+func (m CreateDbHomeWithDbSystemIdFromBackupDetails) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m CreateDbHomeWithDbSystemIdFromBackupDetails) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
 }
 
 func (m CreateDbHomeWithDbSystemIdFromBackupDetails) String() string {

--- a/database/create_db_home_with_db_system_id_from_database_details.go
+++ b/database/create_db_home_with_db_system_id_from_database_details.go
@@ -24,11 +24,30 @@ type CreateDbHomeWithDbSystemIdFromDatabaseDetails struct {
 
 	// The user-provided name of the Database Home.
 	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 }
 
 //GetDisplayName returns DisplayName
 func (m CreateDbHomeWithDbSystemIdFromDatabaseDetails) GetDisplayName() *string {
 	return m.DisplayName
+}
+
+//GetFreeformTags returns FreeformTags
+func (m CreateDbHomeWithDbSystemIdFromDatabaseDetails) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m CreateDbHomeWithDbSystemIdFromDatabaseDetails) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
 }
 
 func (m CreateDbHomeWithDbSystemIdFromDatabaseDetails) String() string {

--- a/database/create_db_home_with_vm_cluster_id_details.go
+++ b/database/create_db_home_with_vm_cluster_id_details.go
@@ -26,12 +26,31 @@ type CreateDbHomeWithVmClusterIdDetails struct {
 	// The user-provided name of the Database Home.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
 	Database *CreateDatabaseDetails `mandatory:"false" json:"database"`
 }
 
 //GetDisplayName returns DisplayName
 func (m CreateDbHomeWithVmClusterIdDetails) GetDisplayName() *string {
 	return m.DisplayName
+}
+
+//GetFreeformTags returns FreeformTags
+func (m CreateDbHomeWithVmClusterIdDetails) GetFreeformTags() map[string]string {
+	return m.FreeformTags
+}
+
+//GetDefinedTags returns DefinedTags
+func (m CreateDbHomeWithVmClusterIdDetails) GetDefinedTags() map[string]map[string]interface{} {
+	return m.DefinedTags
 }
 
 func (m CreateDbHomeWithVmClusterIdDetails) String() string {

--- a/database/create_nfs_backup_destination_details.go
+++ b/database/create_nfs_backup_destination_details.go
@@ -23,9 +23,6 @@ type CreateNfsBackupDestinationDetails struct {
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" json:"compartmentId"`
 
-	// The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
-	LocalMountPointPath *string `mandatory:"true" json:"localMountPointPath"`
-
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
@@ -34,6 +31,12 @@ type CreateNfsBackupDestinationDetails struct {
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// **Deprecated.** The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
+	// This field is deprecated. Use the mountTypeDetails field instead to specify the mount type for NFS.
+	LocalMountPointPath *string `mandatory:"false" json:"localMountPointPath"`
+
+	MountTypeDetails MountTypeDetails `mandatory:"false" json:"mountTypeDetails"`
 }
 
 //GetDisplayName returns DisplayName
@@ -72,4 +75,42 @@ func (m CreateNfsBackupDestinationDetails) MarshalJSON() (buff []byte, e error) 
 	}
 
 	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *CreateNfsBackupDestinationDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		FreeformTags        map[string]string                 `json:"freeformTags"`
+		DefinedTags         map[string]map[string]interface{} `json:"definedTags"`
+		LocalMountPointPath *string                           `json:"localMountPointPath"`
+		MountTypeDetails    mounttypedetails                  `json:"mountTypeDetails"`
+		DisplayName         *string                           `json:"displayName"`
+		CompartmentId       *string                           `json:"compartmentId"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.LocalMountPointPath = model.LocalMountPointPath
+
+	nn, e = model.MountTypeDetails.UnmarshalPolymorphicJSON(model.MountTypeDetails.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.MountTypeDetails = nn.(MountTypeDetails)
+	} else {
+		m.MountTypeDetails = nil
+	}
+
+	m.DisplayName = model.DisplayName
+
+	m.CompartmentId = model.CompartmentId
+	return
 }

--- a/database/database_client.go
+++ b/database/database_client.go
@@ -289,6 +289,59 @@ func (client DatabaseClient) changeAutonomousExadataInfrastructureCompartment(ct
 	return response, err
 }
 
+// ChangeAutonomousVmClusterCompartment To move an Autonomous VM cluster and its dependent resources to another compartment, use the
+// ChangeAutonomousVmClusterCompartment operation.
+func (client DatabaseClient) ChangeAutonomousVmClusterCompartment(ctx context.Context, request ChangeAutonomousVmClusterCompartmentRequest) (response ChangeAutonomousVmClusterCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.changeAutonomousVmClusterCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ChangeAutonomousVmClusterCompartmentResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ChangeAutonomousVmClusterCompartmentResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeAutonomousVmClusterCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeAutonomousVmClusterCompartmentResponse")
+	}
+	return
+}
+
+// changeAutonomousVmClusterCompartment implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) changeAutonomousVmClusterCompartment(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/autonomousVmClusters/{autonomousVmClusterId}/actions/changeCompartment")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeAutonomousVmClusterCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // ChangeBackupDestinationCompartment Move the backup destination and its dependent resources to the specified compartment.
 // For more information about moving backup destinations, see
 // Moving Database Resources to a Different Compartment (https://docs.cloud.oracle.com/Content/Database/Concepts/databaseoverview.htm#moveRes).
@@ -804,6 +857,58 @@ func (client DatabaseClient) createAutonomousDatabaseBackup(ctx context.Context,
 	}
 
 	var response CreateAutonomousDatabaseBackupResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateAutonomousVmCluster Creates an Autonomous VM cluster.
+func (client DatabaseClient) CreateAutonomousVmCluster(ctx context.Context, request CreateAutonomousVmClusterRequest) (response CreateAutonomousVmClusterResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createAutonomousVmCluster, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateAutonomousVmClusterResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateAutonomousVmClusterResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateAutonomousVmClusterResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateAutonomousVmClusterResponse")
+	}
+	return
+}
+
+// createAutonomousVmCluster implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) createAutonomousVmCluster(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/autonomousVmClusters")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateAutonomousVmClusterResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -1490,6 +1595,53 @@ func (client DatabaseClient) deleteAutonomousDatabase(ctx context.Context, reque
 	}
 
 	var response DeleteAutonomousDatabaseResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteAutonomousVmCluster Deletes the specified Autonomous VM cluster.
+func (client DatabaseClient) DeleteAutonomousVmCluster(ctx context.Context, request DeleteAutonomousVmClusterRequest) (response DeleteAutonomousVmClusterResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteAutonomousVmCluster, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteAutonomousVmClusterResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteAutonomousVmClusterResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteAutonomousVmClusterResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteAutonomousVmClusterResponse")
+	}
+	return
+}
+
+// deleteAutonomousVmCluster implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) deleteAutonomousVmCluster(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/autonomousVmClusters/{autonomousVmClusterId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteAutonomousVmClusterResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -2597,6 +2749,53 @@ func (client DatabaseClient) getAutonomousExadataInfrastructure(ctx context.Cont
 	}
 
 	var response GetAutonomousExadataInfrastructureResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetAutonomousVmCluster Gets information about the specified Autonomous VM cluster.
+func (client DatabaseClient) GetAutonomousVmCluster(ctx context.Context, request GetAutonomousVmClusterRequest) (response GetAutonomousVmClusterResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getAutonomousVmCluster, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetAutonomousVmClusterResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetAutonomousVmClusterResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetAutonomousVmClusterResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetAutonomousVmClusterResponse")
+	}
+	return
+}
+
+// getAutonomousVmCluster implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) getAutonomousVmCluster(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/autonomousVmClusters/{autonomousVmClusterId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetAutonomousVmClusterResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -4119,6 +4318,53 @@ func (client DatabaseClient) listAutonomousExadataInfrastructures(ctx context.Co
 	}
 
 	var response ListAutonomousExadataInfrastructuresResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListAutonomousVmClusters Gets a list of Autonomous VM clusters in the specified compartment.
+func (client DatabaseClient) ListAutonomousVmClusters(ctx context.Context, request ListAutonomousVmClustersRequest) (response ListAutonomousVmClustersResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listAutonomousVmClusters, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListAutonomousVmClustersResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListAutonomousVmClustersResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListAutonomousVmClustersResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListAutonomousVmClustersResponse")
+	}
+	return
+}
+
+// listAutonomousVmClusters implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) listAutonomousVmClusters(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/autonomousVmClusters")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListAutonomousVmClustersResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -6095,6 +6341,53 @@ func (client DatabaseClient) updateAutonomousExadataInfrastructure(ctx context.C
 	}
 
 	var response UpdateAutonomousExadataInfrastructureResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateAutonomousVmCluster Updates the specified Autonomous VM cluster.
+func (client DatabaseClient) UpdateAutonomousVmCluster(ctx context.Context, request UpdateAutonomousVmClusterRequest) (response UpdateAutonomousVmClusterResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateAutonomousVmCluster, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateAutonomousVmClusterResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateAutonomousVmClusterResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateAutonomousVmClusterResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateAutonomousVmClusterResponse")
+	}
+	return
+}
+
+// updateAutonomousVmCluster implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) updateAutonomousVmCluster(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/autonomousVmClusters/{autonomousVmClusterId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateAutonomousVmClusterResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)

--- a/database/db_home.go
+++ b/database/db_home.go
@@ -48,6 +48,15 @@ type DbHome struct {
 
 	// The date and time the Database Home was created.
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 }
 
 func (m DbHome) String() string {

--- a/database/db_home_summary.go
+++ b/database/db_home_summary.go
@@ -54,6 +54,15 @@ type DbHomeSummary struct {
 
 	// The date and time the Database Home was created.
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 }
 
 func (m DbHomeSummary) String() string {

--- a/database/delete_autonomous_vm_cluster_request_response.go
+++ b/database/delete_autonomous_vm_cluster_request_response.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteAutonomousVmClusterRequest wrapper for the DeleteAutonomousVmCluster operation
+type DeleteAutonomousVmClusterRequest struct {
+
+	// The autonomous VM cluster OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	AutonomousVmClusterId *string `mandatory:"true" contributesTo:"path" name:"autonomousVmClusterId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteAutonomousVmClusterRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteAutonomousVmClusterRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteAutonomousVmClusterRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteAutonomousVmClusterResponse wrapper for the DeleteAutonomousVmCluster operation
+type DeleteAutonomousVmClusterResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request. Multiple OCID values are returned in a comma-separated list. Use GetWorkRequest with a work request OCID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteAutonomousVmClusterResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteAutonomousVmClusterResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/get_autonomous_vm_cluster_request_response.go
+++ b/database/get_autonomous_vm_cluster_request_response.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetAutonomousVmClusterRequest wrapper for the GetAutonomousVmCluster operation
+type GetAutonomousVmClusterRequest struct {
+
+	// The autonomous VM cluster OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	AutonomousVmClusterId *string `mandatory:"true" contributesTo:"path" name:"autonomousVmClusterId"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetAutonomousVmClusterRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetAutonomousVmClusterRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetAutonomousVmClusterRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetAutonomousVmClusterResponse wrapper for the GetAutonomousVmCluster operation
+type GetAutonomousVmClusterResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The AutonomousVmCluster instance
+	AutonomousVmCluster `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetAutonomousVmClusterResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetAutonomousVmClusterResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/list_autonomous_container_databases_request_response.go
+++ b/database/list_autonomous_container_databases_request_response.go
@@ -18,6 +18,12 @@ type ListAutonomousContainerDatabasesRequest struct {
 	// The Autonomous Exadata Infrastructure OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
 	AutonomousExadataInfrastructureId *string `mandatory:"false" contributesTo:"query" name:"autonomousExadataInfrastructureId"`
 
+	// The Autonomous VM Cluster OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	AutonomousVmClusterId *string `mandatory:"false" contributesTo:"query" name:"autonomousVmClusterId"`
+
+	// A filter to return only resources that match the given Infrastructure Type.
+	InfrastructureType AutonomousContainerDatabaseSummaryInfrastructureTypeEnum `mandatory:"false" contributesTo:"query" name:"infrastructureType" omitEmpty:"true"`
+
 	// The maximum number of items to return per page.
 	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
 

--- a/database/list_autonomous_databases_request_response.go
+++ b/database/list_autonomous_databases_request_response.go
@@ -31,6 +31,9 @@ type ListAutonomousDatabasesRequest struct {
 	// The sort order to use, either ascending (`ASC`) or descending (`DESC`).
 	SortOrder ListAutonomousDatabasesSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
 
+	// A filter to return only resources that match the given Infrastructure Type.
+	InfrastructureType AutonomousDatabaseSummaryInfrastructureTypeEnum `mandatory:"false" contributesTo:"query" name:"infrastructureType" omitEmpty:"true"`
+
 	// A filter to return only resources that match the given lifecycle state exactly.
 	LifecycleState AutonomousDatabaseSummaryLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 

--- a/database/list_autonomous_vm_clusters_request_response.go
+++ b/database/list_autonomous_vm_clusters_request_response.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListAutonomousVmClustersRequest wrapper for the ListAutonomousVmClusters operation
+type ListAutonomousVmClustersRequest struct {
+
+	// The compartment OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// If provided, filters the results for the given Exadata Infrastructure.
+	ExadataInfrastructureId *string `mandatory:"false" contributesTo:"query" name:"exadataInfrastructureId"`
+
+	// The maximum number of items to return per page.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The pagination token to continue listing from.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The field to sort by.  You can provide one sort order (`sortOrder`).  Default order for TIMECREATED is descending.  Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+	SortBy ListAutonomousVmClustersSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+	SortOrder ListAutonomousVmClustersSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// A filter to return only resources that match the given lifecycle state exactly.
+	LifecycleState AutonomousVmClusterSummaryLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+
+	// A filter to return only resources that match the entire display name given. The match is not case sensitive.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListAutonomousVmClustersRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListAutonomousVmClustersRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListAutonomousVmClustersRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListAutonomousVmClustersResponse wrapper for the ListAutonomousVmClusters operation
+type ListAutonomousVmClustersResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []AutonomousVmClusterSummary instances
+	Items []AutonomousVmClusterSummary `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then there are additional items still to get. Include this value as the `page` parameter for the
+	// subsequent GET request. For information about pagination, see
+	// List Pagination (https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListAutonomousVmClustersResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListAutonomousVmClustersResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListAutonomousVmClustersSortByEnum Enum with underlying type: string
+type ListAutonomousVmClustersSortByEnum string
+
+// Set of constants representing the allowable values for ListAutonomousVmClustersSortByEnum
+const (
+	ListAutonomousVmClustersSortByTimecreated ListAutonomousVmClustersSortByEnum = "TIMECREATED"
+	ListAutonomousVmClustersSortByDisplayname ListAutonomousVmClustersSortByEnum = "DISPLAYNAME"
+)
+
+var mappingListAutonomousVmClustersSortBy = map[string]ListAutonomousVmClustersSortByEnum{
+	"TIMECREATED": ListAutonomousVmClustersSortByTimecreated,
+	"DISPLAYNAME": ListAutonomousVmClustersSortByDisplayname,
+}
+
+// GetListAutonomousVmClustersSortByEnumValues Enumerates the set of values for ListAutonomousVmClustersSortByEnum
+func GetListAutonomousVmClustersSortByEnumValues() []ListAutonomousVmClustersSortByEnum {
+	values := make([]ListAutonomousVmClustersSortByEnum, 0)
+	for _, v := range mappingListAutonomousVmClustersSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListAutonomousVmClustersSortOrderEnum Enum with underlying type: string
+type ListAutonomousVmClustersSortOrderEnum string
+
+// Set of constants representing the allowable values for ListAutonomousVmClustersSortOrderEnum
+const (
+	ListAutonomousVmClustersSortOrderAsc  ListAutonomousVmClustersSortOrderEnum = "ASC"
+	ListAutonomousVmClustersSortOrderDesc ListAutonomousVmClustersSortOrderEnum = "DESC"
+)
+
+var mappingListAutonomousVmClustersSortOrder = map[string]ListAutonomousVmClustersSortOrderEnum{
+	"ASC":  ListAutonomousVmClustersSortOrderAsc,
+	"DESC": ListAutonomousVmClustersSortOrderDesc,
+}
+
+// GetListAutonomousVmClustersSortOrderEnumValues Enumerates the set of values for ListAutonomousVmClustersSortOrderEnum
+func GetListAutonomousVmClustersSortOrderEnumValues() []ListAutonomousVmClustersSortOrderEnum {
+	values := make([]ListAutonomousVmClustersSortOrderEnum, 0)
+	for _, v := range mappingListAutonomousVmClustersSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/mount_type_details.go
+++ b/database/mount_type_details.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// MountTypeDetails Mount type details for backup destination.
+type MountTypeDetails interface {
+}
+
+type mounttypedetails struct {
+	JsonData  []byte
+	MountType string `json:"mountType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *mounttypedetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalermounttypedetails mounttypedetails
+	s := struct {
+		Model Unmarshalermounttypedetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.MountType = s.Model.MountType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *mounttypedetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.MountType {
+	case "SELF_MOUNT":
+		mm := SelfMountDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "AUTOMATED_MOUNT":
+		mm := AutomatedMountDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m mounttypedetails) String() string {
+	return common.PointerString(m)
+}
+
+// MountTypeDetailsMountTypeEnum Enum with underlying type: string
+type MountTypeDetailsMountTypeEnum string
+
+// Set of constants representing the allowable values for MountTypeDetailsMountTypeEnum
+const (
+	MountTypeDetailsMountTypeSelfMount      MountTypeDetailsMountTypeEnum = "SELF_MOUNT"
+	MountTypeDetailsMountTypeAutomatedMount MountTypeDetailsMountTypeEnum = "AUTOMATED_MOUNT"
+)
+
+var mappingMountTypeDetailsMountType = map[string]MountTypeDetailsMountTypeEnum{
+	"SELF_MOUNT":      MountTypeDetailsMountTypeSelfMount,
+	"AUTOMATED_MOUNT": MountTypeDetailsMountTypeAutomatedMount,
+}
+
+// GetMountTypeDetailsMountTypeEnumValues Enumerates the set of values for MountTypeDetailsMountTypeEnum
+func GetMountTypeDetailsMountTypeEnumValues() []MountTypeDetailsMountTypeEnum {
+	values := make([]MountTypeDetailsMountTypeEnum, 0)
+	for _, v := range mappingMountTypeDetailsMountType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/self_mount_details.go
+++ b/database/self_mount_details.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// SelfMountDetails Used for creating NFS Self mount backup destinations for non-autonomous ExaCC.
+type SelfMountDetails struct {
+
+	// The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
+	LocalMountPointPath *string `mandatory:"true" json:"localMountPointPath"`
+}
+
+func (m SelfMountDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m SelfMountDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeSelfMountDetails SelfMountDetails
+	s := struct {
+		DiscriminatorParam string `json:"mountType"`
+		MarshalTypeSelfMountDetails
+	}{
+		"SELF_MOUNT",
+		(MarshalTypeSelfMountDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/database/update_autonomous_vm_cluster_details.go
+++ b/database/update_autonomous_vm_cluster_details.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateAutonomousVmClusterDetails Details for updating the Autonomous VM cluster.
+type UpdateAutonomousVmClusterDetails struct {
+
+	// The Oracle license model that applies to the Autonomous VM cluster. The default is BRING_YOUR_OWN_LICENSE.
+	LicenseModel UpdateAutonomousVmClusterDetailsLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m UpdateAutonomousVmClusterDetails) String() string {
+	return common.PointerString(m)
+}
+
+// UpdateAutonomousVmClusterDetailsLicenseModelEnum Enum with underlying type: string
+type UpdateAutonomousVmClusterDetailsLicenseModelEnum string
+
+// Set of constants representing the allowable values for UpdateAutonomousVmClusterDetailsLicenseModelEnum
+const (
+	UpdateAutonomousVmClusterDetailsLicenseModelLicenseIncluded     UpdateAutonomousVmClusterDetailsLicenseModelEnum = "LICENSE_INCLUDED"
+	UpdateAutonomousVmClusterDetailsLicenseModelBringYourOwnLicense UpdateAutonomousVmClusterDetailsLicenseModelEnum = "BRING_YOUR_OWN_LICENSE"
+)
+
+var mappingUpdateAutonomousVmClusterDetailsLicenseModel = map[string]UpdateAutonomousVmClusterDetailsLicenseModelEnum{
+	"LICENSE_INCLUDED":       UpdateAutonomousVmClusterDetailsLicenseModelLicenseIncluded,
+	"BRING_YOUR_OWN_LICENSE": UpdateAutonomousVmClusterDetailsLicenseModelBringYourOwnLicense,
+}
+
+// GetUpdateAutonomousVmClusterDetailsLicenseModelEnumValues Enumerates the set of values for UpdateAutonomousVmClusterDetailsLicenseModelEnum
+func GetUpdateAutonomousVmClusterDetailsLicenseModelEnumValues() []UpdateAutonomousVmClusterDetailsLicenseModelEnum {
+	values := make([]UpdateAutonomousVmClusterDetailsLicenseModelEnum, 0)
+	for _, v := range mappingUpdateAutonomousVmClusterDetailsLicenseModel {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/update_autonomous_vm_cluster_request_response.go
+++ b/database/update_autonomous_vm_cluster_request_response.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateAutonomousVmClusterRequest wrapper for the UpdateAutonomousVmCluster operation
+type UpdateAutonomousVmClusterRequest struct {
+
+	// The autonomous VM cluster OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	AutonomousVmClusterId *string `mandatory:"true" contributesTo:"path" name:"autonomousVmClusterId"`
+
+	// Request to update the attributes of an Autonomous VM cluster.
+	UpdateAutonomousVmClusterDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateAutonomousVmClusterRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateAutonomousVmClusterRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateAutonomousVmClusterRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateAutonomousVmClusterResponse wrapper for the UpdateAutonomousVmCluster operation
+type UpdateAutonomousVmClusterResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The AutonomousVmCluster instance
+	AutonomousVmCluster `presentIn:"body"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request. Multiple OCID values are returned in a comma-separated list. Use GetWorkRequest with a work request OCID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateAutonomousVmClusterResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateAutonomousVmClusterResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/update_backup_destination_details.go
+++ b/database/update_backup_destination_details.go
@@ -26,6 +26,15 @@ type UpdateBackupDestinationDetails struct {
 	// The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
 	LocalMountPointPath *string `mandatory:"false" json:"localMountPointPath"`
 
+	// NFS Mount type for backup destination.
+	NfsMountType UpdateBackupDestinationDetailsNfsMountTypeEnum `mandatory:"false" json:"nfsMountType,omitempty"`
+
+	// IP addresses for NFS Auto mount.
+	NfsServer []string `mandatory:"false" json:"nfsServer"`
+
+	// Specifies the directory on which to mount the file system
+	NfsServerExport *string `mandatory:"false" json:"nfsServerExport"`
+
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
@@ -38,4 +47,27 @@ type UpdateBackupDestinationDetails struct {
 
 func (m UpdateBackupDestinationDetails) String() string {
 	return common.PointerString(m)
+}
+
+// UpdateBackupDestinationDetailsNfsMountTypeEnum Enum with underlying type: string
+type UpdateBackupDestinationDetailsNfsMountTypeEnum string
+
+// Set of constants representing the allowable values for UpdateBackupDestinationDetailsNfsMountTypeEnum
+const (
+	UpdateBackupDestinationDetailsNfsMountTypeSelfMount      UpdateBackupDestinationDetailsNfsMountTypeEnum = "SELF_MOUNT"
+	UpdateBackupDestinationDetailsNfsMountTypeAutomatedMount UpdateBackupDestinationDetailsNfsMountTypeEnum = "AUTOMATED_MOUNT"
+)
+
+var mappingUpdateBackupDestinationDetailsNfsMountType = map[string]UpdateBackupDestinationDetailsNfsMountTypeEnum{
+	"SELF_MOUNT":      UpdateBackupDestinationDetailsNfsMountTypeSelfMount,
+	"AUTOMATED_MOUNT": UpdateBackupDestinationDetailsNfsMountTypeAutomatedMount,
+}
+
+// GetUpdateBackupDestinationDetailsNfsMountTypeEnumValues Enumerates the set of values for UpdateBackupDestinationDetailsNfsMountTypeEnum
+func GetUpdateBackupDestinationDetailsNfsMountTypeEnumValues() []UpdateBackupDestinationDetailsNfsMountTypeEnum {
+	values := make([]UpdateBackupDestinationDetailsNfsMountTypeEnum, 0)
+	for _, v := range mappingUpdateBackupDestinationDetailsNfsMountType {
+		values = append(values, v)
+	}
+	return values
 }

--- a/database/update_db_home_details.go
+++ b/database/update_db_home_details.go
@@ -16,6 +16,15 @@ import (
 // UpdateDbHomeDetails Describes the modification parameters for the Database Home.
 type UpdateDbHomeDetails struct {
 	DbVersion *PatchDetails `mandatory:"false" json:"dbVersion"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 }
 
 func (m UpdateDbHomeDetails) String() string {

--- a/datacatalog/attach_catalog_private_endpoint_details.go
+++ b/datacatalog/attach_catalog_private_endpoint_details.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Catalog API
+//
+// Use the Data Catalog APIs to collect, organize, find, access, understand, enrich, and activate technical, business, and operational metadata.
+//
+
+package datacatalog
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// AttachCatalogPrivateEndpointDetails Information about the attaching the private endpoint resource to a catalog
+type AttachCatalogPrivateEndpointDetails struct {
+
+	// The identifier of the private endpoint to be attached to the catalog resource.
+	CatalogPrivateEndpointId *string `mandatory:"true" json:"catalogPrivateEndpointId"`
+}
+
+func (m AttachCatalogPrivateEndpointDetails) String() string {
+	return common.PointerString(m)
+}

--- a/datacatalog/attach_catalog_private_endpoint_request_response.go
+++ b/datacatalog/attach_catalog_private_endpoint_request_response.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package datacatalog
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// AttachCatalogPrivateEndpointRequest wrapper for the AttachCatalogPrivateEndpoint operation
+type AttachCatalogPrivateEndpointRequest struct {
+
+	// Details for private reverse connection endpoint to be used for attachment.
+	AttachCatalogPrivateEndpointDetails `contributesTo:"body"`
+
+	// Unique catalog identifier.
+	CatalogId *string `mandatory:"true" contributesTo:"path" name:"catalogId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call
+	// for a resource, set the `if-match` parameter to the value of the
+	// etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you
+	// provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// might be rejected.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request AttachCatalogPrivateEndpointRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request AttachCatalogPrivateEndpointRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request AttachCatalogPrivateEndpointRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// AttachCatalogPrivateEndpointResponse wrapper for the AttachCatalogPrivateEndpoint operation
+type AttachCatalogPrivateEndpointResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the asynchronous request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest) with this OCID to track the status of the asynchronous request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response AttachCatalogPrivateEndpointResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response AttachCatalogPrivateEndpointResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/datacatalog/catalog.go
+++ b/datacatalog/catalog.go
@@ -55,6 +55,9 @@ type Catalog struct {
 	// Usage of predefined tag keys. These predefined keys are scoped to namespaces.
 	// Example: `{"foo-namespace": {"bar-key": "value"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// The list of private reverse connection endpoints attached to the catalog
+	AttachedCatalogPrivateEndpoints []string `mandatory:"false" json:"attachedCatalogPrivateEndpoints"`
 }
 
 func (m Catalog) String() string {

--- a/datacatalog/catalog_private_endpoint.go
+++ b/datacatalog/catalog_private_endpoint.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Catalog API
+//
+// Use the Data Catalog APIs to collect, organize, find, access, understand, enrich, and activate technical, business, and operational metadata.
+//
+
+package datacatalog
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CatalogPrivateEndpoint A private network reverse connection creates a connection from service to customer subnet over a private network.
+type CatalogPrivateEndpoint struct {
+
+	// Unique identifier that is immutable
+	Id *string `mandatory:"true" json:"id"`
+
+	// Compartment Identifier.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// Subnet Identifier
+	SubnetId *string `mandatory:"true" json:"subnetId"`
+
+	// List of DNS zones to be used by the data assets to be harvested.
+	// Example: custpvtsubnet.oraclevcn.com for data asset: db.custpvtsubnet.oraclevcn.com
+	DnsZones []string `mandatory:"true" json:"dnsZones"`
+
+	// Private Reverse Connection Endpoint display name
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// The time the private endpoint was created. An RFC3339 (https://tools.ietf.org/html/rfc3339) formatted datetime string.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The time the private endpoint was updated. An RFC3339 (https://tools.ietf.org/html/rfc3339) formatted datetime string.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// Simple key-value pair that is applied without any predefined name, type, or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// The current state of the private endpoint resource.
+	LifecycleState LifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// A message describing the current state in more detail. For example, can be used to provide actionable information for a resource in 'Failed' state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The list of catalogs using the private reverse connection endpoint
+	AttachedCatalogs []string `mandatory:"false" json:"attachedCatalogs"`
+}
+
+func (m CatalogPrivateEndpoint) String() string {
+	return common.PointerString(m)
+}

--- a/datacatalog/catalog_private_endpoint_summary.go
+++ b/datacatalog/catalog_private_endpoint_summary.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Catalog API
+//
+// Use the Data Catalog APIs to collect, organize, find, access, understand, enrich, and activate technical, business, and operational metadata.
+//
+
+package datacatalog
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CatalogPrivateEndpointSummary A private network reverse connection creates a connection from service to customer subnet over a private network.
+type CatalogPrivateEndpointSummary struct {
+
+	// Unique identifier that is immutable
+	Id *string `mandatory:"true" json:"id"`
+
+	// Subnet Identifier
+	SubnetId *string `mandatory:"true" json:"subnetId"`
+
+	// List of DNS zones to be used by the data assets to be harvested.
+	// Example: custpvtsubnet.oraclevcn.com for data asset: db.custpvtsubnet.oraclevcn.com
+	DnsZones []string `mandatory:"true" json:"dnsZones"`
+
+	// Identifier of the compartment this private endpoint belongs to
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The time the private endpoint was created. An RFC3339 (https://tools.ietf.org/html/rfc3339) formatted datetime string.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The time the private endpoint was updated. An RFC3339 (https://tools.ietf.org/html/rfc3339) formatted datetime string.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// Mutable name of the Private Reverse Connection Endpoint
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// A message describing the current state in more detail. For example, can be used to provide actionable information for a resource in 'Failed' state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// Simple key-value pair that is applied without any predefined name, type, or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// The current state of the private endpoint resource.
+	LifecycleState LifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// The list of catalogs using the private reverse connection endpoint
+	AttachedCatalogs []string `mandatory:"false" json:"attachedCatalogs"`
+}
+
+func (m CatalogPrivateEndpointSummary) String() string {
+	return common.PointerString(m)
+}

--- a/datacatalog/catalog_summary.go
+++ b/datacatalog/catalog_summary.go
@@ -47,6 +47,9 @@ type CatalogSummary struct {
 	// Usage of predefined tag keys. These predefined keys are scoped to namespaces.
 	// Example: `{"foo-namespace": {"bar-key": "value"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// The list of private reverse connection endpoints attached to the catalog
+	AttachedCatalogPrivateEndpoints []string `mandatory:"false" json:"attachedCatalogPrivateEndpoints"`
 }
 
 func (m CatalogSummary) String() string {

--- a/datacatalog/change_catalog_compartment_details.go
+++ b/datacatalog/change_catalog_compartment_details.go
@@ -13,7 +13,7 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// ChangeCatalogCompartmentDetails The representation of ChangeCatalogCompartmentDetails
+// ChangeCatalogCompartmentDetails Information about the change compartment
 type ChangeCatalogCompartmentDetails struct {
 
 	// The identifier of the compartment where the resource should be moved.

--- a/datacatalog/change_catalog_compartment_request_response.go
+++ b/datacatalog/change_catalog_compartment_request_response.go
@@ -53,13 +53,12 @@ type ChangeCatalogCompartmentResponse struct {
 	// The underlying http response
 	RawResponse *http.Response
 
-	// Unique Oracle-assigned identifier for the request. If
-	// you need to contact Oracle about a particular request,
-	// please provide the request ID.
-	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
-
-	// Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+	// The OCID of the asynchronous request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest) with this OCID to track the status of the asynchronous request.
 	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 }
 
 func (response ChangeCatalogCompartmentResponse) String() string {

--- a/datacatalog/change_catalog_private_endpoint_compartment_details.go
+++ b/datacatalog/change_catalog_private_endpoint_compartment_details.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Catalog API
+//
+// Use the Data Catalog APIs to collect, organize, find, access, understand, enrich, and activate technical, business, and operational metadata.
+//
+
+package datacatalog
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ChangeCatalogPrivateEndpointCompartmentDetails Information about the change compartment for the  private endpoint resource
+type ChangeCatalogPrivateEndpointCompartmentDetails struct {
+
+	// The identifier of the compartment where the resource should be moved.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+}
+
+func (m ChangeCatalogPrivateEndpointCompartmentDetails) String() string {
+	return common.PointerString(m)
+}

--- a/datacatalog/change_catalog_private_endpoint_compartment_request_response.go
+++ b/datacatalog/change_catalog_private_endpoint_compartment_request_response.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package datacatalog
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ChangeCatalogPrivateEndpointCompartmentRequest wrapper for the ChangeCatalogPrivateEndpointCompartment operation
+type ChangeCatalogPrivateEndpointCompartmentRequest struct {
+
+	// Details for the target compartment.
+	ChangeCatalogPrivateEndpointCompartmentDetails `contributesTo:"body"`
+
+	// Unique private reverse connection identifier.
+	CatalogPrivateEndpointId *string `mandatory:"true" contributesTo:"path" name:"catalogPrivateEndpointId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call
+	// for a resource, set the `if-match` parameter to the value of the
+	// etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you
+	// provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ChangeCatalogPrivateEndpointCompartmentRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ChangeCatalogPrivateEndpointCompartmentRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ChangeCatalogPrivateEndpointCompartmentRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ChangeCatalogPrivateEndpointCompartmentResponse wrapper for the ChangeCatalogPrivateEndpointCompartment operation
+type ChangeCatalogPrivateEndpointCompartmentResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the asynchronous request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest) with this OCID to track the status of the asynchronous request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ChangeCatalogPrivateEndpointCompartmentResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ChangeCatalogPrivateEndpointCompartmentResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/datacatalog/create_catalog_private_endpoint_details.go
+++ b/datacatalog/create_catalog_private_endpoint_details.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Catalog API
+//
+// Use the Data Catalog APIs to collect, organize, find, access, understand, enrich, and activate technical, business, and operational metadata.
+//
+
+package datacatalog
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateCatalogPrivateEndpointDetails Information about the new private endpoint resource
+type CreateCatalogPrivateEndpointDetails struct {
+
+	// List of DNS zones to be used by the data assets to be harvested.
+	// Example: custpvtsubnet.oraclevcn.com for data asset: db.custpvtsubnet.oraclevcn.com
+	DnsZones []string `mandatory:"true" json:"dnsZones"`
+
+	// The OCID of subnet to which the reverse connection is to be created
+	SubnetId *string `mandatory:"true" json:"subnetId"`
+
+	// Compartment identifier.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// Simple key-value pair that is applied without any predefined name, type, or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Display name of the private endpoint resource being created.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+}
+
+func (m CreateCatalogPrivateEndpointDetails) String() string {
+	return common.PointerString(m)
+}

--- a/datacatalog/create_catalog_private_endpoint_request_response.go
+++ b/datacatalog/create_catalog_private_endpoint_request_response.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package datacatalog
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateCatalogPrivateEndpointRequest wrapper for the CreateCatalogPrivateEndpoint operation
+type CreateCatalogPrivateEndpointRequest struct {
+
+	// The information used to create the private reverse connection.
+	CreateCatalogPrivateEndpointDetails `contributesTo:"body"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// might be rejected.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateCatalogPrivateEndpointRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateCatalogPrivateEndpointRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateCatalogPrivateEndpointRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateCatalogPrivateEndpointResponse wrapper for the CreateCatalogPrivateEndpoint operation
+type CreateCatalogPrivateEndpointResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// The OCID of the asynchronous request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest) with this OCID to track the status of the asynchronous request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+}
+
+func (response CreateCatalogPrivateEndpointResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateCatalogPrivateEndpointResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/datacatalog/datacatalog_client.go
+++ b/datacatalog/datacatalog_client.go
@@ -75,6 +75,58 @@ func (client *DataCatalogClient) ConfigurationProvider() *common.ConfigurationPr
 	return client.config
 }
 
+// AttachCatalogPrivateEndpoint Attaches a private reverse connection endpoint resource to a data catalog resource. When provided, 'If-Match' is checked against 'ETag' values of the resource.
+func (client DataCatalogClient) AttachCatalogPrivateEndpoint(ctx context.Context, request AttachCatalogPrivateEndpointRequest) (response AttachCatalogPrivateEndpointResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.attachCatalogPrivateEndpoint, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = AttachCatalogPrivateEndpointResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = AttachCatalogPrivateEndpointResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(AttachCatalogPrivateEndpointResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into AttachCatalogPrivateEndpointResponse")
+	}
+	return
+}
+
+// attachCatalogPrivateEndpoint implements the OCIOperation interface (enables retrying operations)
+func (client DataCatalogClient) attachCatalogPrivateEndpoint(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/catalogs/{catalogId}/actions/attachCatalogPrivateEndpoint")
+	if err != nil {
+		return nil, err
+	}
+
+	var response AttachCatalogPrivateEndpointResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // ChangeCatalogCompartment Moves a resource into a different compartment. When provided, 'If-Match' is checked against 'ETag' values of the resource.
 func (client DataCatalogClient) ChangeCatalogCompartment(ctx context.Context, request ChangeCatalogCompartmentRequest) (response ChangeCatalogCompartmentResponse, err error) {
 	var ociResponse common.OCIResponse
@@ -110,6 +162,53 @@ func (client DataCatalogClient) changeCatalogCompartment(ctx context.Context, re
 	}
 
 	var response ChangeCatalogCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ChangeCatalogPrivateEndpointCompartment Moves a resource into a different compartment. When provided, 'If-Match' is checked against 'ETag' values of the resource.
+func (client DataCatalogClient) ChangeCatalogPrivateEndpointCompartment(ctx context.Context, request ChangeCatalogPrivateEndpointCompartmentRequest) (response ChangeCatalogPrivateEndpointCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.changeCatalogPrivateEndpointCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ChangeCatalogPrivateEndpointCompartmentResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ChangeCatalogPrivateEndpointCompartmentResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeCatalogPrivateEndpointCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeCatalogPrivateEndpointCompartmentResponse")
+	}
+	return
+}
+
+// changeCatalogPrivateEndpointCompartment implements the OCIOperation interface (enables retrying operations)
+func (client DataCatalogClient) changeCatalogPrivateEndpointCompartment(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/catalogPrivateEndpoints/{catalogPrivateEndpointId}/actions/changeCompartment")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeCatalogPrivateEndpointCompartmentResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -267,6 +366,58 @@ func (client DataCatalogClient) createCatalog(ctx context.Context, request commo
 	}
 
 	var response CreateCatalogResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateCatalogPrivateEndpoint Create a new private reverse connection endpoint.
+func (client DataCatalogClient) CreateCatalogPrivateEndpoint(ctx context.Context, request CreateCatalogPrivateEndpointRequest) (response CreateCatalogPrivateEndpointResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createCatalogPrivateEndpoint, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateCatalogPrivateEndpointResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateCatalogPrivateEndpointResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateCatalogPrivateEndpointResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateCatalogPrivateEndpointResponse")
+	}
+	return
+}
+
+// createCatalogPrivateEndpoint implements the OCIOperation interface (enables retrying operations)
+func (client DataCatalogClient) createCatalogPrivateEndpoint(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/catalogPrivateEndpoints")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateCatalogPrivateEndpointResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -1096,6 +1247,53 @@ func (client DataCatalogClient) deleteCatalog(ctx context.Context, request commo
 	return response, err
 }
 
+// DeleteCatalogPrivateEndpoint Deletes a private reverse connection endpoint by identifier.
+func (client DataCatalogClient) DeleteCatalogPrivateEndpoint(ctx context.Context, request DeleteCatalogPrivateEndpointRequest) (response DeleteCatalogPrivateEndpointResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteCatalogPrivateEndpoint, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteCatalogPrivateEndpointResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteCatalogPrivateEndpointResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteCatalogPrivateEndpointResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteCatalogPrivateEndpointResponse")
+	}
+	return
+}
+
+// deleteCatalogPrivateEndpoint implements the OCIOperation interface (enables retrying operations)
+func (client DataCatalogClient) deleteCatalogPrivateEndpoint(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/catalogPrivateEndpoints/{catalogPrivateEndpointId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteCatalogPrivateEndpointResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // DeleteConnection Deletes a specific connection of a data asset.
 func (client DataCatalogClient) DeleteConnection(ctx context.Context, request DeleteConnectionRequest) (response DeleteConnectionResponse, err error) {
 	var ociResponse common.OCIResponse
@@ -1660,6 +1858,53 @@ func (client DataCatalogClient) deleteTermRelationship(ctx context.Context, requ
 	return response, err
 }
 
+// DetachCatalogPrivateEndpoint Detaches a private reverse connection endpoint resource to a data catalog resource. When provided, 'If-Match' is checked against 'ETag' values of the resource.
+func (client DataCatalogClient) DetachCatalogPrivateEndpoint(ctx context.Context, request DetachCatalogPrivateEndpointRequest) (response DetachCatalogPrivateEndpointResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.detachCatalogPrivateEndpoint, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DetachCatalogPrivateEndpointResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DetachCatalogPrivateEndpointResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DetachCatalogPrivateEndpointResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DetachCatalogPrivateEndpointResponse")
+	}
+	return
+}
+
+// detachCatalogPrivateEndpoint implements the OCIOperation interface (enables retrying operations)
+func (client DataCatalogClient) detachCatalogPrivateEndpoint(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/catalogs/{catalogId}/actions/detachCatalogPrivateEndpoint")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DetachCatalogPrivateEndpointResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // ExpandTreeForGlossary Returns the fully expanded tree hierarchy of parent and child terms in this glossary.
 func (client DataCatalogClient) ExpandTreeForGlossary(ctx context.Context, request ExpandTreeForGlossaryRequest) (response ExpandTreeForGlossaryResponse, err error) {
 	var ociResponse common.OCIResponse
@@ -1893,6 +2138,53 @@ func (client DataCatalogClient) getCatalog(ctx context.Context, request common.O
 	}
 
 	var response GetCatalogResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetCatalogPrivateEndpoint Gets a specific private reverse connection by identifier.
+func (client DataCatalogClient) GetCatalogPrivateEndpoint(ctx context.Context, request GetCatalogPrivateEndpointRequest) (response GetCatalogPrivateEndpointResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getCatalogPrivateEndpoint, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetCatalogPrivateEndpointResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetCatalogPrivateEndpointResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetCatalogPrivateEndpointResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetCatalogPrivateEndpointResponse")
+	}
+	return
+}
+
+// getCatalogPrivateEndpoint implements the OCIOperation interface (enables retrying operations)
+func (client DataCatalogClient) getCatalogPrivateEndpoint(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/catalogPrivateEndpoints/{catalogPrivateEndpointId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetCatalogPrivateEndpointResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -2890,6 +3182,53 @@ func (client DataCatalogClient) listAttributes(ctx context.Context, request comm
 	}
 
 	var response ListAttributesResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListCatalogPrivateEndpoints Returns a list of all the catalog private endpoints in the specified compartment.
+func (client DataCatalogClient) ListCatalogPrivateEndpoints(ctx context.Context, request ListCatalogPrivateEndpointsRequest) (response ListCatalogPrivateEndpointsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listCatalogPrivateEndpoints, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListCatalogPrivateEndpointsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListCatalogPrivateEndpointsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListCatalogPrivateEndpointsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListCatalogPrivateEndpointsResponse")
+	}
+	return
+}
+
+// listCatalogPrivateEndpoints implements the OCIOperation interface (enables retrying operations)
+func (client DataCatalogClient) listCatalogPrivateEndpoints(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/catalogPrivateEndpoints")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListCatalogPrivateEndpointsResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -4169,6 +4508,53 @@ func (client DataCatalogClient) updateCatalog(ctx context.Context, request commo
 	}
 
 	var response UpdateCatalogResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateCatalogPrivateEndpoint Updates the private reverse connection endpoint.
+func (client DataCatalogClient) UpdateCatalogPrivateEndpoint(ctx context.Context, request UpdateCatalogPrivateEndpointRequest) (response UpdateCatalogPrivateEndpointResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateCatalogPrivateEndpoint, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateCatalogPrivateEndpointResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateCatalogPrivateEndpointResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateCatalogPrivateEndpointResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateCatalogPrivateEndpointResponse")
+	}
+	return
+}
+
+// updateCatalogPrivateEndpoint implements the OCIOperation interface (enables retrying operations)
+func (client DataCatalogClient) updateCatalogPrivateEndpoint(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/catalogPrivateEndpoints/{catalogPrivateEndpointId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateCatalogPrivateEndpointResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)

--- a/datacatalog/delete_catalog_private_endpoint_request_response.go
+++ b/datacatalog/delete_catalog_private_endpoint_request_response.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package datacatalog
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteCatalogPrivateEndpointRequest wrapper for the DeleteCatalogPrivateEndpoint operation
+type DeleteCatalogPrivateEndpointRequest struct {
+
+	// Unique private reverse connection identifier.
+	CatalogPrivateEndpointId *string `mandatory:"true" contributesTo:"path" name:"catalogPrivateEndpointId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call
+	// for a resource, set the `if-match` parameter to the value of the
+	// etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you
+	// provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteCatalogPrivateEndpointRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteCatalogPrivateEndpointRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteCatalogPrivateEndpointRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteCatalogPrivateEndpointResponse wrapper for the DeleteCatalogPrivateEndpoint operation
+type DeleteCatalogPrivateEndpointResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the asynchronous request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest) with this OCID to track the status of the asynchronous request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteCatalogPrivateEndpointResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteCatalogPrivateEndpointResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/datacatalog/detach_catalog_private_endpoint_details.go
+++ b/datacatalog/detach_catalog_private_endpoint_details.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Catalog API
+//
+// Use the Data Catalog APIs to collect, organize, find, access, understand, enrich, and activate technical, business, and operational metadata.
+//
+
+package datacatalog
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DetachCatalogPrivateEndpointDetails Information about the detaching the private endpoint resource from a catalog
+type DetachCatalogPrivateEndpointDetails struct {
+
+	// The identifier of the private endpoint to be detached from catalog resource.
+	CatalogPrivateEndpointId *string `mandatory:"true" json:"catalogPrivateEndpointId"`
+}
+
+func (m DetachCatalogPrivateEndpointDetails) String() string {
+	return common.PointerString(m)
+}

--- a/datacatalog/detach_catalog_private_endpoint_request_response.go
+++ b/datacatalog/detach_catalog_private_endpoint_request_response.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package datacatalog
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DetachCatalogPrivateEndpointRequest wrapper for the DetachCatalogPrivateEndpoint operation
+type DetachCatalogPrivateEndpointRequest struct {
+
+	// Details for private reverse connection endpoint to be used for attachment
+	DetachCatalogPrivateEndpointDetails `contributesTo:"body"`
+
+	// Unique catalog identifier.
+	CatalogId *string `mandatory:"true" contributesTo:"path" name:"catalogId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call
+	// for a resource, set the `if-match` parameter to the value of the
+	// etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you
+	// provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DetachCatalogPrivateEndpointRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DetachCatalogPrivateEndpointRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DetachCatalogPrivateEndpointRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DetachCatalogPrivateEndpointResponse wrapper for the DetachCatalogPrivateEndpoint operation
+type DetachCatalogPrivateEndpointResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the asynchronous request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest) with this OCID to track the status of the asynchronous request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DetachCatalogPrivateEndpointResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DetachCatalogPrivateEndpointResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/datacatalog/get_catalog_private_endpoint_request_response.go
+++ b/datacatalog/get_catalog_private_endpoint_request_response.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package datacatalog
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetCatalogPrivateEndpointRequest wrapper for the GetCatalogPrivateEndpoint operation
+type GetCatalogPrivateEndpointRequest struct {
+
+	// Unique private reverse connection identifier.
+	CatalogPrivateEndpointId *string `mandatory:"true" contributesTo:"path" name:"catalogPrivateEndpointId"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetCatalogPrivateEndpointRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetCatalogPrivateEndpointRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetCatalogPrivateEndpointRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetCatalogPrivateEndpointResponse wrapper for the GetCatalogPrivateEndpoint operation
+type GetCatalogPrivateEndpointResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The CatalogPrivateEndpoint instance
+	CatalogPrivateEndpoint `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+}
+
+func (response GetCatalogPrivateEndpointResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetCatalogPrivateEndpointResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/datacatalog/list_attribute_tags_request_response.go
+++ b/datacatalog/list_attribute_tags_request_response.go
@@ -28,7 +28,7 @@ type ListAttributeTagsRequest struct {
 	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
 
 	// A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
-	LifecycleState LifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState ListAttributeTagsLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// Unique key of the related term.
 	TermKey *string `mandatory:"false" contributesTo:"query" name:"termKey"`
@@ -103,6 +103,41 @@ func (response ListAttributeTagsResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response ListAttributeTagsResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// ListAttributeTagsLifecycleStateEnum Enum with underlying type: string
+type ListAttributeTagsLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListAttributeTagsLifecycleStateEnum
+const (
+	ListAttributeTagsLifecycleStateCreating ListAttributeTagsLifecycleStateEnum = "CREATING"
+	ListAttributeTagsLifecycleStateActive   ListAttributeTagsLifecycleStateEnum = "ACTIVE"
+	ListAttributeTagsLifecycleStateInactive ListAttributeTagsLifecycleStateEnum = "INACTIVE"
+	ListAttributeTagsLifecycleStateUpdating ListAttributeTagsLifecycleStateEnum = "UPDATING"
+	ListAttributeTagsLifecycleStateDeleting ListAttributeTagsLifecycleStateEnum = "DELETING"
+	ListAttributeTagsLifecycleStateDeleted  ListAttributeTagsLifecycleStateEnum = "DELETED"
+	ListAttributeTagsLifecycleStateFailed   ListAttributeTagsLifecycleStateEnum = "FAILED"
+	ListAttributeTagsLifecycleStateMoving   ListAttributeTagsLifecycleStateEnum = "MOVING"
+)
+
+var mappingListAttributeTagsLifecycleState = map[string]ListAttributeTagsLifecycleStateEnum{
+	"CREATING": ListAttributeTagsLifecycleStateCreating,
+	"ACTIVE":   ListAttributeTagsLifecycleStateActive,
+	"INACTIVE": ListAttributeTagsLifecycleStateInactive,
+	"UPDATING": ListAttributeTagsLifecycleStateUpdating,
+	"DELETING": ListAttributeTagsLifecycleStateDeleting,
+	"DELETED":  ListAttributeTagsLifecycleStateDeleted,
+	"FAILED":   ListAttributeTagsLifecycleStateFailed,
+	"MOVING":   ListAttributeTagsLifecycleStateMoving,
+}
+
+// GetListAttributeTagsLifecycleStateEnumValues Enumerates the set of values for ListAttributeTagsLifecycleStateEnum
+func GetListAttributeTagsLifecycleStateEnumValues() []ListAttributeTagsLifecycleStateEnum {
+	values := make([]ListAttributeTagsLifecycleStateEnum, 0)
+	for _, v := range mappingListAttributeTagsLifecycleState {
+		values = append(values, v)
+	}
+	return values
 }
 
 // ListAttributeTagsFieldsEnum Enum with underlying type: string

--- a/datacatalog/list_attributes_request_response.go
+++ b/datacatalog/list_attributes_request_response.go
@@ -25,7 +25,7 @@ type ListAttributesRequest struct {
 	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
 
 	// A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
-	LifecycleState LifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState ListAttributesLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// Time that the resource was created. An RFC3339 (https://tools.ietf.org/html/rfc3339) formatted datetime string.
 	TimeCreated *common.SDKTime `mandatory:"false" contributesTo:"query" name:"timeCreated"`
@@ -127,6 +127,41 @@ func (response ListAttributesResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response ListAttributesResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// ListAttributesLifecycleStateEnum Enum with underlying type: string
+type ListAttributesLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListAttributesLifecycleStateEnum
+const (
+	ListAttributesLifecycleStateCreating ListAttributesLifecycleStateEnum = "CREATING"
+	ListAttributesLifecycleStateActive   ListAttributesLifecycleStateEnum = "ACTIVE"
+	ListAttributesLifecycleStateInactive ListAttributesLifecycleStateEnum = "INACTIVE"
+	ListAttributesLifecycleStateUpdating ListAttributesLifecycleStateEnum = "UPDATING"
+	ListAttributesLifecycleStateDeleting ListAttributesLifecycleStateEnum = "DELETING"
+	ListAttributesLifecycleStateDeleted  ListAttributesLifecycleStateEnum = "DELETED"
+	ListAttributesLifecycleStateFailed   ListAttributesLifecycleStateEnum = "FAILED"
+	ListAttributesLifecycleStateMoving   ListAttributesLifecycleStateEnum = "MOVING"
+)
+
+var mappingListAttributesLifecycleState = map[string]ListAttributesLifecycleStateEnum{
+	"CREATING": ListAttributesLifecycleStateCreating,
+	"ACTIVE":   ListAttributesLifecycleStateActive,
+	"INACTIVE": ListAttributesLifecycleStateInactive,
+	"UPDATING": ListAttributesLifecycleStateUpdating,
+	"DELETING": ListAttributesLifecycleStateDeleting,
+	"DELETED":  ListAttributesLifecycleStateDeleted,
+	"FAILED":   ListAttributesLifecycleStateFailed,
+	"MOVING":   ListAttributesLifecycleStateMoving,
+}
+
+// GetListAttributesLifecycleStateEnumValues Enumerates the set of values for ListAttributesLifecycleStateEnum
+func GetListAttributesLifecycleStateEnumValues() []ListAttributesLifecycleStateEnum {
+	values := make([]ListAttributesLifecycleStateEnum, 0)
+	for _, v := range mappingListAttributesLifecycleState {
+		values = append(values, v)
+	}
+	return values
 }
 
 // ListAttributesFieldsEnum Enum with underlying type: string

--- a/datacatalog/list_catalog_private_endpoints_request_response.go
+++ b/datacatalog/list_catalog_private_endpoints_request_response.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package datacatalog
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListCatalogPrivateEndpointsRequest wrapper for the ListCatalogPrivateEndpoints operation
+type ListCatalogPrivateEndpointsRequest struct {
+
+	// The OCID of the compartment where you want to list resources.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// A filter to return only resources that match the entire display name given. The match is not case sensitive.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
+	LifecycleState ListCatalogPrivateEndpointsLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+
+	// The sort order to use, either 'asc' or 'desc'.
+	SortOrder ListCatalogPrivateEndpointsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+	SortBy ListCatalogPrivateEndpointsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListCatalogPrivateEndpointsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListCatalogPrivateEndpointsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListCatalogPrivateEndpointsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListCatalogPrivateEndpointsResponse wrapper for the ListCatalogPrivateEndpoints operation
+type ListCatalogPrivateEndpointsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []CatalogPrivateEndpointSummary instances
+	Items []CatalogPrivateEndpointSummary `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListCatalogPrivateEndpointsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListCatalogPrivateEndpointsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListCatalogPrivateEndpointsLifecycleStateEnum Enum with underlying type: string
+type ListCatalogPrivateEndpointsLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListCatalogPrivateEndpointsLifecycleStateEnum
+const (
+	ListCatalogPrivateEndpointsLifecycleStateCreating ListCatalogPrivateEndpointsLifecycleStateEnum = "CREATING"
+	ListCatalogPrivateEndpointsLifecycleStateActive   ListCatalogPrivateEndpointsLifecycleStateEnum = "ACTIVE"
+	ListCatalogPrivateEndpointsLifecycleStateInactive ListCatalogPrivateEndpointsLifecycleStateEnum = "INACTIVE"
+	ListCatalogPrivateEndpointsLifecycleStateUpdating ListCatalogPrivateEndpointsLifecycleStateEnum = "UPDATING"
+	ListCatalogPrivateEndpointsLifecycleStateDeleting ListCatalogPrivateEndpointsLifecycleStateEnum = "DELETING"
+	ListCatalogPrivateEndpointsLifecycleStateDeleted  ListCatalogPrivateEndpointsLifecycleStateEnum = "DELETED"
+	ListCatalogPrivateEndpointsLifecycleStateFailed   ListCatalogPrivateEndpointsLifecycleStateEnum = "FAILED"
+	ListCatalogPrivateEndpointsLifecycleStateMoving   ListCatalogPrivateEndpointsLifecycleStateEnum = "MOVING"
+)
+
+var mappingListCatalogPrivateEndpointsLifecycleState = map[string]ListCatalogPrivateEndpointsLifecycleStateEnum{
+	"CREATING": ListCatalogPrivateEndpointsLifecycleStateCreating,
+	"ACTIVE":   ListCatalogPrivateEndpointsLifecycleStateActive,
+	"INACTIVE": ListCatalogPrivateEndpointsLifecycleStateInactive,
+	"UPDATING": ListCatalogPrivateEndpointsLifecycleStateUpdating,
+	"DELETING": ListCatalogPrivateEndpointsLifecycleStateDeleting,
+	"DELETED":  ListCatalogPrivateEndpointsLifecycleStateDeleted,
+	"FAILED":   ListCatalogPrivateEndpointsLifecycleStateFailed,
+	"MOVING":   ListCatalogPrivateEndpointsLifecycleStateMoving,
+}
+
+// GetListCatalogPrivateEndpointsLifecycleStateEnumValues Enumerates the set of values for ListCatalogPrivateEndpointsLifecycleStateEnum
+func GetListCatalogPrivateEndpointsLifecycleStateEnumValues() []ListCatalogPrivateEndpointsLifecycleStateEnum {
+	values := make([]ListCatalogPrivateEndpointsLifecycleStateEnum, 0)
+	for _, v := range mappingListCatalogPrivateEndpointsLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListCatalogPrivateEndpointsSortOrderEnum Enum with underlying type: string
+type ListCatalogPrivateEndpointsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListCatalogPrivateEndpointsSortOrderEnum
+const (
+	ListCatalogPrivateEndpointsSortOrderAsc  ListCatalogPrivateEndpointsSortOrderEnum = "ASC"
+	ListCatalogPrivateEndpointsSortOrderDesc ListCatalogPrivateEndpointsSortOrderEnum = "DESC"
+)
+
+var mappingListCatalogPrivateEndpointsSortOrder = map[string]ListCatalogPrivateEndpointsSortOrderEnum{
+	"ASC":  ListCatalogPrivateEndpointsSortOrderAsc,
+	"DESC": ListCatalogPrivateEndpointsSortOrderDesc,
+}
+
+// GetListCatalogPrivateEndpointsSortOrderEnumValues Enumerates the set of values for ListCatalogPrivateEndpointsSortOrderEnum
+func GetListCatalogPrivateEndpointsSortOrderEnumValues() []ListCatalogPrivateEndpointsSortOrderEnum {
+	values := make([]ListCatalogPrivateEndpointsSortOrderEnum, 0)
+	for _, v := range mappingListCatalogPrivateEndpointsSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListCatalogPrivateEndpointsSortByEnum Enum with underlying type: string
+type ListCatalogPrivateEndpointsSortByEnum string
+
+// Set of constants representing the allowable values for ListCatalogPrivateEndpointsSortByEnum
+const (
+	ListCatalogPrivateEndpointsSortByTimecreated ListCatalogPrivateEndpointsSortByEnum = "TIMECREATED"
+	ListCatalogPrivateEndpointsSortByDisplayname ListCatalogPrivateEndpointsSortByEnum = "DISPLAYNAME"
+)
+
+var mappingListCatalogPrivateEndpointsSortBy = map[string]ListCatalogPrivateEndpointsSortByEnum{
+	"TIMECREATED": ListCatalogPrivateEndpointsSortByTimecreated,
+	"DISPLAYNAME": ListCatalogPrivateEndpointsSortByDisplayname,
+}
+
+// GetListCatalogPrivateEndpointsSortByEnumValues Enumerates the set of values for ListCatalogPrivateEndpointsSortByEnum
+func GetListCatalogPrivateEndpointsSortByEnumValues() []ListCatalogPrivateEndpointsSortByEnum {
+	values := make([]ListCatalogPrivateEndpointsSortByEnum, 0)
+	for _, v := range mappingListCatalogPrivateEndpointsSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/datacatalog/list_catalogs_request_response.go
+++ b/datacatalog/list_catalogs_request_response.go
@@ -25,7 +25,7 @@ type ListCatalogsRequest struct {
 	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
 
 	// A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
-	LifecycleState LifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState ListCatalogsLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// The sort order to use, either 'asc' or 'desc'.
 	SortOrder ListCatalogsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
@@ -79,6 +79,41 @@ func (response ListCatalogsResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response ListCatalogsResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// ListCatalogsLifecycleStateEnum Enum with underlying type: string
+type ListCatalogsLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListCatalogsLifecycleStateEnum
+const (
+	ListCatalogsLifecycleStateCreating ListCatalogsLifecycleStateEnum = "CREATING"
+	ListCatalogsLifecycleStateActive   ListCatalogsLifecycleStateEnum = "ACTIVE"
+	ListCatalogsLifecycleStateInactive ListCatalogsLifecycleStateEnum = "INACTIVE"
+	ListCatalogsLifecycleStateUpdating ListCatalogsLifecycleStateEnum = "UPDATING"
+	ListCatalogsLifecycleStateDeleting ListCatalogsLifecycleStateEnum = "DELETING"
+	ListCatalogsLifecycleStateDeleted  ListCatalogsLifecycleStateEnum = "DELETED"
+	ListCatalogsLifecycleStateFailed   ListCatalogsLifecycleStateEnum = "FAILED"
+	ListCatalogsLifecycleStateMoving   ListCatalogsLifecycleStateEnum = "MOVING"
+)
+
+var mappingListCatalogsLifecycleState = map[string]ListCatalogsLifecycleStateEnum{
+	"CREATING": ListCatalogsLifecycleStateCreating,
+	"ACTIVE":   ListCatalogsLifecycleStateActive,
+	"INACTIVE": ListCatalogsLifecycleStateInactive,
+	"UPDATING": ListCatalogsLifecycleStateUpdating,
+	"DELETING": ListCatalogsLifecycleStateDeleting,
+	"DELETED":  ListCatalogsLifecycleStateDeleted,
+	"FAILED":   ListCatalogsLifecycleStateFailed,
+	"MOVING":   ListCatalogsLifecycleStateMoving,
+}
+
+// GetListCatalogsLifecycleStateEnumValues Enumerates the set of values for ListCatalogsLifecycleStateEnum
+func GetListCatalogsLifecycleStateEnumValues() []ListCatalogsLifecycleStateEnum {
+	values := make([]ListCatalogsLifecycleStateEnum, 0)
+	for _, v := range mappingListCatalogsLifecycleState {
+		values = append(values, v)
+	}
+	return values
 }
 
 // ListCatalogsSortOrderEnum Enum with underlying type: string

--- a/datacatalog/list_connections_request_response.go
+++ b/datacatalog/list_connections_request_response.go
@@ -22,7 +22,7 @@ type ListConnectionsRequest struct {
 	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
 
 	// A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
-	LifecycleState LifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState ListConnectionsLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// Time that the resource was created. An RFC3339 (https://tools.ietf.org/html/rfc3339) formatted datetime string.
 	TimeCreated *common.SDKTime `mandatory:"false" contributesTo:"query" name:"timeCreated"`
@@ -106,6 +106,41 @@ func (response ListConnectionsResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response ListConnectionsResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// ListConnectionsLifecycleStateEnum Enum with underlying type: string
+type ListConnectionsLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListConnectionsLifecycleStateEnum
+const (
+	ListConnectionsLifecycleStateCreating ListConnectionsLifecycleStateEnum = "CREATING"
+	ListConnectionsLifecycleStateActive   ListConnectionsLifecycleStateEnum = "ACTIVE"
+	ListConnectionsLifecycleStateInactive ListConnectionsLifecycleStateEnum = "INACTIVE"
+	ListConnectionsLifecycleStateUpdating ListConnectionsLifecycleStateEnum = "UPDATING"
+	ListConnectionsLifecycleStateDeleting ListConnectionsLifecycleStateEnum = "DELETING"
+	ListConnectionsLifecycleStateDeleted  ListConnectionsLifecycleStateEnum = "DELETED"
+	ListConnectionsLifecycleStateFailed   ListConnectionsLifecycleStateEnum = "FAILED"
+	ListConnectionsLifecycleStateMoving   ListConnectionsLifecycleStateEnum = "MOVING"
+)
+
+var mappingListConnectionsLifecycleState = map[string]ListConnectionsLifecycleStateEnum{
+	"CREATING": ListConnectionsLifecycleStateCreating,
+	"ACTIVE":   ListConnectionsLifecycleStateActive,
+	"INACTIVE": ListConnectionsLifecycleStateInactive,
+	"UPDATING": ListConnectionsLifecycleStateUpdating,
+	"DELETING": ListConnectionsLifecycleStateDeleting,
+	"DELETED":  ListConnectionsLifecycleStateDeleted,
+	"FAILED":   ListConnectionsLifecycleStateFailed,
+	"MOVING":   ListConnectionsLifecycleStateMoving,
+}
+
+// GetListConnectionsLifecycleStateEnumValues Enumerates the set of values for ListConnectionsLifecycleStateEnum
+func GetListConnectionsLifecycleStateEnumValues() []ListConnectionsLifecycleStateEnum {
+	values := make([]ListConnectionsLifecycleStateEnum, 0)
+	for _, v := range mappingListConnectionsLifecycleState {
+		values = append(values, v)
+	}
+	return values
 }
 
 // ListConnectionsFieldsEnum Enum with underlying type: string

--- a/datacatalog/list_data_asset_tags_request_response.go
+++ b/datacatalog/list_data_asset_tags_request_response.go
@@ -22,7 +22,7 @@ type ListDataAssetTagsRequest struct {
 	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
 
 	// A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
-	LifecycleState LifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState ListDataAssetTagsLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// Unique key of the related term.
 	TermKey *string `mandatory:"false" contributesTo:"query" name:"termKey"`
@@ -97,6 +97,41 @@ func (response ListDataAssetTagsResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response ListDataAssetTagsResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// ListDataAssetTagsLifecycleStateEnum Enum with underlying type: string
+type ListDataAssetTagsLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListDataAssetTagsLifecycleStateEnum
+const (
+	ListDataAssetTagsLifecycleStateCreating ListDataAssetTagsLifecycleStateEnum = "CREATING"
+	ListDataAssetTagsLifecycleStateActive   ListDataAssetTagsLifecycleStateEnum = "ACTIVE"
+	ListDataAssetTagsLifecycleStateInactive ListDataAssetTagsLifecycleStateEnum = "INACTIVE"
+	ListDataAssetTagsLifecycleStateUpdating ListDataAssetTagsLifecycleStateEnum = "UPDATING"
+	ListDataAssetTagsLifecycleStateDeleting ListDataAssetTagsLifecycleStateEnum = "DELETING"
+	ListDataAssetTagsLifecycleStateDeleted  ListDataAssetTagsLifecycleStateEnum = "DELETED"
+	ListDataAssetTagsLifecycleStateFailed   ListDataAssetTagsLifecycleStateEnum = "FAILED"
+	ListDataAssetTagsLifecycleStateMoving   ListDataAssetTagsLifecycleStateEnum = "MOVING"
+)
+
+var mappingListDataAssetTagsLifecycleState = map[string]ListDataAssetTagsLifecycleStateEnum{
+	"CREATING": ListDataAssetTagsLifecycleStateCreating,
+	"ACTIVE":   ListDataAssetTagsLifecycleStateActive,
+	"INACTIVE": ListDataAssetTagsLifecycleStateInactive,
+	"UPDATING": ListDataAssetTagsLifecycleStateUpdating,
+	"DELETING": ListDataAssetTagsLifecycleStateDeleting,
+	"DELETED":  ListDataAssetTagsLifecycleStateDeleted,
+	"FAILED":   ListDataAssetTagsLifecycleStateFailed,
+	"MOVING":   ListDataAssetTagsLifecycleStateMoving,
+}
+
+// GetListDataAssetTagsLifecycleStateEnumValues Enumerates the set of values for ListDataAssetTagsLifecycleStateEnum
+func GetListDataAssetTagsLifecycleStateEnumValues() []ListDataAssetTagsLifecycleStateEnum {
+	values := make([]ListDataAssetTagsLifecycleStateEnum, 0)
+	for _, v := range mappingListDataAssetTagsLifecycleState {
+		values = append(values, v)
+	}
+	return values
 }
 
 // ListDataAssetTagsFieldsEnum Enum with underlying type: string

--- a/datacatalog/list_data_assets_request_response.go
+++ b/datacatalog/list_data_assets_request_response.go
@@ -19,7 +19,7 @@ type ListDataAssetsRequest struct {
 	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
 
 	// A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
-	LifecycleState LifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState ListDataAssetsLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// Time that the resource was created. An RFC3339 (https://tools.ietf.org/html/rfc3339) formatted datetime string.
 	TimeCreated *common.SDKTime `mandatory:"false" contributesTo:"query" name:"timeCreated"`
@@ -100,6 +100,41 @@ func (response ListDataAssetsResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response ListDataAssetsResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// ListDataAssetsLifecycleStateEnum Enum with underlying type: string
+type ListDataAssetsLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListDataAssetsLifecycleStateEnum
+const (
+	ListDataAssetsLifecycleStateCreating ListDataAssetsLifecycleStateEnum = "CREATING"
+	ListDataAssetsLifecycleStateActive   ListDataAssetsLifecycleStateEnum = "ACTIVE"
+	ListDataAssetsLifecycleStateInactive ListDataAssetsLifecycleStateEnum = "INACTIVE"
+	ListDataAssetsLifecycleStateUpdating ListDataAssetsLifecycleStateEnum = "UPDATING"
+	ListDataAssetsLifecycleStateDeleting ListDataAssetsLifecycleStateEnum = "DELETING"
+	ListDataAssetsLifecycleStateDeleted  ListDataAssetsLifecycleStateEnum = "DELETED"
+	ListDataAssetsLifecycleStateFailed   ListDataAssetsLifecycleStateEnum = "FAILED"
+	ListDataAssetsLifecycleStateMoving   ListDataAssetsLifecycleStateEnum = "MOVING"
+)
+
+var mappingListDataAssetsLifecycleState = map[string]ListDataAssetsLifecycleStateEnum{
+	"CREATING": ListDataAssetsLifecycleStateCreating,
+	"ACTIVE":   ListDataAssetsLifecycleStateActive,
+	"INACTIVE": ListDataAssetsLifecycleStateInactive,
+	"UPDATING": ListDataAssetsLifecycleStateUpdating,
+	"DELETING": ListDataAssetsLifecycleStateDeleting,
+	"DELETED":  ListDataAssetsLifecycleStateDeleted,
+	"FAILED":   ListDataAssetsLifecycleStateFailed,
+	"MOVING":   ListDataAssetsLifecycleStateMoving,
+}
+
+// GetListDataAssetsLifecycleStateEnumValues Enumerates the set of values for ListDataAssetsLifecycleStateEnum
+func GetListDataAssetsLifecycleStateEnumValues() []ListDataAssetsLifecycleStateEnum {
+	values := make([]ListDataAssetsLifecycleStateEnum, 0)
+	for _, v := range mappingListDataAssetsLifecycleState {
+		values = append(values, v)
+	}
+	return values
 }
 
 // ListDataAssetsFieldsEnum Enum with underlying type: string

--- a/datacatalog/list_entities_request_response.go
+++ b/datacatalog/list_entities_request_response.go
@@ -22,7 +22,7 @@ type ListEntitiesRequest struct {
 	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
 
 	// A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
-	LifecycleState LifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState ListEntitiesLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// Time that the resource was created. An RFC3339 (https://tools.ietf.org/html/rfc3339) formatted datetime string.
 	TimeCreated *common.SDKTime `mandatory:"false" contributesTo:"query" name:"timeCreated"`
@@ -58,7 +58,7 @@ type ListEntitiesRequest struct {
 	Path *string `mandatory:"false" contributesTo:"query" name:"path"`
 
 	// Harvest status of the harvestable resource as updated by the harvest process.
-	HarvestStatus HarvestStatusEnum `mandatory:"false" contributesTo:"query" name:"harvestStatus" omitEmpty:"true"`
+	HarvestStatus ListEntitiesHarvestStatusEnum `mandatory:"false" contributesTo:"query" name:"harvestStatus" omitEmpty:"true"`
 
 	// Key of the last harvest process to update this resource.
 	LastJobKey *string `mandatory:"false" contributesTo:"query" name:"lastJobKey"`
@@ -124,6 +124,68 @@ func (response ListEntitiesResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response ListEntitiesResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// ListEntitiesLifecycleStateEnum Enum with underlying type: string
+type ListEntitiesLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListEntitiesLifecycleStateEnum
+const (
+	ListEntitiesLifecycleStateCreating ListEntitiesLifecycleStateEnum = "CREATING"
+	ListEntitiesLifecycleStateActive   ListEntitiesLifecycleStateEnum = "ACTIVE"
+	ListEntitiesLifecycleStateInactive ListEntitiesLifecycleStateEnum = "INACTIVE"
+	ListEntitiesLifecycleStateUpdating ListEntitiesLifecycleStateEnum = "UPDATING"
+	ListEntitiesLifecycleStateDeleting ListEntitiesLifecycleStateEnum = "DELETING"
+	ListEntitiesLifecycleStateDeleted  ListEntitiesLifecycleStateEnum = "DELETED"
+	ListEntitiesLifecycleStateFailed   ListEntitiesLifecycleStateEnum = "FAILED"
+	ListEntitiesLifecycleStateMoving   ListEntitiesLifecycleStateEnum = "MOVING"
+)
+
+var mappingListEntitiesLifecycleState = map[string]ListEntitiesLifecycleStateEnum{
+	"CREATING": ListEntitiesLifecycleStateCreating,
+	"ACTIVE":   ListEntitiesLifecycleStateActive,
+	"INACTIVE": ListEntitiesLifecycleStateInactive,
+	"UPDATING": ListEntitiesLifecycleStateUpdating,
+	"DELETING": ListEntitiesLifecycleStateDeleting,
+	"DELETED":  ListEntitiesLifecycleStateDeleted,
+	"FAILED":   ListEntitiesLifecycleStateFailed,
+	"MOVING":   ListEntitiesLifecycleStateMoving,
+}
+
+// GetListEntitiesLifecycleStateEnumValues Enumerates the set of values for ListEntitiesLifecycleStateEnum
+func GetListEntitiesLifecycleStateEnumValues() []ListEntitiesLifecycleStateEnum {
+	values := make([]ListEntitiesLifecycleStateEnum, 0)
+	for _, v := range mappingListEntitiesLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListEntitiesHarvestStatusEnum Enum with underlying type: string
+type ListEntitiesHarvestStatusEnum string
+
+// Set of constants representing the allowable values for ListEntitiesHarvestStatusEnum
+const (
+	ListEntitiesHarvestStatusComplete   ListEntitiesHarvestStatusEnum = "COMPLETE"
+	ListEntitiesHarvestStatusError      ListEntitiesHarvestStatusEnum = "ERROR"
+	ListEntitiesHarvestStatusInProgress ListEntitiesHarvestStatusEnum = "IN_PROGRESS"
+	ListEntitiesHarvestStatusDeferred   ListEntitiesHarvestStatusEnum = "DEFERRED"
+)
+
+var mappingListEntitiesHarvestStatus = map[string]ListEntitiesHarvestStatusEnum{
+	"COMPLETE":    ListEntitiesHarvestStatusComplete,
+	"ERROR":       ListEntitiesHarvestStatusError,
+	"IN_PROGRESS": ListEntitiesHarvestStatusInProgress,
+	"DEFERRED":    ListEntitiesHarvestStatusDeferred,
+}
+
+// GetListEntitiesHarvestStatusEnumValues Enumerates the set of values for ListEntitiesHarvestStatusEnum
+func GetListEntitiesHarvestStatusEnumValues() []ListEntitiesHarvestStatusEnum {
+	values := make([]ListEntitiesHarvestStatusEnum, 0)
+	for _, v := range mappingListEntitiesHarvestStatus {
+		values = append(values, v)
+	}
+	return values
 }
 
 // ListEntitiesFieldsEnum Enum with underlying type: string

--- a/datacatalog/list_entity_tags_request_response.go
+++ b/datacatalog/list_entity_tags_request_response.go
@@ -25,7 +25,7 @@ type ListEntityTagsRequest struct {
 	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
 
 	// A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
-	LifecycleState LifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState ListEntityTagsLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// Unique key of the related term.
 	TermKey *string `mandatory:"false" contributesTo:"query" name:"termKey"`
@@ -100,6 +100,41 @@ func (response ListEntityTagsResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response ListEntityTagsResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// ListEntityTagsLifecycleStateEnum Enum with underlying type: string
+type ListEntityTagsLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListEntityTagsLifecycleStateEnum
+const (
+	ListEntityTagsLifecycleStateCreating ListEntityTagsLifecycleStateEnum = "CREATING"
+	ListEntityTagsLifecycleStateActive   ListEntityTagsLifecycleStateEnum = "ACTIVE"
+	ListEntityTagsLifecycleStateInactive ListEntityTagsLifecycleStateEnum = "INACTIVE"
+	ListEntityTagsLifecycleStateUpdating ListEntityTagsLifecycleStateEnum = "UPDATING"
+	ListEntityTagsLifecycleStateDeleting ListEntityTagsLifecycleStateEnum = "DELETING"
+	ListEntityTagsLifecycleStateDeleted  ListEntityTagsLifecycleStateEnum = "DELETED"
+	ListEntityTagsLifecycleStateFailed   ListEntityTagsLifecycleStateEnum = "FAILED"
+	ListEntityTagsLifecycleStateMoving   ListEntityTagsLifecycleStateEnum = "MOVING"
+)
+
+var mappingListEntityTagsLifecycleState = map[string]ListEntityTagsLifecycleStateEnum{
+	"CREATING": ListEntityTagsLifecycleStateCreating,
+	"ACTIVE":   ListEntityTagsLifecycleStateActive,
+	"INACTIVE": ListEntityTagsLifecycleStateInactive,
+	"UPDATING": ListEntityTagsLifecycleStateUpdating,
+	"DELETING": ListEntityTagsLifecycleStateDeleting,
+	"DELETED":  ListEntityTagsLifecycleStateDeleted,
+	"FAILED":   ListEntityTagsLifecycleStateFailed,
+	"MOVING":   ListEntityTagsLifecycleStateMoving,
+}
+
+// GetListEntityTagsLifecycleStateEnumValues Enumerates the set of values for ListEntityTagsLifecycleStateEnum
+func GetListEntityTagsLifecycleStateEnumValues() []ListEntityTagsLifecycleStateEnum {
+	values := make([]ListEntityTagsLifecycleStateEnum, 0)
+	for _, v := range mappingListEntityTagsLifecycleState {
+		values = append(values, v)
+	}
+	return values
 }
 
 // ListEntityTagsFieldsEnum Enum with underlying type: string

--- a/datacatalog/list_folder_tags_request_response.go
+++ b/datacatalog/list_folder_tags_request_response.go
@@ -25,7 +25,7 @@ type ListFolderTagsRequest struct {
 	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
 
 	// A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
-	LifecycleState LifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState ListFolderTagsLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// Unique key of the related term.
 	TermKey *string `mandatory:"false" contributesTo:"query" name:"termKey"`
@@ -100,6 +100,41 @@ func (response ListFolderTagsResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response ListFolderTagsResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// ListFolderTagsLifecycleStateEnum Enum with underlying type: string
+type ListFolderTagsLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListFolderTagsLifecycleStateEnum
+const (
+	ListFolderTagsLifecycleStateCreating ListFolderTagsLifecycleStateEnum = "CREATING"
+	ListFolderTagsLifecycleStateActive   ListFolderTagsLifecycleStateEnum = "ACTIVE"
+	ListFolderTagsLifecycleStateInactive ListFolderTagsLifecycleStateEnum = "INACTIVE"
+	ListFolderTagsLifecycleStateUpdating ListFolderTagsLifecycleStateEnum = "UPDATING"
+	ListFolderTagsLifecycleStateDeleting ListFolderTagsLifecycleStateEnum = "DELETING"
+	ListFolderTagsLifecycleStateDeleted  ListFolderTagsLifecycleStateEnum = "DELETED"
+	ListFolderTagsLifecycleStateFailed   ListFolderTagsLifecycleStateEnum = "FAILED"
+	ListFolderTagsLifecycleStateMoving   ListFolderTagsLifecycleStateEnum = "MOVING"
+)
+
+var mappingListFolderTagsLifecycleState = map[string]ListFolderTagsLifecycleStateEnum{
+	"CREATING": ListFolderTagsLifecycleStateCreating,
+	"ACTIVE":   ListFolderTagsLifecycleStateActive,
+	"INACTIVE": ListFolderTagsLifecycleStateInactive,
+	"UPDATING": ListFolderTagsLifecycleStateUpdating,
+	"DELETING": ListFolderTagsLifecycleStateDeleting,
+	"DELETED":  ListFolderTagsLifecycleStateDeleted,
+	"FAILED":   ListFolderTagsLifecycleStateFailed,
+	"MOVING":   ListFolderTagsLifecycleStateMoving,
+}
+
+// GetListFolderTagsLifecycleStateEnumValues Enumerates the set of values for ListFolderTagsLifecycleStateEnum
+func GetListFolderTagsLifecycleStateEnumValues() []ListFolderTagsLifecycleStateEnum {
+	values := make([]ListFolderTagsLifecycleStateEnum, 0)
+	for _, v := range mappingListFolderTagsLifecycleState {
+		values = append(values, v)
+	}
+	return values
 }
 
 // ListFolderTagsFieldsEnum Enum with underlying type: string

--- a/datacatalog/list_folders_request_response.go
+++ b/datacatalog/list_folders_request_response.go
@@ -22,7 +22,7 @@ type ListFoldersRequest struct {
 	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
 
 	// A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
-	LifecycleState LifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState ListFoldersLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// Unique folder key.
 	ParentFolderKey *string `mandatory:"false" contributesTo:"query" name:"parentFolderKey"`
@@ -46,7 +46,7 @@ type ListFoldersRequest struct {
 	UpdatedById *string `mandatory:"false" contributesTo:"query" name:"updatedById"`
 
 	// Harvest status of the harvestable resource as updated by the harvest process.
-	HarvestStatus HarvestStatusEnum `mandatory:"false" contributesTo:"query" name:"harvestStatus" omitEmpty:"true"`
+	HarvestStatus ListFoldersHarvestStatusEnum `mandatory:"false" contributesTo:"query" name:"harvestStatus" omitEmpty:"true"`
 
 	// Key of the last harvest process to update this resource.
 	LastJobKey *string `mandatory:"false" contributesTo:"query" name:"lastJobKey"`
@@ -112,6 +112,68 @@ func (response ListFoldersResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response ListFoldersResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// ListFoldersLifecycleStateEnum Enum with underlying type: string
+type ListFoldersLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListFoldersLifecycleStateEnum
+const (
+	ListFoldersLifecycleStateCreating ListFoldersLifecycleStateEnum = "CREATING"
+	ListFoldersLifecycleStateActive   ListFoldersLifecycleStateEnum = "ACTIVE"
+	ListFoldersLifecycleStateInactive ListFoldersLifecycleStateEnum = "INACTIVE"
+	ListFoldersLifecycleStateUpdating ListFoldersLifecycleStateEnum = "UPDATING"
+	ListFoldersLifecycleStateDeleting ListFoldersLifecycleStateEnum = "DELETING"
+	ListFoldersLifecycleStateDeleted  ListFoldersLifecycleStateEnum = "DELETED"
+	ListFoldersLifecycleStateFailed   ListFoldersLifecycleStateEnum = "FAILED"
+	ListFoldersLifecycleStateMoving   ListFoldersLifecycleStateEnum = "MOVING"
+)
+
+var mappingListFoldersLifecycleState = map[string]ListFoldersLifecycleStateEnum{
+	"CREATING": ListFoldersLifecycleStateCreating,
+	"ACTIVE":   ListFoldersLifecycleStateActive,
+	"INACTIVE": ListFoldersLifecycleStateInactive,
+	"UPDATING": ListFoldersLifecycleStateUpdating,
+	"DELETING": ListFoldersLifecycleStateDeleting,
+	"DELETED":  ListFoldersLifecycleStateDeleted,
+	"FAILED":   ListFoldersLifecycleStateFailed,
+	"MOVING":   ListFoldersLifecycleStateMoving,
+}
+
+// GetListFoldersLifecycleStateEnumValues Enumerates the set of values for ListFoldersLifecycleStateEnum
+func GetListFoldersLifecycleStateEnumValues() []ListFoldersLifecycleStateEnum {
+	values := make([]ListFoldersLifecycleStateEnum, 0)
+	for _, v := range mappingListFoldersLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListFoldersHarvestStatusEnum Enum with underlying type: string
+type ListFoldersHarvestStatusEnum string
+
+// Set of constants representing the allowable values for ListFoldersHarvestStatusEnum
+const (
+	ListFoldersHarvestStatusComplete   ListFoldersHarvestStatusEnum = "COMPLETE"
+	ListFoldersHarvestStatusError      ListFoldersHarvestStatusEnum = "ERROR"
+	ListFoldersHarvestStatusInProgress ListFoldersHarvestStatusEnum = "IN_PROGRESS"
+	ListFoldersHarvestStatusDeferred   ListFoldersHarvestStatusEnum = "DEFERRED"
+)
+
+var mappingListFoldersHarvestStatus = map[string]ListFoldersHarvestStatusEnum{
+	"COMPLETE":    ListFoldersHarvestStatusComplete,
+	"ERROR":       ListFoldersHarvestStatusError,
+	"IN_PROGRESS": ListFoldersHarvestStatusInProgress,
+	"DEFERRED":    ListFoldersHarvestStatusDeferred,
+}
+
+// GetListFoldersHarvestStatusEnumValues Enumerates the set of values for ListFoldersHarvestStatusEnum
+func GetListFoldersHarvestStatusEnumValues() []ListFoldersHarvestStatusEnum {
+	values := make([]ListFoldersHarvestStatusEnum, 0)
+	for _, v := range mappingListFoldersHarvestStatus {
+		values = append(values, v)
+	}
+	return values
 }
 
 // ListFoldersFieldsEnum Enum with underlying type: string

--- a/datacatalog/list_glossaries_request_response.go
+++ b/datacatalog/list_glossaries_request_response.go
@@ -19,7 +19,7 @@ type ListGlossariesRequest struct {
 	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
 
 	// A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
-	LifecycleState LifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState ListGlossariesLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// Time that the resource was created. An RFC3339 (https://tools.ietf.org/html/rfc3339) formatted datetime string.
 	TimeCreated *common.SDKTime `mandatory:"false" contributesTo:"query" name:"timeCreated"`
@@ -94,6 +94,41 @@ func (response ListGlossariesResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response ListGlossariesResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// ListGlossariesLifecycleStateEnum Enum with underlying type: string
+type ListGlossariesLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListGlossariesLifecycleStateEnum
+const (
+	ListGlossariesLifecycleStateCreating ListGlossariesLifecycleStateEnum = "CREATING"
+	ListGlossariesLifecycleStateActive   ListGlossariesLifecycleStateEnum = "ACTIVE"
+	ListGlossariesLifecycleStateInactive ListGlossariesLifecycleStateEnum = "INACTIVE"
+	ListGlossariesLifecycleStateUpdating ListGlossariesLifecycleStateEnum = "UPDATING"
+	ListGlossariesLifecycleStateDeleting ListGlossariesLifecycleStateEnum = "DELETING"
+	ListGlossariesLifecycleStateDeleted  ListGlossariesLifecycleStateEnum = "DELETED"
+	ListGlossariesLifecycleStateFailed   ListGlossariesLifecycleStateEnum = "FAILED"
+	ListGlossariesLifecycleStateMoving   ListGlossariesLifecycleStateEnum = "MOVING"
+)
+
+var mappingListGlossariesLifecycleState = map[string]ListGlossariesLifecycleStateEnum{
+	"CREATING": ListGlossariesLifecycleStateCreating,
+	"ACTIVE":   ListGlossariesLifecycleStateActive,
+	"INACTIVE": ListGlossariesLifecycleStateInactive,
+	"UPDATING": ListGlossariesLifecycleStateUpdating,
+	"DELETING": ListGlossariesLifecycleStateDeleting,
+	"DELETED":  ListGlossariesLifecycleStateDeleted,
+	"FAILED":   ListGlossariesLifecycleStateFailed,
+	"MOVING":   ListGlossariesLifecycleStateMoving,
+}
+
+// GetListGlossariesLifecycleStateEnumValues Enumerates the set of values for ListGlossariesLifecycleStateEnum
+func GetListGlossariesLifecycleStateEnumValues() []ListGlossariesLifecycleStateEnum {
+	values := make([]ListGlossariesLifecycleStateEnum, 0)
+	for _, v := range mappingListGlossariesLifecycleState {
+		values = append(values, v)
+	}
+	return values
 }
 
 // ListGlossariesFieldsEnum Enum with underlying type: string

--- a/datacatalog/list_job_definitions_request_response.go
+++ b/datacatalog/list_job_definitions_request_response.go
@@ -19,10 +19,10 @@ type ListJobDefinitionsRequest struct {
 	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
 
 	// A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
-	LifecycleState LifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState ListJobDefinitionsLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// Job type.
-	JobType JobTypeEnum `mandatory:"false" contributesTo:"query" name:"jobType" omitEmpty:"true"`
+	JobType ListJobDefinitionsJobTypeEnum `mandatory:"false" contributesTo:"query" name:"jobType" omitEmpty:"true"`
 
 	// Whether job definition is an incremental harvest (true) or a full harvest (false).
 	IsIncremental *bool `mandatory:"false" contributesTo:"query" name:"isIncremental"`
@@ -109,6 +109,86 @@ func (response ListJobDefinitionsResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response ListJobDefinitionsResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// ListJobDefinitionsLifecycleStateEnum Enum with underlying type: string
+type ListJobDefinitionsLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListJobDefinitionsLifecycleStateEnum
+const (
+	ListJobDefinitionsLifecycleStateCreating ListJobDefinitionsLifecycleStateEnum = "CREATING"
+	ListJobDefinitionsLifecycleStateActive   ListJobDefinitionsLifecycleStateEnum = "ACTIVE"
+	ListJobDefinitionsLifecycleStateInactive ListJobDefinitionsLifecycleStateEnum = "INACTIVE"
+	ListJobDefinitionsLifecycleStateUpdating ListJobDefinitionsLifecycleStateEnum = "UPDATING"
+	ListJobDefinitionsLifecycleStateDeleting ListJobDefinitionsLifecycleStateEnum = "DELETING"
+	ListJobDefinitionsLifecycleStateDeleted  ListJobDefinitionsLifecycleStateEnum = "DELETED"
+	ListJobDefinitionsLifecycleStateFailed   ListJobDefinitionsLifecycleStateEnum = "FAILED"
+	ListJobDefinitionsLifecycleStateMoving   ListJobDefinitionsLifecycleStateEnum = "MOVING"
+)
+
+var mappingListJobDefinitionsLifecycleState = map[string]ListJobDefinitionsLifecycleStateEnum{
+	"CREATING": ListJobDefinitionsLifecycleStateCreating,
+	"ACTIVE":   ListJobDefinitionsLifecycleStateActive,
+	"INACTIVE": ListJobDefinitionsLifecycleStateInactive,
+	"UPDATING": ListJobDefinitionsLifecycleStateUpdating,
+	"DELETING": ListJobDefinitionsLifecycleStateDeleting,
+	"DELETED":  ListJobDefinitionsLifecycleStateDeleted,
+	"FAILED":   ListJobDefinitionsLifecycleStateFailed,
+	"MOVING":   ListJobDefinitionsLifecycleStateMoving,
+}
+
+// GetListJobDefinitionsLifecycleStateEnumValues Enumerates the set of values for ListJobDefinitionsLifecycleStateEnum
+func GetListJobDefinitionsLifecycleStateEnumValues() []ListJobDefinitionsLifecycleStateEnum {
+	values := make([]ListJobDefinitionsLifecycleStateEnum, 0)
+	for _, v := range mappingListJobDefinitionsLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListJobDefinitionsJobTypeEnum Enum with underlying type: string
+type ListJobDefinitionsJobTypeEnum string
+
+// Set of constants representing the allowable values for ListJobDefinitionsJobTypeEnum
+const (
+	ListJobDefinitionsJobTypeHarvest                    ListJobDefinitionsJobTypeEnum = "HARVEST"
+	ListJobDefinitionsJobTypeProfiling                  ListJobDefinitionsJobTypeEnum = "PROFILING"
+	ListJobDefinitionsJobTypeSampling                   ListJobDefinitionsJobTypeEnum = "SAMPLING"
+	ListJobDefinitionsJobTypePreview                    ListJobDefinitionsJobTypeEnum = "PREVIEW"
+	ListJobDefinitionsJobTypeImport                     ListJobDefinitionsJobTypeEnum = "IMPORT"
+	ListJobDefinitionsJobTypeExport                     ListJobDefinitionsJobTypeEnum = "EXPORT"
+	ListJobDefinitionsJobTypeInternal                   ListJobDefinitionsJobTypeEnum = "INTERNAL"
+	ListJobDefinitionsJobTypePurge                      ListJobDefinitionsJobTypeEnum = "PURGE"
+	ListJobDefinitionsJobTypeImmediate                  ListJobDefinitionsJobTypeEnum = "IMMEDIATE"
+	ListJobDefinitionsJobTypeScheduled                  ListJobDefinitionsJobTypeEnum = "SCHEDULED"
+	ListJobDefinitionsJobTypeImmediateExecution         ListJobDefinitionsJobTypeEnum = "IMMEDIATE_EXECUTION"
+	ListJobDefinitionsJobTypeScheduledExecution         ListJobDefinitionsJobTypeEnum = "SCHEDULED_EXECUTION"
+	ListJobDefinitionsJobTypeScheduledExecutionInstance ListJobDefinitionsJobTypeEnum = "SCHEDULED_EXECUTION_INSTANCE"
+)
+
+var mappingListJobDefinitionsJobType = map[string]ListJobDefinitionsJobTypeEnum{
+	"HARVEST":                      ListJobDefinitionsJobTypeHarvest,
+	"PROFILING":                    ListJobDefinitionsJobTypeProfiling,
+	"SAMPLING":                     ListJobDefinitionsJobTypeSampling,
+	"PREVIEW":                      ListJobDefinitionsJobTypePreview,
+	"IMPORT":                       ListJobDefinitionsJobTypeImport,
+	"EXPORT":                       ListJobDefinitionsJobTypeExport,
+	"INTERNAL":                     ListJobDefinitionsJobTypeInternal,
+	"PURGE":                        ListJobDefinitionsJobTypePurge,
+	"IMMEDIATE":                    ListJobDefinitionsJobTypeImmediate,
+	"SCHEDULED":                    ListJobDefinitionsJobTypeScheduled,
+	"IMMEDIATE_EXECUTION":          ListJobDefinitionsJobTypeImmediateExecution,
+	"SCHEDULED_EXECUTION":          ListJobDefinitionsJobTypeScheduledExecution,
+	"SCHEDULED_EXECUTION_INSTANCE": ListJobDefinitionsJobTypeScheduledExecutionInstance,
+}
+
+// GetListJobDefinitionsJobTypeEnumValues Enumerates the set of values for ListJobDefinitionsJobTypeEnum
+func GetListJobDefinitionsJobTypeEnumValues() []ListJobDefinitionsJobTypeEnum {
+	values := make([]ListJobDefinitionsJobTypeEnum, 0)
+	for _, v := range mappingListJobDefinitionsJobType {
+		values = append(values, v)
+	}
+	return values
 }
 
 // ListJobDefinitionsFieldsEnum Enum with underlying type: string

--- a/datacatalog/list_job_executions_request_response.go
+++ b/datacatalog/list_job_executions_request_response.go
@@ -19,7 +19,7 @@ type ListJobExecutionsRequest struct {
 	JobKey *string `mandatory:"true" contributesTo:"path" name:"jobKey"`
 
 	// Job execution lifecycle state.
-	LifecycleState JobExecutionStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState ListJobExecutionsLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// Time that the resource was created. An RFC3339 (https://tools.ietf.org/html/rfc3339) formatted datetime string.
 	TimeCreated *common.SDKTime `mandatory:"false" contributesTo:"query" name:"timeCreated"`
@@ -34,7 +34,7 @@ type ListJobExecutionsRequest struct {
 	UpdatedById *string `mandatory:"false" contributesTo:"query" name:"updatedById"`
 
 	// Job type.
-	JobType JobTypeEnum `mandatory:"false" contributesTo:"query" name:"jobType" omitEmpty:"true"`
+	JobType ListJobExecutionsJobTypeEnum `mandatory:"false" contributesTo:"query" name:"jobType" omitEmpty:"true"`
 
 	// Sub-type of this job execution.
 	SubType *string `mandatory:"false" contributesTo:"query" name:"subType"`
@@ -129,6 +129,82 @@ func (response ListJobExecutionsResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response ListJobExecutionsResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// ListJobExecutionsLifecycleStateEnum Enum with underlying type: string
+type ListJobExecutionsLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListJobExecutionsLifecycleStateEnum
+const (
+	ListJobExecutionsLifecycleStateCreated    ListJobExecutionsLifecycleStateEnum = "CREATED"
+	ListJobExecutionsLifecycleStateInProgress ListJobExecutionsLifecycleStateEnum = "IN_PROGRESS"
+	ListJobExecutionsLifecycleStateInactive   ListJobExecutionsLifecycleStateEnum = "INACTIVE"
+	ListJobExecutionsLifecycleStateFailed     ListJobExecutionsLifecycleStateEnum = "FAILED"
+	ListJobExecutionsLifecycleStateSucceeded  ListJobExecutionsLifecycleStateEnum = "SUCCEEDED"
+	ListJobExecutionsLifecycleStateCanceled   ListJobExecutionsLifecycleStateEnum = "CANCELED"
+)
+
+var mappingListJobExecutionsLifecycleState = map[string]ListJobExecutionsLifecycleStateEnum{
+	"CREATED":     ListJobExecutionsLifecycleStateCreated,
+	"IN_PROGRESS": ListJobExecutionsLifecycleStateInProgress,
+	"INACTIVE":    ListJobExecutionsLifecycleStateInactive,
+	"FAILED":      ListJobExecutionsLifecycleStateFailed,
+	"SUCCEEDED":   ListJobExecutionsLifecycleStateSucceeded,
+	"CANCELED":    ListJobExecutionsLifecycleStateCanceled,
+}
+
+// GetListJobExecutionsLifecycleStateEnumValues Enumerates the set of values for ListJobExecutionsLifecycleStateEnum
+func GetListJobExecutionsLifecycleStateEnumValues() []ListJobExecutionsLifecycleStateEnum {
+	values := make([]ListJobExecutionsLifecycleStateEnum, 0)
+	for _, v := range mappingListJobExecutionsLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListJobExecutionsJobTypeEnum Enum with underlying type: string
+type ListJobExecutionsJobTypeEnum string
+
+// Set of constants representing the allowable values for ListJobExecutionsJobTypeEnum
+const (
+	ListJobExecutionsJobTypeHarvest                    ListJobExecutionsJobTypeEnum = "HARVEST"
+	ListJobExecutionsJobTypeProfiling                  ListJobExecutionsJobTypeEnum = "PROFILING"
+	ListJobExecutionsJobTypeSampling                   ListJobExecutionsJobTypeEnum = "SAMPLING"
+	ListJobExecutionsJobTypePreview                    ListJobExecutionsJobTypeEnum = "PREVIEW"
+	ListJobExecutionsJobTypeImport                     ListJobExecutionsJobTypeEnum = "IMPORT"
+	ListJobExecutionsJobTypeExport                     ListJobExecutionsJobTypeEnum = "EXPORT"
+	ListJobExecutionsJobTypeInternal                   ListJobExecutionsJobTypeEnum = "INTERNAL"
+	ListJobExecutionsJobTypePurge                      ListJobExecutionsJobTypeEnum = "PURGE"
+	ListJobExecutionsJobTypeImmediate                  ListJobExecutionsJobTypeEnum = "IMMEDIATE"
+	ListJobExecutionsJobTypeScheduled                  ListJobExecutionsJobTypeEnum = "SCHEDULED"
+	ListJobExecutionsJobTypeImmediateExecution         ListJobExecutionsJobTypeEnum = "IMMEDIATE_EXECUTION"
+	ListJobExecutionsJobTypeScheduledExecution         ListJobExecutionsJobTypeEnum = "SCHEDULED_EXECUTION"
+	ListJobExecutionsJobTypeScheduledExecutionInstance ListJobExecutionsJobTypeEnum = "SCHEDULED_EXECUTION_INSTANCE"
+)
+
+var mappingListJobExecutionsJobType = map[string]ListJobExecutionsJobTypeEnum{
+	"HARVEST":                      ListJobExecutionsJobTypeHarvest,
+	"PROFILING":                    ListJobExecutionsJobTypeProfiling,
+	"SAMPLING":                     ListJobExecutionsJobTypeSampling,
+	"PREVIEW":                      ListJobExecutionsJobTypePreview,
+	"IMPORT":                       ListJobExecutionsJobTypeImport,
+	"EXPORT":                       ListJobExecutionsJobTypeExport,
+	"INTERNAL":                     ListJobExecutionsJobTypeInternal,
+	"PURGE":                        ListJobExecutionsJobTypePurge,
+	"IMMEDIATE":                    ListJobExecutionsJobTypeImmediate,
+	"SCHEDULED":                    ListJobExecutionsJobTypeScheduled,
+	"IMMEDIATE_EXECUTION":          ListJobExecutionsJobTypeImmediateExecution,
+	"SCHEDULED_EXECUTION":          ListJobExecutionsJobTypeScheduledExecution,
+	"SCHEDULED_EXECUTION_INSTANCE": ListJobExecutionsJobTypeScheduledExecutionInstance,
+}
+
+// GetListJobExecutionsJobTypeEnumValues Enumerates the set of values for ListJobExecutionsJobTypeEnum
+func GetListJobExecutionsJobTypeEnumValues() []ListJobExecutionsJobTypeEnum {
+	values := make([]ListJobExecutionsJobTypeEnum, 0)
+	for _, v := range mappingListJobExecutionsJobType {
+		values = append(values, v)
+	}
+	return values
 }
 
 // ListJobExecutionsFieldsEnum Enum with underlying type: string

--- a/datacatalog/list_job_logs_request_response.go
+++ b/datacatalog/list_job_logs_request_response.go
@@ -22,7 +22,7 @@ type ListJobLogsRequest struct {
 	JobExecutionKey *string `mandatory:"true" contributesTo:"path" name:"jobExecutionKey"`
 
 	// A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
-	LifecycleState LifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState ListJobLogsLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// Severity level for this Log.
 	Severity *string `mandatory:"false" contributesTo:"query" name:"severity"`
@@ -100,6 +100,41 @@ func (response ListJobLogsResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response ListJobLogsResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// ListJobLogsLifecycleStateEnum Enum with underlying type: string
+type ListJobLogsLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListJobLogsLifecycleStateEnum
+const (
+	ListJobLogsLifecycleStateCreating ListJobLogsLifecycleStateEnum = "CREATING"
+	ListJobLogsLifecycleStateActive   ListJobLogsLifecycleStateEnum = "ACTIVE"
+	ListJobLogsLifecycleStateInactive ListJobLogsLifecycleStateEnum = "INACTIVE"
+	ListJobLogsLifecycleStateUpdating ListJobLogsLifecycleStateEnum = "UPDATING"
+	ListJobLogsLifecycleStateDeleting ListJobLogsLifecycleStateEnum = "DELETING"
+	ListJobLogsLifecycleStateDeleted  ListJobLogsLifecycleStateEnum = "DELETED"
+	ListJobLogsLifecycleStateFailed   ListJobLogsLifecycleStateEnum = "FAILED"
+	ListJobLogsLifecycleStateMoving   ListJobLogsLifecycleStateEnum = "MOVING"
+)
+
+var mappingListJobLogsLifecycleState = map[string]ListJobLogsLifecycleStateEnum{
+	"CREATING": ListJobLogsLifecycleStateCreating,
+	"ACTIVE":   ListJobLogsLifecycleStateActive,
+	"INACTIVE": ListJobLogsLifecycleStateInactive,
+	"UPDATING": ListJobLogsLifecycleStateUpdating,
+	"DELETING": ListJobLogsLifecycleStateDeleting,
+	"DELETED":  ListJobLogsLifecycleStateDeleted,
+	"FAILED":   ListJobLogsLifecycleStateFailed,
+	"MOVING":   ListJobLogsLifecycleStateMoving,
+}
+
+// GetListJobLogsLifecycleStateEnumValues Enumerates the set of values for ListJobLogsLifecycleStateEnum
+func GetListJobLogsLifecycleStateEnumValues() []ListJobLogsLifecycleStateEnum {
+	values := make([]ListJobLogsLifecycleStateEnum, 0)
+	for _, v := range mappingListJobLogsLifecycleState {
+		values = append(values, v)
+	}
+	return values
 }
 
 // ListJobLogsFieldsEnum Enum with underlying type: string

--- a/datacatalog/list_jobs_request_response.go
+++ b/datacatalog/list_jobs_request_response.go
@@ -19,7 +19,7 @@ type ListJobsRequest struct {
 	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
 
 	// Job lifecycle state.
-	LifecycleState JobLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState ListJobsLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// Time that the resource was created. An RFC3339 (https://tools.ietf.org/html/rfc3339) formatted datetime string.
 	TimeCreated *common.SDKTime `mandatory:"false" contributesTo:"query" name:"timeCreated"`
@@ -34,7 +34,7 @@ type ListJobsRequest struct {
 	UpdatedById *string `mandatory:"false" contributesTo:"query" name:"updatedById"`
 
 	// Job type.
-	JobType JobTypeEnum `mandatory:"false" contributesTo:"query" name:"jobType" omitEmpty:"true"`
+	JobType ListJobsJobTypeEnum `mandatory:"false" contributesTo:"query" name:"jobType" omitEmpty:"true"`
 
 	// Unique job definition key.
 	JobDefinitionKey *string `mandatory:"false" contributesTo:"query" name:"jobDefinitionKey"`
@@ -51,7 +51,7 @@ type ListJobsRequest struct {
 	TimeScheduleEnd *common.SDKTime `mandatory:"false" contributesTo:"query" name:"timeScheduleEnd"`
 
 	// Type of the job schedule.
-	ScheduleType JobScheduleTypeEnum `mandatory:"false" contributesTo:"query" name:"scheduleType" omitEmpty:"true"`
+	ScheduleType ListJobsScheduleTypeEnum `mandatory:"false" contributesTo:"query" name:"scheduleType" omitEmpty:"true"`
 
 	// Unique connection key.
 	ConnectionKey *string `mandatory:"false" contributesTo:"query" name:"connectionKey"`
@@ -124,6 +124,99 @@ func (response ListJobsResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response ListJobsResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// ListJobsLifecycleStateEnum Enum with underlying type: string
+type ListJobsLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListJobsLifecycleStateEnum
+const (
+	ListJobsLifecycleStateActive   ListJobsLifecycleStateEnum = "ACTIVE"
+	ListJobsLifecycleStateInactive ListJobsLifecycleStateEnum = "INACTIVE"
+	ListJobsLifecycleStateExpired  ListJobsLifecycleStateEnum = "EXPIRED"
+)
+
+var mappingListJobsLifecycleState = map[string]ListJobsLifecycleStateEnum{
+	"ACTIVE":   ListJobsLifecycleStateActive,
+	"INACTIVE": ListJobsLifecycleStateInactive,
+	"EXPIRED":  ListJobsLifecycleStateExpired,
+}
+
+// GetListJobsLifecycleStateEnumValues Enumerates the set of values for ListJobsLifecycleStateEnum
+func GetListJobsLifecycleStateEnumValues() []ListJobsLifecycleStateEnum {
+	values := make([]ListJobsLifecycleStateEnum, 0)
+	for _, v := range mappingListJobsLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListJobsJobTypeEnum Enum with underlying type: string
+type ListJobsJobTypeEnum string
+
+// Set of constants representing the allowable values for ListJobsJobTypeEnum
+const (
+	ListJobsJobTypeHarvest                    ListJobsJobTypeEnum = "HARVEST"
+	ListJobsJobTypeProfiling                  ListJobsJobTypeEnum = "PROFILING"
+	ListJobsJobTypeSampling                   ListJobsJobTypeEnum = "SAMPLING"
+	ListJobsJobTypePreview                    ListJobsJobTypeEnum = "PREVIEW"
+	ListJobsJobTypeImport                     ListJobsJobTypeEnum = "IMPORT"
+	ListJobsJobTypeExport                     ListJobsJobTypeEnum = "EXPORT"
+	ListJobsJobTypeInternal                   ListJobsJobTypeEnum = "INTERNAL"
+	ListJobsJobTypePurge                      ListJobsJobTypeEnum = "PURGE"
+	ListJobsJobTypeImmediate                  ListJobsJobTypeEnum = "IMMEDIATE"
+	ListJobsJobTypeScheduled                  ListJobsJobTypeEnum = "SCHEDULED"
+	ListJobsJobTypeImmediateExecution         ListJobsJobTypeEnum = "IMMEDIATE_EXECUTION"
+	ListJobsJobTypeScheduledExecution         ListJobsJobTypeEnum = "SCHEDULED_EXECUTION"
+	ListJobsJobTypeScheduledExecutionInstance ListJobsJobTypeEnum = "SCHEDULED_EXECUTION_INSTANCE"
+)
+
+var mappingListJobsJobType = map[string]ListJobsJobTypeEnum{
+	"HARVEST":                      ListJobsJobTypeHarvest,
+	"PROFILING":                    ListJobsJobTypeProfiling,
+	"SAMPLING":                     ListJobsJobTypeSampling,
+	"PREVIEW":                      ListJobsJobTypePreview,
+	"IMPORT":                       ListJobsJobTypeImport,
+	"EXPORT":                       ListJobsJobTypeExport,
+	"INTERNAL":                     ListJobsJobTypeInternal,
+	"PURGE":                        ListJobsJobTypePurge,
+	"IMMEDIATE":                    ListJobsJobTypeImmediate,
+	"SCHEDULED":                    ListJobsJobTypeScheduled,
+	"IMMEDIATE_EXECUTION":          ListJobsJobTypeImmediateExecution,
+	"SCHEDULED_EXECUTION":          ListJobsJobTypeScheduledExecution,
+	"SCHEDULED_EXECUTION_INSTANCE": ListJobsJobTypeScheduledExecutionInstance,
+}
+
+// GetListJobsJobTypeEnumValues Enumerates the set of values for ListJobsJobTypeEnum
+func GetListJobsJobTypeEnumValues() []ListJobsJobTypeEnum {
+	values := make([]ListJobsJobTypeEnum, 0)
+	for _, v := range mappingListJobsJobType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListJobsScheduleTypeEnum Enum with underlying type: string
+type ListJobsScheduleTypeEnum string
+
+// Set of constants representing the allowable values for ListJobsScheduleTypeEnum
+const (
+	ListJobsScheduleTypeScheduled ListJobsScheduleTypeEnum = "SCHEDULED"
+	ListJobsScheduleTypeImmediate ListJobsScheduleTypeEnum = "IMMEDIATE"
+)
+
+var mappingListJobsScheduleType = map[string]ListJobsScheduleTypeEnum{
+	"SCHEDULED": ListJobsScheduleTypeScheduled,
+	"IMMEDIATE": ListJobsScheduleTypeImmediate,
+}
+
+// GetListJobsScheduleTypeEnumValues Enumerates the set of values for ListJobsScheduleTypeEnum
+func GetListJobsScheduleTypeEnumValues() []ListJobsScheduleTypeEnum {
+	values := make([]ListJobsScheduleTypeEnum, 0)
+	for _, v := range mappingListJobsScheduleType {
+		values = append(values, v)
+	}
+	return values
 }
 
 // ListJobsFieldsEnum Enum with underlying type: string

--- a/datacatalog/list_tags_request_response.go
+++ b/datacatalog/list_tags_request_response.go
@@ -19,7 +19,7 @@ type ListTagsRequest struct {
 	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
 
 	// A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
-	LifecycleState LifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState ListTagsLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// Specifies the fields to return in a term summary response.
 	Fields []ListTagsFieldsEnum `contributesTo:"query" name:"fields" omitEmpty:"true" collectionFormat:"multi"`
@@ -82,6 +82,41 @@ func (response ListTagsResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response ListTagsResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// ListTagsLifecycleStateEnum Enum with underlying type: string
+type ListTagsLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListTagsLifecycleStateEnum
+const (
+	ListTagsLifecycleStateCreating ListTagsLifecycleStateEnum = "CREATING"
+	ListTagsLifecycleStateActive   ListTagsLifecycleStateEnum = "ACTIVE"
+	ListTagsLifecycleStateInactive ListTagsLifecycleStateEnum = "INACTIVE"
+	ListTagsLifecycleStateUpdating ListTagsLifecycleStateEnum = "UPDATING"
+	ListTagsLifecycleStateDeleting ListTagsLifecycleStateEnum = "DELETING"
+	ListTagsLifecycleStateDeleted  ListTagsLifecycleStateEnum = "DELETED"
+	ListTagsLifecycleStateFailed   ListTagsLifecycleStateEnum = "FAILED"
+	ListTagsLifecycleStateMoving   ListTagsLifecycleStateEnum = "MOVING"
+)
+
+var mappingListTagsLifecycleState = map[string]ListTagsLifecycleStateEnum{
+	"CREATING": ListTagsLifecycleStateCreating,
+	"ACTIVE":   ListTagsLifecycleStateActive,
+	"INACTIVE": ListTagsLifecycleStateInactive,
+	"UPDATING": ListTagsLifecycleStateUpdating,
+	"DELETING": ListTagsLifecycleStateDeleting,
+	"DELETED":  ListTagsLifecycleStateDeleted,
+	"FAILED":   ListTagsLifecycleStateFailed,
+	"MOVING":   ListTagsLifecycleStateMoving,
+}
+
+// GetListTagsLifecycleStateEnumValues Enumerates the set of values for ListTagsLifecycleStateEnum
+func GetListTagsLifecycleStateEnumValues() []ListTagsLifecycleStateEnum {
+	values := make([]ListTagsLifecycleStateEnum, 0)
+	for _, v := range mappingListTagsLifecycleState {
+		values = append(values, v)
+	}
+	return values
 }
 
 // ListTagsFieldsEnum Enum with underlying type: string

--- a/datacatalog/list_term_relationships_request_response.go
+++ b/datacatalog/list_term_relationships_request_response.go
@@ -25,7 +25,7 @@ type ListTermRelationshipsRequest struct {
 	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
 
 	// A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
-	LifecycleState LifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState ListTermRelationshipsLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// Specifies the fields to return in a term relationship summary response.
 	Fields []ListTermRelationshipsFieldsEnum `contributesTo:"query" name:"fields" omitEmpty:"true" collectionFormat:"multi"`
@@ -88,6 +88,41 @@ func (response ListTermRelationshipsResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response ListTermRelationshipsResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// ListTermRelationshipsLifecycleStateEnum Enum with underlying type: string
+type ListTermRelationshipsLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListTermRelationshipsLifecycleStateEnum
+const (
+	ListTermRelationshipsLifecycleStateCreating ListTermRelationshipsLifecycleStateEnum = "CREATING"
+	ListTermRelationshipsLifecycleStateActive   ListTermRelationshipsLifecycleStateEnum = "ACTIVE"
+	ListTermRelationshipsLifecycleStateInactive ListTermRelationshipsLifecycleStateEnum = "INACTIVE"
+	ListTermRelationshipsLifecycleStateUpdating ListTermRelationshipsLifecycleStateEnum = "UPDATING"
+	ListTermRelationshipsLifecycleStateDeleting ListTermRelationshipsLifecycleStateEnum = "DELETING"
+	ListTermRelationshipsLifecycleStateDeleted  ListTermRelationshipsLifecycleStateEnum = "DELETED"
+	ListTermRelationshipsLifecycleStateFailed   ListTermRelationshipsLifecycleStateEnum = "FAILED"
+	ListTermRelationshipsLifecycleStateMoving   ListTermRelationshipsLifecycleStateEnum = "MOVING"
+)
+
+var mappingListTermRelationshipsLifecycleState = map[string]ListTermRelationshipsLifecycleStateEnum{
+	"CREATING": ListTermRelationshipsLifecycleStateCreating,
+	"ACTIVE":   ListTermRelationshipsLifecycleStateActive,
+	"INACTIVE": ListTermRelationshipsLifecycleStateInactive,
+	"UPDATING": ListTermRelationshipsLifecycleStateUpdating,
+	"DELETING": ListTermRelationshipsLifecycleStateDeleting,
+	"DELETED":  ListTermRelationshipsLifecycleStateDeleted,
+	"FAILED":   ListTermRelationshipsLifecycleStateFailed,
+	"MOVING":   ListTermRelationshipsLifecycleStateMoving,
+}
+
+// GetListTermRelationshipsLifecycleStateEnumValues Enumerates the set of values for ListTermRelationshipsLifecycleStateEnum
+func GetListTermRelationshipsLifecycleStateEnumValues() []ListTermRelationshipsLifecycleStateEnum {
+	values := make([]ListTermRelationshipsLifecycleStateEnum, 0)
+	for _, v := range mappingListTermRelationshipsLifecycleState {
+		values = append(values, v)
+	}
+	return values
 }
 
 // ListTermRelationshipsFieldsEnum Enum with underlying type: string

--- a/datacatalog/list_terms_request_response.go
+++ b/datacatalog/list_terms_request_response.go
@@ -22,7 +22,7 @@ type ListTermsRequest struct {
 	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
 
 	// A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
-	LifecycleState LifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState ListTermsLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// Unique key of the parent term.
 	ParentTermKey *string `mandatory:"false" contributesTo:"query" name:"parentTermKey"`
@@ -31,7 +31,7 @@ type ListTermsRequest struct {
 	IsAllowedToHaveChildTerms *bool `mandatory:"false" contributesTo:"query" name:"isAllowedToHaveChildTerms"`
 
 	// Status of the approval workflow for this business term in the glossary.
-	WorkflowStatus TermWorkflowStatusEnum `mandatory:"false" contributesTo:"query" name:"workflowStatus" omitEmpty:"true"`
+	WorkflowStatus ListTermsWorkflowStatusEnum `mandatory:"false" contributesTo:"query" name:"workflowStatus" omitEmpty:"true"`
 
 	// Full path of the resource for resources that support paths.
 	Path *string `mandatory:"false" contributesTo:"query" name:"path"`
@@ -97,6 +97,68 @@ func (response ListTermsResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response ListTermsResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// ListTermsLifecycleStateEnum Enum with underlying type: string
+type ListTermsLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListTermsLifecycleStateEnum
+const (
+	ListTermsLifecycleStateCreating ListTermsLifecycleStateEnum = "CREATING"
+	ListTermsLifecycleStateActive   ListTermsLifecycleStateEnum = "ACTIVE"
+	ListTermsLifecycleStateInactive ListTermsLifecycleStateEnum = "INACTIVE"
+	ListTermsLifecycleStateUpdating ListTermsLifecycleStateEnum = "UPDATING"
+	ListTermsLifecycleStateDeleting ListTermsLifecycleStateEnum = "DELETING"
+	ListTermsLifecycleStateDeleted  ListTermsLifecycleStateEnum = "DELETED"
+	ListTermsLifecycleStateFailed   ListTermsLifecycleStateEnum = "FAILED"
+	ListTermsLifecycleStateMoving   ListTermsLifecycleStateEnum = "MOVING"
+)
+
+var mappingListTermsLifecycleState = map[string]ListTermsLifecycleStateEnum{
+	"CREATING": ListTermsLifecycleStateCreating,
+	"ACTIVE":   ListTermsLifecycleStateActive,
+	"INACTIVE": ListTermsLifecycleStateInactive,
+	"UPDATING": ListTermsLifecycleStateUpdating,
+	"DELETING": ListTermsLifecycleStateDeleting,
+	"DELETED":  ListTermsLifecycleStateDeleted,
+	"FAILED":   ListTermsLifecycleStateFailed,
+	"MOVING":   ListTermsLifecycleStateMoving,
+}
+
+// GetListTermsLifecycleStateEnumValues Enumerates the set of values for ListTermsLifecycleStateEnum
+func GetListTermsLifecycleStateEnumValues() []ListTermsLifecycleStateEnum {
+	values := make([]ListTermsLifecycleStateEnum, 0)
+	for _, v := range mappingListTermsLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListTermsWorkflowStatusEnum Enum with underlying type: string
+type ListTermsWorkflowStatusEnum string
+
+// Set of constants representing the allowable values for ListTermsWorkflowStatusEnum
+const (
+	ListTermsWorkflowStatusNew         ListTermsWorkflowStatusEnum = "NEW"
+	ListTermsWorkflowStatusApproved    ListTermsWorkflowStatusEnum = "APPROVED"
+	ListTermsWorkflowStatusUnderReview ListTermsWorkflowStatusEnum = "UNDER_REVIEW"
+	ListTermsWorkflowStatusEscalated   ListTermsWorkflowStatusEnum = "ESCALATED"
+)
+
+var mappingListTermsWorkflowStatus = map[string]ListTermsWorkflowStatusEnum{
+	"NEW":          ListTermsWorkflowStatusNew,
+	"APPROVED":     ListTermsWorkflowStatusApproved,
+	"UNDER_REVIEW": ListTermsWorkflowStatusUnderReview,
+	"ESCALATED":    ListTermsWorkflowStatusEscalated,
+}
+
+// GetListTermsWorkflowStatusEnumValues Enumerates the set of values for ListTermsWorkflowStatusEnum
+func GetListTermsWorkflowStatusEnumValues() []ListTermsWorkflowStatusEnum {
+	values := make([]ListTermsWorkflowStatusEnum, 0)
+	for _, v := range mappingListTermsWorkflowStatus {
+		values = append(values, v)
+	}
+	return values
 }
 
 // ListTermsFieldsEnum Enum with underlying type: string

--- a/datacatalog/list_types_request_response.go
+++ b/datacatalog/list_types_request_response.go
@@ -19,7 +19,7 @@ type ListTypesRequest struct {
 	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
 
 	// A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
-	LifecycleState LifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState ListTypesLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// Indicates whether the type is internal, making it unavailable for use by metadata elements.
 	IsInternal *string `mandatory:"false" contributesTo:"query" name:"isInternal"`
@@ -97,6 +97,41 @@ func (response ListTypesResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response ListTypesResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// ListTypesLifecycleStateEnum Enum with underlying type: string
+type ListTypesLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListTypesLifecycleStateEnum
+const (
+	ListTypesLifecycleStateCreating ListTypesLifecycleStateEnum = "CREATING"
+	ListTypesLifecycleStateActive   ListTypesLifecycleStateEnum = "ACTIVE"
+	ListTypesLifecycleStateInactive ListTypesLifecycleStateEnum = "INACTIVE"
+	ListTypesLifecycleStateUpdating ListTypesLifecycleStateEnum = "UPDATING"
+	ListTypesLifecycleStateDeleting ListTypesLifecycleStateEnum = "DELETING"
+	ListTypesLifecycleStateDeleted  ListTypesLifecycleStateEnum = "DELETED"
+	ListTypesLifecycleStateFailed   ListTypesLifecycleStateEnum = "FAILED"
+	ListTypesLifecycleStateMoving   ListTypesLifecycleStateEnum = "MOVING"
+)
+
+var mappingListTypesLifecycleState = map[string]ListTypesLifecycleStateEnum{
+	"CREATING": ListTypesLifecycleStateCreating,
+	"ACTIVE":   ListTypesLifecycleStateActive,
+	"INACTIVE": ListTypesLifecycleStateInactive,
+	"UPDATING": ListTypesLifecycleStateUpdating,
+	"DELETING": ListTypesLifecycleStateDeleting,
+	"DELETED":  ListTypesLifecycleStateDeleted,
+	"FAILED":   ListTypesLifecycleStateFailed,
+	"MOVING":   ListTypesLifecycleStateMoving,
+}
+
+// GetListTypesLifecycleStateEnumValues Enumerates the set of values for ListTypesLifecycleStateEnum
+func GetListTypesLifecycleStateEnumValues() []ListTypesLifecycleStateEnum {
+	values := make([]ListTypesLifecycleStateEnum, 0)
+	for _, v := range mappingListTypesLifecycleState {
+		values = append(values, v)
+	}
+	return values
 }
 
 // ListTypesFieldsEnum Enum with underlying type: string

--- a/datacatalog/search_criteria_request_response.go
+++ b/datacatalog/search_criteria_request_response.go
@@ -25,7 +25,7 @@ type SearchCriteriaRequest struct {
 	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
 
 	// A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
-	LifecycleState LifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+	LifecycleState SearchCriteriaLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
 	// A search timeout string (for example, timeout=4000ms), bounding the search request to be executed within the
 	// specified time value and bail with the hits accumulated up to that point when expired.
@@ -90,6 +90,41 @@ func (response SearchCriteriaResponse) String() string {
 // HTTPResponse implements the OCIResponse interface
 func (response SearchCriteriaResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
+}
+
+// SearchCriteriaLifecycleStateEnum Enum with underlying type: string
+type SearchCriteriaLifecycleStateEnum string
+
+// Set of constants representing the allowable values for SearchCriteriaLifecycleStateEnum
+const (
+	SearchCriteriaLifecycleStateCreating SearchCriteriaLifecycleStateEnum = "CREATING"
+	SearchCriteriaLifecycleStateActive   SearchCriteriaLifecycleStateEnum = "ACTIVE"
+	SearchCriteriaLifecycleStateInactive SearchCriteriaLifecycleStateEnum = "INACTIVE"
+	SearchCriteriaLifecycleStateUpdating SearchCriteriaLifecycleStateEnum = "UPDATING"
+	SearchCriteriaLifecycleStateDeleting SearchCriteriaLifecycleStateEnum = "DELETING"
+	SearchCriteriaLifecycleStateDeleted  SearchCriteriaLifecycleStateEnum = "DELETED"
+	SearchCriteriaLifecycleStateFailed   SearchCriteriaLifecycleStateEnum = "FAILED"
+	SearchCriteriaLifecycleStateMoving   SearchCriteriaLifecycleStateEnum = "MOVING"
+)
+
+var mappingSearchCriteriaLifecycleState = map[string]SearchCriteriaLifecycleStateEnum{
+	"CREATING": SearchCriteriaLifecycleStateCreating,
+	"ACTIVE":   SearchCriteriaLifecycleStateActive,
+	"INACTIVE": SearchCriteriaLifecycleStateInactive,
+	"UPDATING": SearchCriteriaLifecycleStateUpdating,
+	"DELETING": SearchCriteriaLifecycleStateDeleting,
+	"DELETED":  SearchCriteriaLifecycleStateDeleted,
+	"FAILED":   SearchCriteriaLifecycleStateFailed,
+	"MOVING":   SearchCriteriaLifecycleStateMoving,
+}
+
+// GetSearchCriteriaLifecycleStateEnumValues Enumerates the set of values for SearchCriteriaLifecycleStateEnum
+func GetSearchCriteriaLifecycleStateEnumValues() []SearchCriteriaLifecycleStateEnum {
+	values := make([]SearchCriteriaLifecycleStateEnum, 0)
+	for _, v := range mappingSearchCriteriaLifecycleState {
+		values = append(values, v)
+	}
+	return values
 }
 
 // SearchCriteriaSortByEnum Enum with underlying type: string

--- a/datacatalog/update_catalog_details.go
+++ b/datacatalog/update_catalog_details.go
@@ -13,7 +13,7 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// UpdateCatalogDetails The information to be updated.
+// UpdateCatalogDetails The information to be updated for catalog resource.
 type UpdateCatalogDetails struct {
 
 	// Data catalog identifier.

--- a/datacatalog/update_catalog_private_endpoint_details.go
+++ b/datacatalog/update_catalog_private_endpoint_details.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Catalog API
+//
+// Use the Data Catalog APIs to collect, organize, find, access, understand, enrich, and activate technical, business, and operational metadata.
+//
+
+package datacatalog
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateCatalogPrivateEndpointDetails Information about the modified private endpoint resource
+type UpdateCatalogPrivateEndpointDetails struct {
+
+	// List of DNS zones to be used by the data assets to be harvested.
+	// Example: custpvtsubnet.oraclevcn.com for data asset: db.custpvtsubnet.oraclevcn.com
+	DnsZones []string `mandatory:"false" json:"dnsZones"`
+
+	// Simple key-value pair that is applied without any predefined name, type, or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Display name of the private endpoint resource.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+}
+
+func (m UpdateCatalogPrivateEndpointDetails) String() string {
+	return common.PointerString(m)
+}

--- a/datacatalog/update_catalog_private_endpoint_request_response.go
+++ b/datacatalog/update_catalog_private_endpoint_request_response.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package datacatalog
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateCatalogPrivateEndpointRequest wrapper for the UpdateCatalogPrivateEndpoint operation
+type UpdateCatalogPrivateEndpointRequest struct {
+
+	// Unique private reverse connection identifier.
+	CatalogPrivateEndpointId *string `mandatory:"true" contributesTo:"path" name:"catalogPrivateEndpointId"`
+
+	// The information to be updated in private reverse connection
+	UpdateCatalogPrivateEndpointDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call
+	// for a resource, set the `if-match` parameter to the value of the
+	// etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you
+	// provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateCatalogPrivateEndpointRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateCatalogPrivateEndpointRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateCatalogPrivateEndpointRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateCatalogPrivateEndpointResponse wrapper for the UpdateCatalogPrivateEndpoint operation
+type UpdateCatalogPrivateEndpointResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// The OCID of the asynchronous request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest) with this OCID to track the status of the asynchronous request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+}
+
+func (response UpdateCatalogPrivateEndpointResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateCatalogPrivateEndpointResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/datacatalog/work_request.go
+++ b/datacatalog/work_request.go
@@ -58,17 +58,29 @@ type WorkRequestOperationTypeEnum string
 
 // Set of constants representing the allowable values for WorkRequestOperationTypeEnum
 const (
-	WorkRequestOperationTypeCreateCatalog WorkRequestOperationTypeEnum = "CREATE_CATALOG"
-	WorkRequestOperationTypeUpdateCatalog WorkRequestOperationTypeEnum = "UPDATE_CATALOG"
-	WorkRequestOperationTypeDeleteCatalog WorkRequestOperationTypeEnum = "DELETE_CATALOG"
-	WorkRequestOperationTypeMoveCatalog   WorkRequestOperationTypeEnum = "MOVE_CATALOG"
+	WorkRequestOperationTypeCreateCatalog                WorkRequestOperationTypeEnum = "CREATE_CATALOG"
+	WorkRequestOperationTypeUpdateCatalog                WorkRequestOperationTypeEnum = "UPDATE_CATALOG"
+	WorkRequestOperationTypeDeleteCatalog                WorkRequestOperationTypeEnum = "DELETE_CATALOG"
+	WorkRequestOperationTypeMoveCatalog                  WorkRequestOperationTypeEnum = "MOVE_CATALOG"
+	WorkRequestOperationTypeCreateCatalogPrivateEndpoint WorkRequestOperationTypeEnum = "CREATE_CATALOG_PRIVATE_ENDPOINT"
+	WorkRequestOperationTypeDeleteCatalogPrivateEndpoint WorkRequestOperationTypeEnum = "DELETE_CATALOG_PRIVATE_ENDPOINT"
+	WorkRequestOperationTypeUpdateCatalogPrivateEndpoint WorkRequestOperationTypeEnum = "UPDATE_CATALOG_PRIVATE_ENDPOINT"
+	WorkRequestOperationTypeMoveCatalogPrivateEndpoint   WorkRequestOperationTypeEnum = "MOVE_CATALOG_PRIVATE_ENDPOINT"
+	WorkRequestOperationTypeAttachCatalogPrivateEndpoint WorkRequestOperationTypeEnum = "ATTACH_CATALOG_PRIVATE_ENDPOINT"
+	WorkRequestOperationTypeDetachCatalogPrivateEndpoint WorkRequestOperationTypeEnum = "DETACH_CATALOG_PRIVATE_ENDPOINT"
 )
 
 var mappingWorkRequestOperationType = map[string]WorkRequestOperationTypeEnum{
-	"CREATE_CATALOG": WorkRequestOperationTypeCreateCatalog,
-	"UPDATE_CATALOG": WorkRequestOperationTypeUpdateCatalog,
-	"DELETE_CATALOG": WorkRequestOperationTypeDeleteCatalog,
-	"MOVE_CATALOG":   WorkRequestOperationTypeMoveCatalog,
+	"CREATE_CATALOG":                  WorkRequestOperationTypeCreateCatalog,
+	"UPDATE_CATALOG":                  WorkRequestOperationTypeUpdateCatalog,
+	"DELETE_CATALOG":                  WorkRequestOperationTypeDeleteCatalog,
+	"MOVE_CATALOG":                    WorkRequestOperationTypeMoveCatalog,
+	"CREATE_CATALOG_PRIVATE_ENDPOINT": WorkRequestOperationTypeCreateCatalogPrivateEndpoint,
+	"DELETE_CATALOG_PRIVATE_ENDPOINT": WorkRequestOperationTypeDeleteCatalogPrivateEndpoint,
+	"UPDATE_CATALOG_PRIVATE_ENDPOINT": WorkRequestOperationTypeUpdateCatalogPrivateEndpoint,
+	"MOVE_CATALOG_PRIVATE_ENDPOINT":   WorkRequestOperationTypeMoveCatalogPrivateEndpoint,
+	"ATTACH_CATALOG_PRIVATE_ENDPOINT": WorkRequestOperationTypeAttachCatalogPrivateEndpoint,
+	"DETACH_CATALOG_PRIVATE_ENDPOINT": WorkRequestOperationTypeDetachCatalogPrivateEndpoint,
 }
 
 // GetWorkRequestOperationTypeEnumValues Enumerates the set of values for WorkRequestOperationTypeEnum

--- a/dataflow/application.go
+++ b/dataflow/application.go
@@ -58,6 +58,10 @@ type Application struct {
 	// Example: `2018-04-03T21:10:29.600Z`
 	TimeUpdated *common.SDKTime `mandatory:"true" json:"timeUpdated"`
 
+	// An Oracle Cloud Infrastructure URI of an archive (zip) file that may used to support the execution of the application.
+	// See https://docs.cloud.oracle.com/iaas/Content/API/SDKDocs/hdfsconnector.htm#uriformat
+	ArchiveUri *string `mandatory:"false" json:"archiveUri"`
+
 	// The arguments passed to the running application as command line arguments.  An argument is
 	// either a plain text or a placeholder. Placeholders are replaced using values from the parameters
 	// map.  Each placeholder specified must be represented in the parameters map else the request

--- a/dataflow/create_application_details.go
+++ b/dataflow/create_application_details.go
@@ -41,6 +41,10 @@ type CreateApplicationDetails struct {
 	// The Spark version utilized to run the application.
 	SparkVersion *string `mandatory:"true" json:"sparkVersion"`
 
+	// An Oracle Cloud Infrastructure URI of an archive (zip) file that may used to support the execution of the application.
+	// See https://docs.cloud.oracle.com/iaas/Content/API/SDKDocs/hdfsconnector.htm#uriformat
+	ArchiveUri *string `mandatory:"false" json:"archiveUri"`
+
 	// The arguments passed to the running application as command line arguments.  An argument is
 	// either a plain text or a placeholder. Placeholders are replaced using values from the parameters
 	// map.  Each placeholder specified must be represented in the parameters map else the request

--- a/dataflow/run.go
+++ b/dataflow/run.go
@@ -55,6 +55,10 @@ type Run struct {
 	// Example: `2018-04-03T21:10:29.600Z`
 	TimeUpdated *common.SDKTime `mandatory:"true" json:"timeUpdated"`
 
+	// An Oracle Cloud Infrastructure URI of an archive (zip) file that may used to support the execution of the application.
+	// See https://docs.cloud.oracle.com/iaas/Content/API/SDKDocs/hdfsconnector.htm#uriformat
+	ArchiveUri *string `mandatory:"false" json:"archiveUri"`
+
 	// The arguments passed to the running application as command line arguments.  An argument is
 	// either a plain text or a placeholder. Placeholders are replaced using values from the parameters
 	// map.  Each placeholder specified must be represented in the parameters map else the request

--- a/dataflow/update_application_details.go
+++ b/dataflow/update_application_details.go
@@ -29,6 +29,10 @@ type UpdateApplicationDetails struct {
 	// The Spark language.
 	Language ApplicationLanguageEnum `mandatory:"false" json:"language,omitempty"`
 
+	// An Oracle Cloud Infrastructure URI of an archive (zip) file that may used to support the execution of the application.
+	// See https://docs.cloud.oracle.com/iaas/Content/API/SDKDocs/hdfsconnector.htm#uriformat
+	ArchiveUri *string `mandatory:"false" json:"archiveUri"`
+
 	// The arguments passed to the running application as command line arguments.  An argument is
 	// either a plain text or a placeholder. Placeholders are replaced using values from the parameters
 	// map.  Each placeholder specified must be represented in the parameters map else the request

--- a/dataintegration/abstract_data_operation_config.go
+++ b/dataintegration/abstract_data_operation_config.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// AbstractDataOperationConfig The information about the data operation.
+type AbstractDataOperationConfig interface {
+}
+
+type abstractdataoperationconfig struct {
+	JsonData  []byte
+	ModelType string `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *abstractdataoperationconfig) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerabstractdataoperationconfig abstractdataoperationconfig
+	s := struct {
+		Model Unmarshalerabstractdataoperationconfig
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *abstractdataoperationconfig) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "WRITE_OPERATION_CONFIG":
+		mm := WriteOperationConfig{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "READ_OPERATION_CONFIG":
+		mm := ReadOperationConfig{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m abstractdataoperationconfig) String() string {
+	return common.PointerString(m)
+}
+
+// AbstractDataOperationConfigModelTypeEnum Enum with underlying type: string
+type AbstractDataOperationConfigModelTypeEnum string
+
+// Set of constants representing the allowable values for AbstractDataOperationConfigModelTypeEnum
+const (
+	AbstractDataOperationConfigModelTypeReadOperationConfig  AbstractDataOperationConfigModelTypeEnum = "READ_OPERATION_CONFIG"
+	AbstractDataOperationConfigModelTypeWriteOperationConfig AbstractDataOperationConfigModelTypeEnum = "WRITE_OPERATION_CONFIG"
+)
+
+var mappingAbstractDataOperationConfigModelType = map[string]AbstractDataOperationConfigModelTypeEnum{
+	"READ_OPERATION_CONFIG":  AbstractDataOperationConfigModelTypeReadOperationConfig,
+	"WRITE_OPERATION_CONFIG": AbstractDataOperationConfigModelTypeWriteOperationConfig,
+}
+
+// GetAbstractDataOperationConfigModelTypeEnumValues Enumerates the set of values for AbstractDataOperationConfigModelTypeEnum
+func GetAbstractDataOperationConfigModelTypeEnumValues() []AbstractDataOperationConfigModelTypeEnum {
+	values := make([]AbstractDataOperationConfigModelTypeEnum, 0)
+	for _, v := range mappingAbstractDataOperationConfigModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/abstract_field.go
+++ b/dataintegration/abstract_field.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// AbstractField The type representing the abstract field concept.
+type AbstractField struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+}
+
+//GetKey returns Key
+func (m AbstractField) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m AbstractField) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m AbstractField) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetConfigValues returns ConfigValues
+func (m AbstractField) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m AbstractField) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetName returns Name
+func (m AbstractField) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m AbstractField) GetDescription() *string {
+	return m.Description
+}
+
+func (m AbstractField) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m AbstractField) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeAbstractField AbstractField
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeAbstractField
+	}{
+		"FIELD",
+		(MarshalTypeAbstractField)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/abstract_format_attribute.go
+++ b/dataintegration/abstract_format_attribute.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// AbstractFormatAttribute The abstract format attribute.
+type AbstractFormatAttribute interface {
+}
+
+type abstractformatattribute struct {
+	JsonData  []byte
+	ModelType string `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *abstractformatattribute) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerabstractformatattribute abstractformatattribute
+	s := struct {
+		Model Unmarshalerabstractformatattribute
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *abstractformatattribute) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "JSON_FORMAT":
+		mm := JsonFormatAttribute{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "CSV_FORMAT":
+		mm := CsvFormatAttribute{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m abstractformatattribute) String() string {
+	return common.PointerString(m)
+}
+
+// AbstractFormatAttributeModelTypeEnum Enum with underlying type: string
+type AbstractFormatAttributeModelTypeEnum string
+
+// Set of constants representing the allowable values for AbstractFormatAttributeModelTypeEnum
+const (
+	AbstractFormatAttributeModelTypeJsonFormat AbstractFormatAttributeModelTypeEnum = "JSON_FORMAT"
+	AbstractFormatAttributeModelTypeCsvFormat  AbstractFormatAttributeModelTypeEnum = "CSV_FORMAT"
+)
+
+var mappingAbstractFormatAttributeModelType = map[string]AbstractFormatAttributeModelTypeEnum{
+	"JSON_FORMAT": AbstractFormatAttributeModelTypeJsonFormat,
+	"CSV_FORMAT":  AbstractFormatAttributeModelTypeCsvFormat,
+}
+
+// GetAbstractFormatAttributeModelTypeEnumValues Enumerates the set of values for AbstractFormatAttributeModelTypeEnum
+func GetAbstractFormatAttributeModelTypeEnumValues() []AbstractFormatAttributeModelTypeEnum {
+	values := make([]AbstractFormatAttributeModelTypeEnum, 0)
+	for _, v := range mappingAbstractFormatAttributeModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/abstract_read_attribute.go
+++ b/dataintegration/abstract_read_attribute.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// AbstractReadAttribute The abstract read attribute.
+type AbstractReadAttribute interface {
+}
+
+type abstractreadattribute struct {
+	JsonData  []byte
+	ModelType string `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *abstractreadattribute) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerabstractreadattribute abstractreadattribute
+	s := struct {
+		Model Unmarshalerabstractreadattribute
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *abstractreadattribute) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "ORACLEREADATTRIBUTE":
+		mm := OracleReadAttribute{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m abstractreadattribute) String() string {
+	return common.PointerString(m)
+}
+
+// AbstractReadAttributeModelTypeEnum Enum with underlying type: string
+type AbstractReadAttributeModelTypeEnum string
+
+// Set of constants representing the allowable values for AbstractReadAttributeModelTypeEnum
+const (
+	AbstractReadAttributeModelTypeOraclereadattribute AbstractReadAttributeModelTypeEnum = "ORACLEREADATTRIBUTE"
+)
+
+var mappingAbstractReadAttributeModelType = map[string]AbstractReadAttributeModelTypeEnum{
+	"ORACLEREADATTRIBUTE": AbstractReadAttributeModelTypeOraclereadattribute,
+}
+
+// GetAbstractReadAttributeModelTypeEnumValues Enumerates the set of values for AbstractReadAttributeModelTypeEnum
+func GetAbstractReadAttributeModelTypeEnumValues() []AbstractReadAttributeModelTypeEnum {
+	values := make([]AbstractReadAttributeModelTypeEnum, 0)
+	for _, v := range mappingAbstractReadAttributeModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/abstract_write_attribute.go
+++ b/dataintegration/abstract_write_attribute.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// AbstractWriteAttribute The abstract write attribute.
+type AbstractWriteAttribute interface {
+}
+
+type abstractwriteattribute struct {
+	JsonData  []byte
+	ModelType string `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *abstractwriteattribute) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerabstractwriteattribute abstractwriteattribute
+	s := struct {
+		Model Unmarshalerabstractwriteattribute
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *abstractwriteattribute) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "ORACLEADWCWRITEATTRIBUTE":
+		mm := OracleAdwcWriteAttribute{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLEWRITEATTRIBUTE":
+		mm := OracleWriteAttribute{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLEATPWRITEATTRIBUTE":
+		mm := OracleAtpWriteAttribute{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m abstractwriteattribute) String() string {
+	return common.PointerString(m)
+}
+
+// AbstractWriteAttributeModelTypeEnum Enum with underlying type: string
+type AbstractWriteAttributeModelTypeEnum string
+
+// Set of constants representing the allowable values for AbstractWriteAttributeModelTypeEnum
+const (
+	AbstractWriteAttributeModelTypeOraclewriteattribute     AbstractWriteAttributeModelTypeEnum = "ORACLEWRITEATTRIBUTE"
+	AbstractWriteAttributeModelTypeOracleatpwriteattribute  AbstractWriteAttributeModelTypeEnum = "ORACLEATPWRITEATTRIBUTE"
+	AbstractWriteAttributeModelTypeOracleadwcwriteattribute AbstractWriteAttributeModelTypeEnum = "ORACLEADWCWRITEATTRIBUTE"
+)
+
+var mappingAbstractWriteAttributeModelType = map[string]AbstractWriteAttributeModelTypeEnum{
+	"ORACLEWRITEATTRIBUTE":     AbstractWriteAttributeModelTypeOraclewriteattribute,
+	"ORACLEATPWRITEATTRIBUTE":  AbstractWriteAttributeModelTypeOracleatpwriteattribute,
+	"ORACLEADWCWRITEATTRIBUTE": AbstractWriteAttributeModelTypeOracleadwcwriteattribute,
+}
+
+// GetAbstractWriteAttributeModelTypeEnumValues Enumerates the set of values for AbstractWriteAttributeModelTypeEnum
+func GetAbstractWriteAttributeModelTypeEnumValues() []AbstractWriteAttributeModelTypeEnum {
+	values := make([]AbstractWriteAttributeModelTypeEnum, 0)
+	for _, v := range mappingAbstractWriteAttributeModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/aggregator.go
+++ b/dataintegration/aggregator.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Aggregator The information about the aggregator operator. The aggregate operator performs calculations, like sum or count, on all rows or a group of rows to create new, derivative attributes.
+type Aggregator struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+
+	GroupByColumns *DynamicProxyField `mandatory:"false" json:"groupByColumns"`
+}
+
+//GetKey returns Key
+func (m Aggregator) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m Aggregator) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m Aggregator) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m Aggregator) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m Aggregator) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m Aggregator) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetInputPorts returns InputPorts
+func (m Aggregator) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m Aggregator) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m Aggregator) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m Aggregator) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetParameters returns Parameters
+func (m Aggregator) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m Aggregator) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+func (m Aggregator) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m Aggregator) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeAggregator Aggregator
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeAggregator
+	}{
+		"AGGREGATOR_OPERATOR",
+		(MarshalTypeAggregator)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/application.go
+++ b/dataintegration/application.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Application The application type contains the audit summary information and the definition of the application.
+type Application struct {
+
+	// Generated key that can be used in API calls to identify application.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// version
+	ApplicationVersion *int `mandatory:"false" json:"applicationVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// List of dependent objects in this patch.
+	DependentObjectMetadata []PatchObjectMetadata `mandatory:"false" json:"dependentObjectMetadata"`
+
+	// List of objects that are published / unpublished in this patch.
+	PublishedObjectMetadata map[string]PatchObjectMetadata `mandatory:"false" json:"publishedObjectMetadata"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+}
+
+func (m Application) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/application_details.go
+++ b/dataintegration/application_details.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ApplicationDetails The information about the application.
+type ApplicationDetails struct {
+
+	// Generated key that can be used in API calls to identify application.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"true" json:"modelType"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"true" json:"objectVersion"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// version
+	ApplicationVersion *int `mandatory:"false" json:"applicationVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+}
+
+func (m ApplicationDetails) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/application_summary.go
+++ b/dataintegration/application_summary.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ApplicationSummary The application summary type contains the audit summary information and the definition of the application.
+type ApplicationSummary struct {
+
+	// Generated key that can be used in API calls to identify application.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// version
+	ApplicationVersion *int `mandatory:"false" json:"applicationVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// List of dependent objects in this patch.
+	DependentObjectMetadata []PatchObjectMetadata `mandatory:"false" json:"dependentObjectMetadata"`
+
+	// List of objects that are published / unpublished in this patch.
+	PublishedObjectMetadata map[string]PatchObjectMetadata `mandatory:"false" json:"publishedObjectMetadata"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+}
+
+func (m ApplicationSummary) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/application_summary_collection.go
+++ b/dataintegration/application_summary_collection.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ApplicationSummaryCollection This is the collection of application summaries, it may be a collection of lightweight details or full definitions.
+type ApplicationSummaryCollection struct {
+
+	// The array of Application summaries
+	Items []ApplicationSummary `mandatory:"true" json:"items"`
+}
+
+func (m ApplicationSummaryCollection) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/base_type.go
+++ b/dataintegration/base_type.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// BaseType Base type for the type system
+type BaseType interface {
+
+	// The key of the object.
+	GetKey() *string
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	GetParentRef() *ParentReference
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	GetName() *string
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// Detailed description for the object.
+	GetDescription() *string
+}
+
+type basetype struct {
+	JsonData     []byte
+	Key          *string          `mandatory:"false" json:"key"`
+	ModelVersion *string          `mandatory:"false" json:"modelVersion"`
+	ParentRef    *ParentReference `mandatory:"false" json:"parentRef"`
+	Name         *string          `mandatory:"false" json:"name"`
+	ObjectStatus *int             `mandatory:"false" json:"objectStatus"`
+	Description  *string          `mandatory:"false" json:"description"`
+	ModelType    string           `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *basetype) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerbasetype basetype
+	s := struct {
+		Model Unmarshalerbasetype
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Key = s.Model.Key
+	m.ModelVersion = s.Model.ModelVersion
+	m.ParentRef = s.Model.ParentRef
+	m.Name = s.Model.Name
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.Description = s.Model.Description
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *basetype) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "CONFIGURED_TYPE":
+		mm := ConfiguredType{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "JAVA_TYPE":
+		mm := JavaType{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "DYNAMIC_TYPE":
+		mm := DynamicType{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "DERIVED_TYPE":
+		mm := DerivedType{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "DATA_TYPE":
+		mm := DataType{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "COMPOSITE_TYPE":
+		mm := CompositeType{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetKey returns Key
+func (m basetype) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m basetype) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m basetype) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m basetype) GetName() *string {
+	return m.Name
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m basetype) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetDescription returns Description
+func (m basetype) GetDescription() *string {
+	return m.Description
+}
+
+func (m basetype) String() string {
+	return common.PointerString(m)
+}
+
+// BaseTypeModelTypeEnum Enum with underlying type: string
+type BaseTypeModelTypeEnum string
+
+// Set of constants representing the allowable values for BaseTypeModelTypeEnum
+const (
+	BaseTypeModelTypeDynamicType    BaseTypeModelTypeEnum = "DYNAMIC_TYPE"
+	BaseTypeModelTypeStructuredType BaseTypeModelTypeEnum = "STRUCTURED_TYPE"
+	BaseTypeModelTypeDataType       BaseTypeModelTypeEnum = "DATA_TYPE"
+	BaseTypeModelTypeJavaType       BaseTypeModelTypeEnum = "JAVA_TYPE"
+	BaseTypeModelTypeConfiguredType BaseTypeModelTypeEnum = "CONFIGURED_TYPE"
+	BaseTypeModelTypeCompositeType  BaseTypeModelTypeEnum = "COMPOSITE_TYPE"
+)
+
+var mappingBaseTypeModelType = map[string]BaseTypeModelTypeEnum{
+	"DYNAMIC_TYPE":    BaseTypeModelTypeDynamicType,
+	"STRUCTURED_TYPE": BaseTypeModelTypeStructuredType,
+	"DATA_TYPE":       BaseTypeModelTypeDataType,
+	"JAVA_TYPE":       BaseTypeModelTypeJavaType,
+	"CONFIGURED_TYPE": BaseTypeModelTypeConfiguredType,
+	"COMPOSITE_TYPE":  BaseTypeModelTypeCompositeType,
+}
+
+// GetBaseTypeModelTypeEnumValues Enumerates the set of values for BaseTypeModelTypeEnum
+func GetBaseTypeModelTypeEnumValues() []BaseTypeModelTypeEnum {
+	values := make([]BaseTypeModelTypeEnum, 0)
+	for _, v := range mappingBaseTypeModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/change_compartment_details.go
+++ b/dataintegration/change_compartment_details.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ChangeCompartmentDetails The information about change compartment action.
+type ChangeCompartmentDetails struct {
+
+	// The OCID of the compartment to move the the workspace to.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+}
+
+func (m ChangeCompartmentDetails) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/change_compartment_request_response.go
+++ b/dataintegration/change_compartment_request_response.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ChangeCompartmentRequest wrapper for the ChangeCompartment operation
+type ChangeCompartmentRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// The details of change compartment action.
+	ChangeCompartmentDetails `contributesTo:"body"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Caller may provide "retry tokens" allowing them to retry an operation
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ChangeCompartmentRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ChangeCompartmentRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ChangeCompartmentRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ChangeCompartmentResponse wrapper for the ChangeCompartment operation
+type ChangeCompartmentResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the work request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+	// with this ID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+}
+
+func (response ChangeCompartmentResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ChangeCompartmentResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/composite_field_map.go
+++ b/dataintegration/composite_field_map.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CompositeFieldMap A composite field map.
+type CompositeFieldMap struct {
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// An array of field maps.
+	FieldMaps []FieldMap `mandatory:"false" json:"fieldMaps"`
+}
+
+//GetDescription returns Description
+func (m CompositeFieldMap) GetDescription() *string {
+	return m.Description
+}
+
+func (m CompositeFieldMap) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CompositeFieldMap) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCompositeFieldMap CompositeFieldMap
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeCompositeFieldMap
+	}{
+		"COMPOSITE_FIELD_MAP",
+		(MarshalTypeCompositeFieldMap)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *CompositeFieldMap) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Description  *string          `json:"description"`
+		Key          *string          `json:"key"`
+		ModelVersion *string          `json:"modelVersion"`
+		ParentRef    *ParentReference `json:"parentRef"`
+		ConfigValues *ConfigValues    `json:"configValues"`
+		ObjectStatus *int             `json:"objectStatus"`
+		FieldMaps    []fieldmap       `json:"fieldMaps"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Description = model.Description
+
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.ConfigValues = model.ConfigValues
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.FieldMaps = make([]FieldMap, len(model.FieldMaps))
+	for i, n := range model.FieldMaps {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.FieldMaps[i] = nn.(FieldMap)
+		} else {
+			m.FieldMaps[i] = nil
+		}
+	}
+	return
+}

--- a/dataintegration/composite_type.go
+++ b/dataintegration/composite_type.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CompositeType A CompositeType represents a type that is composed of a list of sub-types, for example an "Address" type.   The sub-types can be simple DataType or other CompositeType objects. Thus in general a CompositeType may represent an arbitrarily deep hierarchy of types.
+type CompositeType struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	ParentType *CompositeType `mandatory:"false" json:"parentType"`
+
+	// elements
+	Elements []TypedObject `mandatory:"false" json:"elements"`
+
+	ConfigDefinition *ConfigDefinition `mandatory:"false" json:"configDefinition"`
+}
+
+//GetKey returns Key
+func (m CompositeType) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m CompositeType) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m CompositeType) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m CompositeType) GetName() *string {
+	return m.Name
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m CompositeType) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetDescription returns Description
+func (m CompositeType) GetDescription() *string {
+	return m.Description
+}
+
+func (m CompositeType) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CompositeType) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCompositeType CompositeType
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeCompositeType
+	}{
+		"COMPOSITE_TYPE",
+		(MarshalTypeCompositeType)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *CompositeType) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key              *string           `json:"key"`
+		ModelVersion     *string           `json:"modelVersion"`
+		ParentRef        *ParentReference  `json:"parentRef"`
+		Name             *string           `json:"name"`
+		ObjectStatus     *int              `json:"objectStatus"`
+		Description      *string           `json:"description"`
+		ParentType       *CompositeType    `json:"parentType"`
+		Elements         []typedobject     `json:"elements"`
+		ConfigDefinition *ConfigDefinition `json:"configDefinition"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.Name = model.Name
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.Description = model.Description
+
+	m.ParentType = model.ParentType
+
+	m.Elements = make([]TypedObject, len(model.Elements))
+	for i, n := range model.Elements {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.Elements[i] = nn.(TypedObject)
+		} else {
+			m.Elements[i] = nil
+		}
+	}
+
+	m.ConfigDefinition = model.ConfigDefinition
+	return
+}

--- a/dataintegration/conditional_input_link.go
+++ b/dataintegration/conditional_input_link.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConditionalInputLink The information about the conditional input link.
+type ConditionalInputLink struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// Key of FlowPort reference
+	Port *string `mandatory:"false" json:"port"`
+
+	FromLink *OutputLink `mandatory:"false" json:"fromLink"`
+
+	FieldMap FieldMap `mandatory:"false" json:"fieldMap"`
+
+	Condition *Expression `mandatory:"false" json:"condition"`
+}
+
+//GetKey returns Key
+func (m ConditionalInputLink) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m ConditionalInputLink) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m ConditionalInputLink) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m ConditionalInputLink) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetDescription returns Description
+func (m ConditionalInputLink) GetDescription() *string {
+	return m.Description
+}
+
+//GetPort returns Port
+func (m ConditionalInputLink) GetPort() *string {
+	return m.Port
+}
+
+func (m ConditionalInputLink) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ConditionalInputLink) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeConditionalInputLink ConditionalInputLink
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeConditionalInputLink
+	}{
+		"CONDITIONAL_INPUT_LINK",
+		(MarshalTypeConditionalInputLink)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *ConditionalInputLink) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key          *string          `json:"key"`
+		ModelVersion *string          `json:"modelVersion"`
+		ParentRef    *ParentReference `json:"parentRef"`
+		ObjectStatus *int             `json:"objectStatus"`
+		Description  *string          `json:"description"`
+		Port         *string          `json:"port"`
+		FromLink     *OutputLink      `json:"fromLink"`
+		FieldMap     fieldmap         `json:"fieldMap"`
+		Condition    *Expression      `json:"condition"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.Description = model.Description
+
+	m.Port = model.Port
+
+	m.FromLink = model.FromLink
+
+	nn, e = model.FieldMap.UnmarshalPolymorphicJSON(model.FieldMap.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.FieldMap = nn.(FieldMap)
+	} else {
+		m.FieldMap = nil
+	}
+
+	m.Condition = model.Condition
+	return
+}

--- a/dataintegration/config_definition.go
+++ b/dataintegration/config_definition.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConfigDefinition The configuration details of a configurable object. This contains one or more config param definitions.
+type ConfigDefinition struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Whether the configuration is contained or not.
+	IsContained *bool `mandatory:"false" json:"isContained"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// configParamDefs
+	ConfigParameterDefinitions map[string]ConfigParameterDefinition `mandatory:"false" json:"configParameterDefinitions"`
+}
+
+func (m ConfigDefinition) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/config_parameter_definition.go
+++ b/dataintegration/config_parameter_definition.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConfigParameterDefinition The configurable properties of an object type.
+type ConfigParameterDefinition struct {
+	ParameterType BaseType `mandatory:"false" json:"parameterType"`
+
+	// This object represents the configurable properties for an object type.
+	ParameterName *string `mandatory:"false" json:"parameterName"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The default value for the parameter.
+	DefaultValue *interface{} `mandatory:"false" json:"defaultValue"`
+
+	// The parameter class field name.
+	ClassFieldName *string `mandatory:"false" json:"classFieldName"`
+
+	// Whether the parameter is static or not.
+	IsStatic *bool `mandatory:"false" json:"isStatic"`
+
+	// Whether the parameter is a class field or not.
+	IsClassFieldValue *bool `mandatory:"false" json:"isClassFieldValue"`
+}
+
+func (m ConfigParameterDefinition) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *ConfigParameterDefinition) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		ParameterType     basetype     `json:"parameterType"`
+		ParameterName     *string      `json:"parameterName"`
+		Description       *string      `json:"description"`
+		DefaultValue      *interface{} `json:"defaultValue"`
+		ClassFieldName    *string      `json:"classFieldName"`
+		IsStatic          *bool        `json:"isStatic"`
+		IsClassFieldValue *bool        `json:"isClassFieldValue"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	nn, e = model.ParameterType.UnmarshalPolymorphicJSON(model.ParameterType.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.ParameterType = nn.(BaseType)
+	} else {
+		m.ParameterType = nil
+	}
+
+	m.ParameterName = model.ParameterName
+
+	m.Description = model.Description
+
+	m.DefaultValue = model.DefaultValue
+
+	m.ClassFieldName = model.ClassFieldName
+
+	m.IsStatic = model.IsStatic
+
+	m.IsClassFieldValue = model.IsClassFieldValue
+	return
+}

--- a/dataintegration/config_parameter_value.go
+++ b/dataintegration/config_parameter_value.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConfigParameterValue This holds the values/objects.
+type ConfigParameterValue struct {
+
+	// A string value of the parameter.
+	StringValue *string `mandatory:"false" json:"stringValue"`
+
+	// An integer value of the parameter.
+	IntValue *int `mandatory:"false" json:"intValue"`
+
+	// The root object reference value.
+	RefValue *interface{} `mandatory:"false" json:"refValue"`
+
+	// Reference to the parameter by its key.
+	ParameterValue *string `mandatory:"false" json:"parameterValue"`
+}
+
+func (m ConfigParameterValue) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/config_provider.go
+++ b/dataintegration/config_provider.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConfigProvider The information about the configuration provider.
+type ConfigProvider struct {
+
+	// bindings
+	Bindings map[string]ParameterValue `mandatory:"false" json:"bindings"`
+
+	// childProviders
+	ChildProviders map[string]ConfigProvider `mandatory:"false" json:"childProviders"`
+}
+
+func (m ConfigProvider) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/config_values.go
+++ b/dataintegration/config_values.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConfigValues Configuration values can be string, objects or parameters.
+type ConfigValues struct {
+
+	// configParamValues
+	ConfigParamValues map[string]ConfigParameterValue `mandatory:"false" json:"configParamValues"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+}
+
+func (m ConfigValues) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/configured_type.go
+++ b/dataintegration/configured_type.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConfiguredType A ConfiguraedType represents a type that has built-in configuration to the type itself. An example is a SSN type whose basic type is VARCHAR, but the type itself also has a built-in configuration like length=10
+type ConfiguredType struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	WrappedType BaseType `mandatory:"false" json:"wrappedType"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	ConfigDefinition *ConfigDefinition `mandatory:"false" json:"configDefinition"`
+}
+
+//GetKey returns Key
+func (m ConfiguredType) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m ConfiguredType) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m ConfiguredType) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m ConfiguredType) GetName() *string {
+	return m.Name
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m ConfiguredType) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetDescription returns Description
+func (m ConfiguredType) GetDescription() *string {
+	return m.Description
+}
+
+func (m ConfiguredType) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ConfiguredType) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeConfiguredType ConfiguredType
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeConfiguredType
+	}{
+		"CONFIGURED_TYPE",
+		(MarshalTypeConfiguredType)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *ConfiguredType) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key              *string           `json:"key"`
+		ModelVersion     *string           `json:"modelVersion"`
+		ParentRef        *ParentReference  `json:"parentRef"`
+		Name             *string           `json:"name"`
+		ObjectStatus     *int              `json:"objectStatus"`
+		Description      *string           `json:"description"`
+		WrappedType      basetype          `json:"wrappedType"`
+		ConfigValues     *ConfigValues     `json:"configValues"`
+		ConfigDefinition *ConfigDefinition `json:"configDefinition"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.Name = model.Name
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.Description = model.Description
+
+	nn, e = model.WrappedType.UnmarshalPolymorphicJSON(model.WrappedType.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.WrappedType = nn.(BaseType)
+	} else {
+		m.WrappedType = nil
+	}
+
+	m.ConfigValues = model.ConfigValues
+
+	m.ConfigDefinition = model.ConfigDefinition
+	return
+}

--- a/dataintegration/connection.go
+++ b/dataintegration/connection.go
@@ -1,0 +1,228 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Connection The connection object.
+type Connection interface {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	GetKey() *string
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	GetParentRef() *ParentReference
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	GetName() *string
+
+	// Detailed description for the object.
+	GetDescription() *string
+
+	// The version of the object that is used to track changes in the object instance.
+	GetObjectVersion() *int
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	GetIdentifier() *string
+
+	GetPrimarySchema() *Schema
+
+	// The properties for the connection.
+	GetConnectionProperties() []ConnectionProperty
+
+	// The default property for the connection.
+	GetIsDefault() *bool
+
+	GetMetadata() *ObjectMetadata
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	GetKeyMap() map[string]string
+}
+
+type connection struct {
+	JsonData             []byte
+	Key                  *string              `mandatory:"false" json:"key"`
+	ModelVersion         *string              `mandatory:"false" json:"modelVersion"`
+	ParentRef            *ParentReference     `mandatory:"false" json:"parentRef"`
+	Name                 *string              `mandatory:"false" json:"name"`
+	Description          *string              `mandatory:"false" json:"description"`
+	ObjectVersion        *int                 `mandatory:"false" json:"objectVersion"`
+	ObjectStatus         *int                 `mandatory:"false" json:"objectStatus"`
+	Identifier           *string              `mandatory:"false" json:"identifier"`
+	PrimarySchema        *Schema              `mandatory:"false" json:"primarySchema"`
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+	IsDefault            *bool                `mandatory:"false" json:"isDefault"`
+	Metadata             *ObjectMetadata      `mandatory:"false" json:"metadata"`
+	KeyMap               map[string]string    `mandatory:"false" json:"keyMap"`
+	ModelType            string               `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *connection) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerconnection connection
+	s := struct {
+		Model Unmarshalerconnection
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Key = s.Model.Key
+	m.ModelVersion = s.Model.ModelVersion
+	m.ParentRef = s.Model.ParentRef
+	m.Name = s.Model.Name
+	m.Description = s.Model.Description
+	m.ObjectVersion = s.Model.ObjectVersion
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.Identifier = s.Model.Identifier
+	m.PrimarySchema = s.Model.PrimarySchema
+	m.ConnectionProperties = s.Model.ConnectionProperties
+	m.IsDefault = s.Model.IsDefault
+	m.Metadata = s.Model.Metadata
+	m.KeyMap = s.Model.KeyMap
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *connection) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "ORACLE_OBJECT_STORAGE_CONNECTION":
+		mm := ConnectionFromObjectStorage{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_ADWC_CONNECTION":
+		mm := ConnectionFromAdwc{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_ATP_CONNECTION":
+		mm := ConnectionFromAtp{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLEDB_CONNECTION":
+		mm := ConnectionFromOracle{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetKey returns Key
+func (m connection) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m connection) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m connection) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m connection) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m connection) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m connection) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m connection) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m connection) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetPrimarySchema returns PrimarySchema
+func (m connection) GetPrimarySchema() *Schema {
+	return m.PrimarySchema
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m connection) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetIsDefault returns IsDefault
+func (m connection) GetIsDefault() *bool {
+	return m.IsDefault
+}
+
+//GetMetadata returns Metadata
+func (m connection) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m connection) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m connection) String() string {
+	return common.PointerString(m)
+}
+
+// ConnectionModelTypeEnum Enum with underlying type: string
+type ConnectionModelTypeEnum string
+
+// Set of constants representing the allowable values for ConnectionModelTypeEnum
+const (
+	ConnectionModelTypeOracleAdwcConnection          ConnectionModelTypeEnum = "ORACLE_ADWC_CONNECTION"
+	ConnectionModelTypeOracleAtpConnection           ConnectionModelTypeEnum = "ORACLE_ATP_CONNECTION"
+	ConnectionModelTypeOracleObjectStorageConnection ConnectionModelTypeEnum = "ORACLE_OBJECT_STORAGE_CONNECTION"
+	ConnectionModelTypeOracledbConnection            ConnectionModelTypeEnum = "ORACLEDB_CONNECTION"
+)
+
+var mappingConnectionModelType = map[string]ConnectionModelTypeEnum{
+	"ORACLE_ADWC_CONNECTION":           ConnectionModelTypeOracleAdwcConnection,
+	"ORACLE_ATP_CONNECTION":            ConnectionModelTypeOracleAtpConnection,
+	"ORACLE_OBJECT_STORAGE_CONNECTION": ConnectionModelTypeOracleObjectStorageConnection,
+	"ORACLEDB_CONNECTION":              ConnectionModelTypeOracledbConnection,
+}
+
+// GetConnectionModelTypeEnumValues Enumerates the set of values for ConnectionModelTypeEnum
+func GetConnectionModelTypeEnumValues() []ConnectionModelTypeEnum {
+	values := make([]ConnectionModelTypeEnum, 0)
+	for _, v := range mappingConnectionModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/connection_details.go
+++ b/dataintegration/connection_details.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConnectionDetails The connection details object.
+type ConnectionDetails interface {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	GetKey() *string
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	GetParentRef() *ParentReference
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	GetName() *string
+
+	// Detailed description for the object.
+	GetDescription() *string
+
+	// The version of the object that is used to track changes in the object instance.
+	GetObjectVersion() *int
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	GetIdentifier() *string
+
+	GetPrimarySchema() *Schema
+
+	// The properties for the connection.
+	GetConnectionProperties() []ConnectionProperty
+
+	// The default property for the connection.
+	GetIsDefault() *bool
+
+	GetMetadata() *ObjectMetadata
+}
+
+type connectiondetails struct {
+	JsonData             []byte
+	Key                  *string              `mandatory:"false" json:"key"`
+	ModelVersion         *string              `mandatory:"false" json:"modelVersion"`
+	ParentRef            *ParentReference     `mandatory:"false" json:"parentRef"`
+	Name                 *string              `mandatory:"false" json:"name"`
+	Description          *string              `mandatory:"false" json:"description"`
+	ObjectVersion        *int                 `mandatory:"false" json:"objectVersion"`
+	ObjectStatus         *int                 `mandatory:"false" json:"objectStatus"`
+	Identifier           *string              `mandatory:"false" json:"identifier"`
+	PrimarySchema        *Schema              `mandatory:"false" json:"primarySchema"`
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+	IsDefault            *bool                `mandatory:"false" json:"isDefault"`
+	Metadata             *ObjectMetadata      `mandatory:"false" json:"metadata"`
+	ModelType            string               `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *connectiondetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerconnectiondetails connectiondetails
+	s := struct {
+		Model Unmarshalerconnectiondetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Key = s.Model.Key
+	m.ModelVersion = s.Model.ModelVersion
+	m.ParentRef = s.Model.ParentRef
+	m.Name = s.Model.Name
+	m.Description = s.Model.Description
+	m.ObjectVersion = s.Model.ObjectVersion
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.Identifier = s.Model.Identifier
+	m.PrimarySchema = s.Model.PrimarySchema
+	m.ConnectionProperties = s.Model.ConnectionProperties
+	m.IsDefault = s.Model.IsDefault
+	m.Metadata = s.Model.Metadata
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *connectiondetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "ORACLE_OBJECT_STORAGE_CONNECTION":
+		mm := ConnectionFromObjectStorageDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_ADWC_CONNECTION":
+		mm := ConnectionFromAdwcDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_ATP_CONNECTION":
+		mm := ConnectionFromAtpDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLEDB_CONNECTION":
+		mm := ConnectionFromOracleDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetKey returns Key
+func (m connectiondetails) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m connectiondetails) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m connectiondetails) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m connectiondetails) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m connectiondetails) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m connectiondetails) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m connectiondetails) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m connectiondetails) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetPrimarySchema returns PrimarySchema
+func (m connectiondetails) GetPrimarySchema() *Schema {
+	return m.PrimarySchema
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m connectiondetails) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetIsDefault returns IsDefault
+func (m connectiondetails) GetIsDefault() *bool {
+	return m.IsDefault
+}
+
+//GetMetadata returns Metadata
+func (m connectiondetails) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m connectiondetails) String() string {
+	return common.PointerString(m)
+}
+
+// ConnectionDetailsModelTypeEnum Enum with underlying type: string
+type ConnectionDetailsModelTypeEnum string
+
+// Set of constants representing the allowable values for ConnectionDetailsModelTypeEnum
+const (
+	ConnectionDetailsModelTypeOracleAdwcConnection          ConnectionDetailsModelTypeEnum = "ORACLE_ADWC_CONNECTION"
+	ConnectionDetailsModelTypeOracleAtpConnection           ConnectionDetailsModelTypeEnum = "ORACLE_ATP_CONNECTION"
+	ConnectionDetailsModelTypeOracleObjectStorageConnection ConnectionDetailsModelTypeEnum = "ORACLE_OBJECT_STORAGE_CONNECTION"
+	ConnectionDetailsModelTypeOracledbConnection            ConnectionDetailsModelTypeEnum = "ORACLEDB_CONNECTION"
+)
+
+var mappingConnectionDetailsModelType = map[string]ConnectionDetailsModelTypeEnum{
+	"ORACLE_ADWC_CONNECTION":           ConnectionDetailsModelTypeOracleAdwcConnection,
+	"ORACLE_ATP_CONNECTION":            ConnectionDetailsModelTypeOracleAtpConnection,
+	"ORACLE_OBJECT_STORAGE_CONNECTION": ConnectionDetailsModelTypeOracleObjectStorageConnection,
+	"ORACLEDB_CONNECTION":              ConnectionDetailsModelTypeOracledbConnection,
+}
+
+// GetConnectionDetailsModelTypeEnumValues Enumerates the set of values for ConnectionDetailsModelTypeEnum
+func GetConnectionDetailsModelTypeEnumValues() []ConnectionDetailsModelTypeEnum {
+	values := make([]ConnectionDetailsModelTypeEnum, 0)
+	for _, v := range mappingConnectionDetailsModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/connection_from_adwc.go
+++ b/dataintegration/connection_from_adwc.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConnectionFromAdwc The ADWC connection details object.
+type ConnectionFromAdwc struct {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	PrimarySchema *Schema `mandatory:"false" json:"primarySchema"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	// The default property for the connection.
+	IsDefault *bool `mandatory:"false" json:"isDefault"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+
+	// The user name for the connection.
+	Username *string `mandatory:"false" json:"username"`
+
+	// The password for the connection.
+	Password *string `mandatory:"false" json:"password"`
+}
+
+//GetKey returns Key
+func (m ConnectionFromAdwc) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m ConnectionFromAdwc) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m ConnectionFromAdwc) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m ConnectionFromAdwc) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m ConnectionFromAdwc) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m ConnectionFromAdwc) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m ConnectionFromAdwc) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m ConnectionFromAdwc) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetPrimarySchema returns PrimarySchema
+func (m ConnectionFromAdwc) GetPrimarySchema() *Schema {
+	return m.PrimarySchema
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m ConnectionFromAdwc) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetIsDefault returns IsDefault
+func (m ConnectionFromAdwc) GetIsDefault() *bool {
+	return m.IsDefault
+}
+
+//GetMetadata returns Metadata
+func (m ConnectionFromAdwc) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m ConnectionFromAdwc) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m ConnectionFromAdwc) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ConnectionFromAdwc) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeConnectionFromAdwc ConnectionFromAdwc
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeConnectionFromAdwc
+	}{
+		"ORACLE_ADWC_CONNECTION",
+		(MarshalTypeConnectionFromAdwc)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/connection_from_adwc_details.go
+++ b/dataintegration/connection_from_adwc_details.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConnectionFromAdwcDetails The ADWC connection details object.
+type ConnectionFromAdwcDetails struct {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	PrimarySchema *Schema `mandatory:"false" json:"primarySchema"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	// The default property for the connection.
+	IsDefault *bool `mandatory:"false" json:"isDefault"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// The user name for the connection.
+	Username *string `mandatory:"false" json:"username"`
+
+	// The password for the connection.
+	Password *string `mandatory:"false" json:"password"`
+}
+
+//GetKey returns Key
+func (m ConnectionFromAdwcDetails) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m ConnectionFromAdwcDetails) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m ConnectionFromAdwcDetails) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m ConnectionFromAdwcDetails) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m ConnectionFromAdwcDetails) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m ConnectionFromAdwcDetails) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m ConnectionFromAdwcDetails) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m ConnectionFromAdwcDetails) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetPrimarySchema returns PrimarySchema
+func (m ConnectionFromAdwcDetails) GetPrimarySchema() *Schema {
+	return m.PrimarySchema
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m ConnectionFromAdwcDetails) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetIsDefault returns IsDefault
+func (m ConnectionFromAdwcDetails) GetIsDefault() *bool {
+	return m.IsDefault
+}
+
+//GetMetadata returns Metadata
+func (m ConnectionFromAdwcDetails) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m ConnectionFromAdwcDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ConnectionFromAdwcDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeConnectionFromAdwcDetails ConnectionFromAdwcDetails
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeConnectionFromAdwcDetails
+	}{
+		"ORACLE_ADWC_CONNECTION",
+		(MarshalTypeConnectionFromAdwcDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/connection_from_atp.go
+++ b/dataintegration/connection_from_atp.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConnectionFromAtp The ATP connection details.
+type ConnectionFromAtp struct {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	PrimarySchema *Schema `mandatory:"false" json:"primarySchema"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	// The default property for the connection.
+	IsDefault *bool `mandatory:"false" json:"isDefault"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+
+	// The user name for the connection.
+	Username *string `mandatory:"false" json:"username"`
+
+	// The password for the connection.
+	Password *string `mandatory:"false" json:"password"`
+}
+
+//GetKey returns Key
+func (m ConnectionFromAtp) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m ConnectionFromAtp) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m ConnectionFromAtp) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m ConnectionFromAtp) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m ConnectionFromAtp) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m ConnectionFromAtp) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m ConnectionFromAtp) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m ConnectionFromAtp) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetPrimarySchema returns PrimarySchema
+func (m ConnectionFromAtp) GetPrimarySchema() *Schema {
+	return m.PrimarySchema
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m ConnectionFromAtp) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetIsDefault returns IsDefault
+func (m ConnectionFromAtp) GetIsDefault() *bool {
+	return m.IsDefault
+}
+
+//GetMetadata returns Metadata
+func (m ConnectionFromAtp) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m ConnectionFromAtp) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m ConnectionFromAtp) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ConnectionFromAtp) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeConnectionFromAtp ConnectionFromAtp
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeConnectionFromAtp
+	}{
+		"ORACLE_ATP_CONNECTION",
+		(MarshalTypeConnectionFromAtp)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/connection_from_atp_details.go
+++ b/dataintegration/connection_from_atp_details.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConnectionFromAtpDetails The ATP connection details.
+type ConnectionFromAtpDetails struct {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	PrimarySchema *Schema `mandatory:"false" json:"primarySchema"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	// The default property for the connection.
+	IsDefault *bool `mandatory:"false" json:"isDefault"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// The user name for the connection.
+	Username *string `mandatory:"false" json:"username"`
+
+	// The password for the connection.
+	Password *string `mandatory:"false" json:"password"`
+}
+
+//GetKey returns Key
+func (m ConnectionFromAtpDetails) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m ConnectionFromAtpDetails) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m ConnectionFromAtpDetails) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m ConnectionFromAtpDetails) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m ConnectionFromAtpDetails) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m ConnectionFromAtpDetails) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m ConnectionFromAtpDetails) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m ConnectionFromAtpDetails) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetPrimarySchema returns PrimarySchema
+func (m ConnectionFromAtpDetails) GetPrimarySchema() *Schema {
+	return m.PrimarySchema
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m ConnectionFromAtpDetails) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetIsDefault returns IsDefault
+func (m ConnectionFromAtpDetails) GetIsDefault() *bool {
+	return m.IsDefault
+}
+
+//GetMetadata returns Metadata
+func (m ConnectionFromAtpDetails) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m ConnectionFromAtpDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ConnectionFromAtpDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeConnectionFromAtpDetails ConnectionFromAtpDetails
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeConnectionFromAtpDetails
+	}{
+		"ORACLE_ATP_CONNECTION",
+		(MarshalTypeConnectionFromAtpDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/connection_from_object_storage.go
+++ b/dataintegration/connection_from_object_storage.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConnectionFromObjectStorage The Object Storage connection details.
+type ConnectionFromObjectStorage struct {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	PrimarySchema *Schema `mandatory:"false" json:"primarySchema"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	// The default property for the connection.
+	IsDefault *bool `mandatory:"false" json:"isDefault"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+
+	// The credential file content from a wallet for the data asset.
+	CredentialFileContent *string `mandatory:"false" json:"credentialFileContent"`
+
+	// The OCI user OCID for the user to connect to.
+	UserId *string `mandatory:"false" json:"userId"`
+
+	// The fingeprint for the user.
+	FingerPrint *string `mandatory:"false" json:"fingerPrint"`
+
+	// The pass phrase for the connection.
+	PassPhrase *string `mandatory:"false" json:"passPhrase"`
+}
+
+//GetKey returns Key
+func (m ConnectionFromObjectStorage) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m ConnectionFromObjectStorage) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m ConnectionFromObjectStorage) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m ConnectionFromObjectStorage) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m ConnectionFromObjectStorage) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m ConnectionFromObjectStorage) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m ConnectionFromObjectStorage) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m ConnectionFromObjectStorage) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetPrimarySchema returns PrimarySchema
+func (m ConnectionFromObjectStorage) GetPrimarySchema() *Schema {
+	return m.PrimarySchema
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m ConnectionFromObjectStorage) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetIsDefault returns IsDefault
+func (m ConnectionFromObjectStorage) GetIsDefault() *bool {
+	return m.IsDefault
+}
+
+//GetMetadata returns Metadata
+func (m ConnectionFromObjectStorage) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m ConnectionFromObjectStorage) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m ConnectionFromObjectStorage) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ConnectionFromObjectStorage) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeConnectionFromObjectStorage ConnectionFromObjectStorage
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeConnectionFromObjectStorage
+	}{
+		"ORACLE_OBJECT_STORAGE_CONNECTION",
+		(MarshalTypeConnectionFromObjectStorage)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/connection_from_object_storage_details.go
+++ b/dataintegration/connection_from_object_storage_details.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConnectionFromObjectStorageDetails The Object Storage connection details.
+type ConnectionFromObjectStorageDetails struct {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	PrimarySchema *Schema `mandatory:"false" json:"primarySchema"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	// The default property for the connection.
+	IsDefault *bool `mandatory:"false" json:"isDefault"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// The credential file content from a wallet for the data asset.
+	CredentialFileContent *string `mandatory:"false" json:"credentialFileContent"`
+
+	// The OCI user OCID for the user to connect to.
+	UserId *string `mandatory:"false" json:"userId"`
+
+	// The fingeprint for the user.
+	FingerPrint *string `mandatory:"false" json:"fingerPrint"`
+
+	// The pass phrase for the connection.
+	PassPhrase *string `mandatory:"false" json:"passPhrase"`
+}
+
+//GetKey returns Key
+func (m ConnectionFromObjectStorageDetails) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m ConnectionFromObjectStorageDetails) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m ConnectionFromObjectStorageDetails) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m ConnectionFromObjectStorageDetails) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m ConnectionFromObjectStorageDetails) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m ConnectionFromObjectStorageDetails) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m ConnectionFromObjectStorageDetails) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m ConnectionFromObjectStorageDetails) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetPrimarySchema returns PrimarySchema
+func (m ConnectionFromObjectStorageDetails) GetPrimarySchema() *Schema {
+	return m.PrimarySchema
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m ConnectionFromObjectStorageDetails) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetIsDefault returns IsDefault
+func (m ConnectionFromObjectStorageDetails) GetIsDefault() *bool {
+	return m.IsDefault
+}
+
+//GetMetadata returns Metadata
+func (m ConnectionFromObjectStorageDetails) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m ConnectionFromObjectStorageDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ConnectionFromObjectStorageDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeConnectionFromObjectStorageDetails ConnectionFromObjectStorageDetails
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeConnectionFromObjectStorageDetails
+	}{
+		"ORACLE_OBJECT_STORAGE_CONNECTION",
+		(MarshalTypeConnectionFromObjectStorageDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/connection_from_oracle.go
+++ b/dataintegration/connection_from_oracle.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConnectionFromOracle The Oracle connection details object.
+type ConnectionFromOracle struct {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	PrimarySchema *Schema `mandatory:"false" json:"primarySchema"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	// The default property for the connection.
+	IsDefault *bool `mandatory:"false" json:"isDefault"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+
+	// The user name for the connection.
+	Username *string `mandatory:"false" json:"username"`
+
+	// The password for the connection.
+	Password *string `mandatory:"false" json:"password"`
+}
+
+//GetKey returns Key
+func (m ConnectionFromOracle) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m ConnectionFromOracle) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m ConnectionFromOracle) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m ConnectionFromOracle) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m ConnectionFromOracle) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m ConnectionFromOracle) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m ConnectionFromOracle) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m ConnectionFromOracle) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetPrimarySchema returns PrimarySchema
+func (m ConnectionFromOracle) GetPrimarySchema() *Schema {
+	return m.PrimarySchema
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m ConnectionFromOracle) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetIsDefault returns IsDefault
+func (m ConnectionFromOracle) GetIsDefault() *bool {
+	return m.IsDefault
+}
+
+//GetMetadata returns Metadata
+func (m ConnectionFromOracle) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m ConnectionFromOracle) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m ConnectionFromOracle) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ConnectionFromOracle) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeConnectionFromOracle ConnectionFromOracle
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeConnectionFromOracle
+	}{
+		"ORACLEDB_CONNECTION",
+		(MarshalTypeConnectionFromOracle)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/connection_from_oracle_details.go
+++ b/dataintegration/connection_from_oracle_details.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConnectionFromOracleDetails The Oracle connection details object.
+type ConnectionFromOracleDetails struct {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	PrimarySchema *Schema `mandatory:"false" json:"primarySchema"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	// The default property for the connection.
+	IsDefault *bool `mandatory:"false" json:"isDefault"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// The user name for the connection.
+	Username *string `mandatory:"false" json:"username"`
+
+	// The password for the connection.
+	Password *string `mandatory:"false" json:"password"`
+}
+
+//GetKey returns Key
+func (m ConnectionFromOracleDetails) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m ConnectionFromOracleDetails) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m ConnectionFromOracleDetails) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m ConnectionFromOracleDetails) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m ConnectionFromOracleDetails) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m ConnectionFromOracleDetails) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m ConnectionFromOracleDetails) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m ConnectionFromOracleDetails) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetPrimarySchema returns PrimarySchema
+func (m ConnectionFromOracleDetails) GetPrimarySchema() *Schema {
+	return m.PrimarySchema
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m ConnectionFromOracleDetails) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetIsDefault returns IsDefault
+func (m ConnectionFromOracleDetails) GetIsDefault() *bool {
+	return m.IsDefault
+}
+
+//GetMetadata returns Metadata
+func (m ConnectionFromOracleDetails) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m ConnectionFromOracleDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ConnectionFromOracleDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeConnectionFromOracleDetails ConnectionFromOracleDetails
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeConnectionFromOracleDetails
+	}{
+		"ORACLEDB_CONNECTION",
+		(MarshalTypeConnectionFromOracleDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/connection_property.go
+++ b/dataintegration/connection_property.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConnectionProperty The connection name/value pair.
+type ConnectionProperty struct {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// value
+	Value *string `mandatory:"false" json:"value"`
+}
+
+func (m ConnectionProperty) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/connection_summary.go
+++ b/dataintegration/connection_summary.go
@@ -1,0 +1,228 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConnectionSummary The connection summary object.
+type ConnectionSummary interface {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	GetKey() *string
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	GetParentRef() *ParentReference
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	GetName() *string
+
+	// Detailed description for the object.
+	GetDescription() *string
+
+	// The version of the object that is used to track changes in the object instance.
+	GetObjectVersion() *int
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	GetIdentifier() *string
+
+	GetPrimarySchema() *Schema
+
+	// The properties for the connection.
+	GetConnectionProperties() []ConnectionProperty
+
+	// The default property for the connection.
+	GetIsDefault() *bool
+
+	GetMetadata() *ObjectMetadata
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	GetKeyMap() map[string]string
+}
+
+type connectionsummary struct {
+	JsonData             []byte
+	Key                  *string              `mandatory:"false" json:"key"`
+	ModelVersion         *string              `mandatory:"false" json:"modelVersion"`
+	ParentRef            *ParentReference     `mandatory:"false" json:"parentRef"`
+	Name                 *string              `mandatory:"false" json:"name"`
+	Description          *string              `mandatory:"false" json:"description"`
+	ObjectVersion        *int                 `mandatory:"false" json:"objectVersion"`
+	ObjectStatus         *int                 `mandatory:"false" json:"objectStatus"`
+	Identifier           *string              `mandatory:"false" json:"identifier"`
+	PrimarySchema        *Schema              `mandatory:"false" json:"primarySchema"`
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+	IsDefault            *bool                `mandatory:"false" json:"isDefault"`
+	Metadata             *ObjectMetadata      `mandatory:"false" json:"metadata"`
+	KeyMap               map[string]string    `mandatory:"false" json:"keyMap"`
+	ModelType            string               `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *connectionsummary) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerconnectionsummary connectionsummary
+	s := struct {
+		Model Unmarshalerconnectionsummary
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Key = s.Model.Key
+	m.ModelVersion = s.Model.ModelVersion
+	m.ParentRef = s.Model.ParentRef
+	m.Name = s.Model.Name
+	m.Description = s.Model.Description
+	m.ObjectVersion = s.Model.ObjectVersion
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.Identifier = s.Model.Identifier
+	m.PrimarySchema = s.Model.PrimarySchema
+	m.ConnectionProperties = s.Model.ConnectionProperties
+	m.IsDefault = s.Model.IsDefault
+	m.Metadata = s.Model.Metadata
+	m.KeyMap = s.Model.KeyMap
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *connectionsummary) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "ORACLE_ATP_CONNECTION":
+		mm := ConnectionSummaryFromAtp{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLEDB_CONNECTION":
+		mm := ConnectionSummaryFromOracle{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_ADWC_CONNECTION":
+		mm := ConnectionSummaryFromAdwc{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_OBJECT_STORAGE_CONNECTION":
+		mm := ConnectionSummaryFromObjectStorage{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetKey returns Key
+func (m connectionsummary) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m connectionsummary) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m connectionsummary) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m connectionsummary) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m connectionsummary) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m connectionsummary) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m connectionsummary) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m connectionsummary) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetPrimarySchema returns PrimarySchema
+func (m connectionsummary) GetPrimarySchema() *Schema {
+	return m.PrimarySchema
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m connectionsummary) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetIsDefault returns IsDefault
+func (m connectionsummary) GetIsDefault() *bool {
+	return m.IsDefault
+}
+
+//GetMetadata returns Metadata
+func (m connectionsummary) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m connectionsummary) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m connectionsummary) String() string {
+	return common.PointerString(m)
+}
+
+// ConnectionSummaryModelTypeEnum Enum with underlying type: string
+type ConnectionSummaryModelTypeEnum string
+
+// Set of constants representing the allowable values for ConnectionSummaryModelTypeEnum
+const (
+	ConnectionSummaryModelTypeOracleAdwcConnection          ConnectionSummaryModelTypeEnum = "ORACLE_ADWC_CONNECTION"
+	ConnectionSummaryModelTypeOracleAtpConnection           ConnectionSummaryModelTypeEnum = "ORACLE_ATP_CONNECTION"
+	ConnectionSummaryModelTypeOracleObjectStorageConnection ConnectionSummaryModelTypeEnum = "ORACLE_OBJECT_STORAGE_CONNECTION"
+	ConnectionSummaryModelTypeOracledbConnection            ConnectionSummaryModelTypeEnum = "ORACLEDB_CONNECTION"
+)
+
+var mappingConnectionSummaryModelType = map[string]ConnectionSummaryModelTypeEnum{
+	"ORACLE_ADWC_CONNECTION":           ConnectionSummaryModelTypeOracleAdwcConnection,
+	"ORACLE_ATP_CONNECTION":            ConnectionSummaryModelTypeOracleAtpConnection,
+	"ORACLE_OBJECT_STORAGE_CONNECTION": ConnectionSummaryModelTypeOracleObjectStorageConnection,
+	"ORACLEDB_CONNECTION":              ConnectionSummaryModelTypeOracledbConnection,
+}
+
+// GetConnectionSummaryModelTypeEnumValues Enumerates the set of values for ConnectionSummaryModelTypeEnum
+func GetConnectionSummaryModelTypeEnumValues() []ConnectionSummaryModelTypeEnum {
+	values := make([]ConnectionSummaryModelTypeEnum, 0)
+	for _, v := range mappingConnectionSummaryModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/connection_summary_collection.go
+++ b/dataintegration/connection_summary_collection.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConnectionSummaryCollection This is the collection of connection summaries, it may be a collection of lightweight details or full definitions.
+type ConnectionSummaryCollection struct {
+
+	// The array of Connection summaries
+	Items []ConnectionSummary `mandatory:"true" json:"items"`
+}
+
+func (m ConnectionSummaryCollection) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *ConnectionSummaryCollection) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Items []connectionsummary `json:"items"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Items = make([]ConnectionSummary, len(model.Items))
+	for i, n := range model.Items {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.Items[i] = nn.(ConnectionSummary)
+		} else {
+			m.Items[i] = nil
+		}
+	}
+	return
+}

--- a/dataintegration/connection_summary_from_adwc.go
+++ b/dataintegration/connection_summary_from_adwc.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConnectionSummaryFromAdwc The ADWC connection details object.
+type ConnectionSummaryFromAdwc struct {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	PrimarySchema *Schema `mandatory:"false" json:"primarySchema"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	// The default property for the connection.
+	IsDefault *bool `mandatory:"false" json:"isDefault"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+
+	// The user name for the connection.
+	Username *string `mandatory:"false" json:"username"`
+
+	// The password for the connection.
+	Password *string `mandatory:"false" json:"password"`
+}
+
+//GetKey returns Key
+func (m ConnectionSummaryFromAdwc) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m ConnectionSummaryFromAdwc) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m ConnectionSummaryFromAdwc) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m ConnectionSummaryFromAdwc) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m ConnectionSummaryFromAdwc) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m ConnectionSummaryFromAdwc) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m ConnectionSummaryFromAdwc) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m ConnectionSummaryFromAdwc) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetPrimarySchema returns PrimarySchema
+func (m ConnectionSummaryFromAdwc) GetPrimarySchema() *Schema {
+	return m.PrimarySchema
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m ConnectionSummaryFromAdwc) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetIsDefault returns IsDefault
+func (m ConnectionSummaryFromAdwc) GetIsDefault() *bool {
+	return m.IsDefault
+}
+
+//GetMetadata returns Metadata
+func (m ConnectionSummaryFromAdwc) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m ConnectionSummaryFromAdwc) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m ConnectionSummaryFromAdwc) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ConnectionSummaryFromAdwc) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeConnectionSummaryFromAdwc ConnectionSummaryFromAdwc
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeConnectionSummaryFromAdwc
+	}{
+		"ORACLE_ADWC_CONNECTION",
+		(MarshalTypeConnectionSummaryFromAdwc)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/connection_summary_from_atp.go
+++ b/dataintegration/connection_summary_from_atp.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConnectionSummaryFromAtp The ATP connection details.
+type ConnectionSummaryFromAtp struct {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	PrimarySchema *Schema `mandatory:"false" json:"primarySchema"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	// The default property for the connection.
+	IsDefault *bool `mandatory:"false" json:"isDefault"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+
+	// The user name for the connection.
+	Username *string `mandatory:"false" json:"username"`
+
+	// The password for the connection.
+	Password *string `mandatory:"false" json:"password"`
+}
+
+//GetKey returns Key
+func (m ConnectionSummaryFromAtp) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m ConnectionSummaryFromAtp) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m ConnectionSummaryFromAtp) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m ConnectionSummaryFromAtp) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m ConnectionSummaryFromAtp) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m ConnectionSummaryFromAtp) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m ConnectionSummaryFromAtp) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m ConnectionSummaryFromAtp) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetPrimarySchema returns PrimarySchema
+func (m ConnectionSummaryFromAtp) GetPrimarySchema() *Schema {
+	return m.PrimarySchema
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m ConnectionSummaryFromAtp) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetIsDefault returns IsDefault
+func (m ConnectionSummaryFromAtp) GetIsDefault() *bool {
+	return m.IsDefault
+}
+
+//GetMetadata returns Metadata
+func (m ConnectionSummaryFromAtp) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m ConnectionSummaryFromAtp) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m ConnectionSummaryFromAtp) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ConnectionSummaryFromAtp) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeConnectionSummaryFromAtp ConnectionSummaryFromAtp
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeConnectionSummaryFromAtp
+	}{
+		"ORACLE_ATP_CONNECTION",
+		(MarshalTypeConnectionSummaryFromAtp)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/connection_summary_from_object_storage.go
+++ b/dataintegration/connection_summary_from_object_storage.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConnectionSummaryFromObjectStorage The Object Storage connection details.
+type ConnectionSummaryFromObjectStorage struct {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	PrimarySchema *Schema `mandatory:"false" json:"primarySchema"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	// The default property for the connection.
+	IsDefault *bool `mandatory:"false" json:"isDefault"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+
+	// The credential file content from a wallet for the data asset.
+	CredentialFileContent *string `mandatory:"false" json:"credentialFileContent"`
+
+	// The OCI user OCID for the user to connect to.
+	UserId *string `mandatory:"false" json:"userId"`
+
+	// The fingeprint for the user.
+	FingerPrint *string `mandatory:"false" json:"fingerPrint"`
+
+	// The pass phrase for the connection.
+	PassPhrase *string `mandatory:"false" json:"passPhrase"`
+}
+
+//GetKey returns Key
+func (m ConnectionSummaryFromObjectStorage) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m ConnectionSummaryFromObjectStorage) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m ConnectionSummaryFromObjectStorage) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m ConnectionSummaryFromObjectStorage) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m ConnectionSummaryFromObjectStorage) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m ConnectionSummaryFromObjectStorage) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m ConnectionSummaryFromObjectStorage) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m ConnectionSummaryFromObjectStorage) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetPrimarySchema returns PrimarySchema
+func (m ConnectionSummaryFromObjectStorage) GetPrimarySchema() *Schema {
+	return m.PrimarySchema
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m ConnectionSummaryFromObjectStorage) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetIsDefault returns IsDefault
+func (m ConnectionSummaryFromObjectStorage) GetIsDefault() *bool {
+	return m.IsDefault
+}
+
+//GetMetadata returns Metadata
+func (m ConnectionSummaryFromObjectStorage) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m ConnectionSummaryFromObjectStorage) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m ConnectionSummaryFromObjectStorage) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ConnectionSummaryFromObjectStorage) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeConnectionSummaryFromObjectStorage ConnectionSummaryFromObjectStorage
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeConnectionSummaryFromObjectStorage
+	}{
+		"ORACLE_OBJECT_STORAGE_CONNECTION",
+		(MarshalTypeConnectionSummaryFromObjectStorage)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/connection_summary_from_oracle.go
+++ b/dataintegration/connection_summary_from_oracle.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConnectionSummaryFromOracle The Oracle connection details object.
+type ConnectionSummaryFromOracle struct {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	PrimarySchema *Schema `mandatory:"false" json:"primarySchema"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	// The default property for the connection.
+	IsDefault *bool `mandatory:"false" json:"isDefault"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+
+	// The user name for the connection.
+	Username *string `mandatory:"false" json:"username"`
+
+	// The password for the connection.
+	Password *string `mandatory:"false" json:"password"`
+}
+
+//GetKey returns Key
+func (m ConnectionSummaryFromOracle) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m ConnectionSummaryFromOracle) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m ConnectionSummaryFromOracle) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m ConnectionSummaryFromOracle) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m ConnectionSummaryFromOracle) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m ConnectionSummaryFromOracle) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m ConnectionSummaryFromOracle) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m ConnectionSummaryFromOracle) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetPrimarySchema returns PrimarySchema
+func (m ConnectionSummaryFromOracle) GetPrimarySchema() *Schema {
+	return m.PrimarySchema
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m ConnectionSummaryFromOracle) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetIsDefault returns IsDefault
+func (m ConnectionSummaryFromOracle) GetIsDefault() *bool {
+	return m.IsDefault
+}
+
+//GetMetadata returns Metadata
+func (m ConnectionSummaryFromOracle) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m ConnectionSummaryFromOracle) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m ConnectionSummaryFromOracle) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ConnectionSummaryFromOracle) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeConnectionSummaryFromOracle ConnectionSummaryFromOracle
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeConnectionSummaryFromOracle
+	}{
+		"ORACLEDB_CONNECTION",
+		(MarshalTypeConnectionSummaryFromOracle)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/connection_validation.go
+++ b/dataintegration/connection_validation.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConnectionValidation The information about connection validation
+type ConnectionValidation struct {
+	ValidationMessage *Message `mandatory:"false" json:"validationMessage"`
+
+	// Objects will use a 36 character key as unique ID. It is system generated and cannot be edited by user
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+}
+
+func (m ConnectionValidation) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/connection_validation_summary.go
+++ b/dataintegration/connection_validation_summary.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConnectionValidationSummary The information about connection validation
+type ConnectionValidationSummary struct {
+	ValidationMessage *Message `mandatory:"false" json:"validationMessage"`
+
+	// Objects will use a 36 character key as unique ID. It is system generated and cannot be edited by user
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+}
+
+func (m ConnectionValidationSummary) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/connection_validation_summary_collection.go
+++ b/dataintegration/connection_validation_summary_collection.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ConnectionValidationSummaryCollection List of connection validation summaries
+type ConnectionValidationSummaryCollection struct {
+
+	// The array of validation summaries
+	Items []ConnectionValidationSummary `mandatory:"true" json:"items"`
+}
+
+func (m ConnectionValidationSummaryCollection) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/count_statistic.go
+++ b/dataintegration/count_statistic.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CountStatistic A count statistics
+type CountStatistic struct {
+
+	// The array of statistics
+	ObjectTypeCountList []CountStatisticSummary `mandatory:"true" json:"objectTypeCountList"`
+}
+
+func (m CountStatistic) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/count_statistic_summary.go
+++ b/dataintegration/count_statistic_summary.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CountStatisticSummary Detail of object.
+type CountStatisticSummary struct {
+
+	// the type of object for the object count statistic.
+	ObjectType CountStatisticSummaryObjectTypeEnum `mandatory:"false" json:"objectType,omitempty"`
+
+	// the value for the object count statistic.
+	ObjectCount *int64 `mandatory:"false" json:"objectCount"`
+}
+
+func (m CountStatisticSummary) String() string {
+	return common.PointerString(m)
+}
+
+// CountStatisticSummaryObjectTypeEnum Enum with underlying type: string
+type CountStatisticSummaryObjectTypeEnum string
+
+// Set of constants representing the allowable values for CountStatisticSummaryObjectTypeEnum
+const (
+	CountStatisticSummaryObjectTypeProject     CountStatisticSummaryObjectTypeEnum = "PROJECT"
+	CountStatisticSummaryObjectTypeFolder      CountStatisticSummaryObjectTypeEnum = "FOLDER"
+	CountStatisticSummaryObjectTypeDataFlow    CountStatisticSummaryObjectTypeEnum = "DATA_FLOW"
+	CountStatisticSummaryObjectTypeDataAsset   CountStatisticSummaryObjectTypeEnum = "DATA_ASSET"
+	CountStatisticSummaryObjectTypeConnection  CountStatisticSummaryObjectTypeEnum = "CONNECTION"
+	CountStatisticSummaryObjectTypeTask        CountStatisticSummaryObjectTypeEnum = "TASK"
+	CountStatisticSummaryObjectTypeApplication CountStatisticSummaryObjectTypeEnum = "APPLICATION"
+)
+
+var mappingCountStatisticSummaryObjectType = map[string]CountStatisticSummaryObjectTypeEnum{
+	"PROJECT":     CountStatisticSummaryObjectTypeProject,
+	"FOLDER":      CountStatisticSummaryObjectTypeFolder,
+	"DATA_FLOW":   CountStatisticSummaryObjectTypeDataFlow,
+	"DATA_ASSET":  CountStatisticSummaryObjectTypeDataAsset,
+	"CONNECTION":  CountStatisticSummaryObjectTypeConnection,
+	"TASK":        CountStatisticSummaryObjectTypeTask,
+	"APPLICATION": CountStatisticSummaryObjectTypeApplication,
+}
+
+// GetCountStatisticSummaryObjectTypeEnumValues Enumerates the set of values for CountStatisticSummaryObjectTypeEnum
+func GetCountStatisticSummaryObjectTypeEnumValues() []CountStatisticSummaryObjectTypeEnum {
+	values := make([]CountStatisticSummaryObjectTypeEnum, 0)
+	for _, v := range mappingCountStatisticSummaryObjectType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/create_application_details.go
+++ b/dataintegration/create_application_details.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateApplicationDetails Properties used in application create operations.
+type CreateApplicationDetails struct {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"true" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"true" json:"identifier"`
+
+	// Currently not used on application creation. Reserved for future.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// The type of the application.
+	ModelType CreateApplicationDetailsModelTypeEnum `mandatory:"false" json:"modelType,omitempty"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+}
+
+func (m CreateApplicationDetails) String() string {
+	return common.PointerString(m)
+}
+
+// CreateApplicationDetailsModelTypeEnum Enum with underlying type: string
+type CreateApplicationDetailsModelTypeEnum string
+
+// Set of constants representing the allowable values for CreateApplicationDetailsModelTypeEnum
+const (
+	CreateApplicationDetailsModelTypeIntegrationApplication CreateApplicationDetailsModelTypeEnum = "INTEGRATION_APPLICATION"
+)
+
+var mappingCreateApplicationDetailsModelType = map[string]CreateApplicationDetailsModelTypeEnum{
+	"INTEGRATION_APPLICATION": CreateApplicationDetailsModelTypeIntegrationApplication,
+}
+
+// GetCreateApplicationDetailsModelTypeEnumValues Enumerates the set of values for CreateApplicationDetailsModelTypeEnum
+func GetCreateApplicationDetailsModelTypeEnumValues() []CreateApplicationDetailsModelTypeEnum {
+	values := make([]CreateApplicationDetailsModelTypeEnum, 0)
+	for _, v := range mappingCreateApplicationDetailsModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/create_application_request_response.go
+++ b/dataintegration/create_application_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateApplicationRequest wrapper for the CreateApplication operation
+type CreateApplicationRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// The details needed to create an application.
+	CreateApplicationDetails `contributesTo:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Caller may provide "retry tokens" allowing them to retry an operation
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateApplicationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateApplicationRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateApplicationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateApplicationResponse wrapper for the CreateApplication operation
+type CreateApplicationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Application instance
+	Application `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateApplicationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateApplicationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/create_config_provider.go
+++ b/dataintegration/create_config_provider.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateConfigProvider The type to create a config provider.
+type CreateConfigProvider struct {
+
+	// bindings
+	Bindings map[string]ParameterValue `mandatory:"false" json:"bindings"`
+}
+
+func (m CreateConfigProvider) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/create_connection_details.go
+++ b/dataintegration/create_connection_details.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateConnectionDetails Properties used in connection create operations.
+type CreateConnectionDetails interface {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	GetName() *string
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	GetIdentifier() *string
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	GetKey() *string
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	GetParentRef() *ParentReference
+
+	// Detailed description for the object.
+	GetDescription() *string
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// The properties for the connection.
+	GetConnectionProperties() []ConnectionProperty
+
+	GetRegistryMetadata() *RegistryMetadata
+}
+
+type createconnectiondetails struct {
+	JsonData             []byte
+	Name                 *string              `mandatory:"true" json:"name"`
+	Identifier           *string              `mandatory:"true" json:"identifier"`
+	Key                  *string              `mandatory:"false" json:"key"`
+	ModelVersion         *string              `mandatory:"false" json:"modelVersion"`
+	ParentRef            *ParentReference     `mandatory:"false" json:"parentRef"`
+	Description          *string              `mandatory:"false" json:"description"`
+	ObjectStatus         *int                 `mandatory:"false" json:"objectStatus"`
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+	RegistryMetadata     *RegistryMetadata    `mandatory:"false" json:"registryMetadata"`
+	ModelType            string               `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *createconnectiondetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalercreateconnectiondetails createconnectiondetails
+	s := struct {
+		Model Unmarshalercreateconnectiondetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Name = s.Model.Name
+	m.Identifier = s.Model.Identifier
+	m.Key = s.Model.Key
+	m.ModelVersion = s.Model.ModelVersion
+	m.ParentRef = s.Model.ParentRef
+	m.Description = s.Model.Description
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.ConnectionProperties = s.Model.ConnectionProperties
+	m.RegistryMetadata = s.Model.RegistryMetadata
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *createconnectiondetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "ORACLE_ATP_CONNECTION":
+		mm := CreateConnectionFromAtp{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_ADWC_CONNECTION":
+		mm := CreateConnectionFromAdwc{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLEDB_CONNECTION":
+		mm := CreateConnectionFromOracle{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_OBJECT_STORAGE_CONNECTION":
+		mm := CreateConnectionFromObjectStorage{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetName returns Name
+func (m createconnectiondetails) GetName() *string {
+	return m.Name
+}
+
+//GetIdentifier returns Identifier
+func (m createconnectiondetails) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetKey returns Key
+func (m createconnectiondetails) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m createconnectiondetails) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m createconnectiondetails) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetDescription returns Description
+func (m createconnectiondetails) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m createconnectiondetails) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m createconnectiondetails) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m createconnectiondetails) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m createconnectiondetails) String() string {
+	return common.PointerString(m)
+}
+
+// CreateConnectionDetailsModelTypeEnum Enum with underlying type: string
+type CreateConnectionDetailsModelTypeEnum string
+
+// Set of constants representing the allowable values for CreateConnectionDetailsModelTypeEnum
+const (
+	CreateConnectionDetailsModelTypeOracleAdwcConnection          CreateConnectionDetailsModelTypeEnum = "ORACLE_ADWC_CONNECTION"
+	CreateConnectionDetailsModelTypeOracleAtpConnection           CreateConnectionDetailsModelTypeEnum = "ORACLE_ATP_CONNECTION"
+	CreateConnectionDetailsModelTypeOracleObjectStorageConnection CreateConnectionDetailsModelTypeEnum = "ORACLE_OBJECT_STORAGE_CONNECTION"
+	CreateConnectionDetailsModelTypeOracledbConnection            CreateConnectionDetailsModelTypeEnum = "ORACLEDB_CONNECTION"
+)
+
+var mappingCreateConnectionDetailsModelType = map[string]CreateConnectionDetailsModelTypeEnum{
+	"ORACLE_ADWC_CONNECTION":           CreateConnectionDetailsModelTypeOracleAdwcConnection,
+	"ORACLE_ATP_CONNECTION":            CreateConnectionDetailsModelTypeOracleAtpConnection,
+	"ORACLE_OBJECT_STORAGE_CONNECTION": CreateConnectionDetailsModelTypeOracleObjectStorageConnection,
+	"ORACLEDB_CONNECTION":              CreateConnectionDetailsModelTypeOracledbConnection,
+}
+
+// GetCreateConnectionDetailsModelTypeEnumValues Enumerates the set of values for CreateConnectionDetailsModelTypeEnum
+func GetCreateConnectionDetailsModelTypeEnumValues() []CreateConnectionDetailsModelTypeEnum {
+	values := make([]CreateConnectionDetailsModelTypeEnum, 0)
+	for _, v := range mappingCreateConnectionDetailsModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/create_connection_from_adwc.go
+++ b/dataintegration/create_connection_from_adwc.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateConnectionFromAdwc The ADWC connection details object.
+type CreateConnectionFromAdwc struct {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"true" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"true" json:"identifier"`
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+
+	// The user name for the connection.
+	Username *string `mandatory:"false" json:"username"`
+
+	// The password for the connection.
+	Password *string `mandatory:"false" json:"password"`
+}
+
+//GetKey returns Key
+func (m CreateConnectionFromAdwc) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m CreateConnectionFromAdwc) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m CreateConnectionFromAdwc) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m CreateConnectionFromAdwc) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m CreateConnectionFromAdwc) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m CreateConnectionFromAdwc) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m CreateConnectionFromAdwc) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m CreateConnectionFromAdwc) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m CreateConnectionFromAdwc) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m CreateConnectionFromAdwc) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateConnectionFromAdwc) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateConnectionFromAdwc CreateConnectionFromAdwc
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeCreateConnectionFromAdwc
+	}{
+		"ORACLE_ADWC_CONNECTION",
+		(MarshalTypeCreateConnectionFromAdwc)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/create_connection_from_atp.go
+++ b/dataintegration/create_connection_from_atp.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateConnectionFromAtp The ATP connection details.
+type CreateConnectionFromAtp struct {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"true" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"true" json:"identifier"`
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+
+	// The user name for the connection.
+	Username *string `mandatory:"false" json:"username"`
+
+	// The password for the connection.
+	Password *string `mandatory:"false" json:"password"`
+}
+
+//GetKey returns Key
+func (m CreateConnectionFromAtp) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m CreateConnectionFromAtp) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m CreateConnectionFromAtp) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m CreateConnectionFromAtp) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m CreateConnectionFromAtp) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m CreateConnectionFromAtp) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m CreateConnectionFromAtp) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m CreateConnectionFromAtp) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m CreateConnectionFromAtp) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m CreateConnectionFromAtp) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateConnectionFromAtp) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateConnectionFromAtp CreateConnectionFromAtp
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeCreateConnectionFromAtp
+	}{
+		"ORACLE_ATP_CONNECTION",
+		(MarshalTypeCreateConnectionFromAtp)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/create_connection_from_object_storage.go
+++ b/dataintegration/create_connection_from_object_storage.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateConnectionFromObjectStorage The Object Storage connection details.
+type CreateConnectionFromObjectStorage struct {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"true" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"true" json:"identifier"`
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+
+	// The credential file content from a wallet for the data asset.
+	CredentialFileContent *string `mandatory:"false" json:"credentialFileContent"`
+
+	// The OCI user OCID for the user to connect to.
+	UserId *string `mandatory:"false" json:"userId"`
+
+	// The fingeprint for the user.
+	FingerPrint *string `mandatory:"false" json:"fingerPrint"`
+
+	// The pass phrase for the connection.
+	PassPhrase *string `mandatory:"false" json:"passPhrase"`
+}
+
+//GetKey returns Key
+func (m CreateConnectionFromObjectStorage) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m CreateConnectionFromObjectStorage) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m CreateConnectionFromObjectStorage) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m CreateConnectionFromObjectStorage) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m CreateConnectionFromObjectStorage) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m CreateConnectionFromObjectStorage) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m CreateConnectionFromObjectStorage) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m CreateConnectionFromObjectStorage) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m CreateConnectionFromObjectStorage) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m CreateConnectionFromObjectStorage) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateConnectionFromObjectStorage) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateConnectionFromObjectStorage CreateConnectionFromObjectStorage
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeCreateConnectionFromObjectStorage
+	}{
+		"ORACLE_OBJECT_STORAGE_CONNECTION",
+		(MarshalTypeCreateConnectionFromObjectStorage)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/create_connection_from_oracle.go
+++ b/dataintegration/create_connection_from_oracle.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateConnectionFromOracle The Oracle connection details object.
+type CreateConnectionFromOracle struct {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"true" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"true" json:"identifier"`
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+
+	// The user name for the connection.
+	Username *string `mandatory:"false" json:"username"`
+
+	// The password for the connection.
+	Password *string `mandatory:"false" json:"password"`
+}
+
+//GetKey returns Key
+func (m CreateConnectionFromOracle) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m CreateConnectionFromOracle) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m CreateConnectionFromOracle) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m CreateConnectionFromOracle) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m CreateConnectionFromOracle) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m CreateConnectionFromOracle) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m CreateConnectionFromOracle) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m CreateConnectionFromOracle) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m CreateConnectionFromOracle) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m CreateConnectionFromOracle) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateConnectionFromOracle) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateConnectionFromOracle CreateConnectionFromOracle
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeCreateConnectionFromOracle
+	}{
+		"ORACLEDB_CONNECTION",
+		(MarshalTypeCreateConnectionFromOracle)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/create_connection_request_response.go
+++ b/dataintegration/create_connection_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateConnectionRequest wrapper for the CreateConnection operation
+type CreateConnectionRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// Request body parameter for connection details
+	CreateConnectionDetails `contributesTo:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Caller may provide "retry tokens" allowing them to retry an operation
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateConnectionRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateConnectionRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateConnectionRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateConnectionResponse wrapper for the CreateConnection operation
+type CreateConnectionResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Connection instance
+	Connection `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateConnectionResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateConnectionResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/create_connection_validation_details.go
+++ b/dataintegration/create_connection_validation_details.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateConnectionValidationDetails Connection validation definition
+type CreateConnectionValidationDetails struct {
+	DataAsset CreateDataAssetDetails `mandatory:"false" json:"dataAsset"`
+
+	Connection CreateConnectionDetails `mandatory:"false" json:"connection"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+}
+
+func (m CreateConnectionValidationDetails) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *CreateConnectionValidationDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		DataAsset        createdataassetdetails  `json:"dataAsset"`
+		Connection       createconnectiondetails `json:"connection"`
+		RegistryMetadata *RegistryMetadata       `json:"registryMetadata"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	nn, e = model.DataAsset.UnmarshalPolymorphicJSON(model.DataAsset.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.DataAsset = nn.(CreateDataAssetDetails)
+	} else {
+		m.DataAsset = nil
+	}
+
+	nn, e = model.Connection.UnmarshalPolymorphicJSON(model.Connection.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.Connection = nn.(CreateConnectionDetails)
+	} else {
+		m.Connection = nil
+	}
+
+	m.RegistryMetadata = model.RegistryMetadata
+	return
+}

--- a/dataintegration/create_connection_validation_request_response.go
+++ b/dataintegration/create_connection_validation_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateConnectionValidationRequest wrapper for the CreateConnectionValidation operation
+type CreateConnectionValidationRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// Connection info
+	CreateConnectionValidationDetails `contributesTo:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Caller may provide "retry tokens" allowing them to retry an operation
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateConnectionValidationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateConnectionValidationRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateConnectionValidationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateConnectionValidationResponse wrapper for the CreateConnectionValidation operation
+type CreateConnectionValidationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ConnectionValidation instance
+	ConnectionValidation `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateConnectionValidationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateConnectionValidationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/create_data_asset_details.go
+++ b/dataintegration/create_data_asset_details.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateDataAssetDetails Properties used in data asset update operations.
+type CreateDataAssetDetails interface {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	GetName() *string
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	GetIdentifier() *string
+
+	// Currently not used on data asset creation. Reserved for future.
+	GetKey() *string
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	// Detailed description for the object.
+	GetDescription() *string
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// The external key for the object
+	GetExternalKey() *string
+
+	// assetProperties
+	GetAssetProperties() map[string]string
+
+	GetRegistryMetadata() *RegistryMetadata
+}
+
+type createdataassetdetails struct {
+	JsonData         []byte
+	Name             *string           `mandatory:"true" json:"name"`
+	Identifier       *string           `mandatory:"true" json:"identifier"`
+	Key              *string           `mandatory:"false" json:"key"`
+	ModelVersion     *string           `mandatory:"false" json:"modelVersion"`
+	Description      *string           `mandatory:"false" json:"description"`
+	ObjectStatus     *int              `mandatory:"false" json:"objectStatus"`
+	ExternalKey      *string           `mandatory:"false" json:"externalKey"`
+	AssetProperties  map[string]string `mandatory:"false" json:"assetProperties"`
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+	ModelType        string            `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *createdataassetdetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalercreatedataassetdetails createdataassetdetails
+	s := struct {
+		Model Unmarshalercreatedataassetdetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Name = s.Model.Name
+	m.Identifier = s.Model.Identifier
+	m.Key = s.Model.Key
+	m.ModelVersion = s.Model.ModelVersion
+	m.Description = s.Model.Description
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.ExternalKey = s.Model.ExternalKey
+	m.AssetProperties = s.Model.AssetProperties
+	m.RegistryMetadata = s.Model.RegistryMetadata
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *createdataassetdetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "ORACLE_DATA_ASSET":
+		mm := CreateDataAssetFromOracle{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_ADWC_DATA_ASSET":
+		mm := CreateDataAssetFromAdwc{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_ATP_DATA_ASSET":
+		mm := CreateDataAssetFromAtp{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_OBJECT_STORAGE_DATA_ASSET":
+		mm := CreateDataAssetFromObjectStorage{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetName returns Name
+func (m createdataassetdetails) GetName() *string {
+	return m.Name
+}
+
+//GetIdentifier returns Identifier
+func (m createdataassetdetails) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetKey returns Key
+func (m createdataassetdetails) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m createdataassetdetails) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetDescription returns Description
+func (m createdataassetdetails) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m createdataassetdetails) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetExternalKey returns ExternalKey
+func (m createdataassetdetails) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m createdataassetdetails) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m createdataassetdetails) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m createdataassetdetails) String() string {
+	return common.PointerString(m)
+}
+
+// CreateDataAssetDetailsModelTypeEnum Enum with underlying type: string
+type CreateDataAssetDetailsModelTypeEnum string
+
+// Set of constants representing the allowable values for CreateDataAssetDetailsModelTypeEnum
+const (
+	CreateDataAssetDetailsModelTypeDataAsset              CreateDataAssetDetailsModelTypeEnum = "ORACLE_DATA_ASSET"
+	CreateDataAssetDetailsModelTypeObjectStorageDataAsset CreateDataAssetDetailsModelTypeEnum = "ORACLE_OBJECT_STORAGE_DATA_ASSET"
+	CreateDataAssetDetailsModelTypeAtpDataAsset           CreateDataAssetDetailsModelTypeEnum = "ORACLE_ATP_DATA_ASSET"
+	CreateDataAssetDetailsModelTypeAdwcDataAsset          CreateDataAssetDetailsModelTypeEnum = "ORACLE_ADWC_DATA_ASSET"
+)
+
+var mappingCreateDataAssetDetailsModelType = map[string]CreateDataAssetDetailsModelTypeEnum{
+	"ORACLE_DATA_ASSET":                CreateDataAssetDetailsModelTypeDataAsset,
+	"ORACLE_OBJECT_STORAGE_DATA_ASSET": CreateDataAssetDetailsModelTypeObjectStorageDataAsset,
+	"ORACLE_ATP_DATA_ASSET":            CreateDataAssetDetailsModelTypeAtpDataAsset,
+	"ORACLE_ADWC_DATA_ASSET":           CreateDataAssetDetailsModelTypeAdwcDataAsset,
+}
+
+// GetCreateDataAssetDetailsModelTypeEnumValues Enumerates the set of values for CreateDataAssetDetailsModelTypeEnum
+func GetCreateDataAssetDetailsModelTypeEnumValues() []CreateDataAssetDetailsModelTypeEnum {
+	values := make([]CreateDataAssetDetailsModelTypeEnum, 0)
+	for _, v := range mappingCreateDataAssetDetailsModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/create_data_asset_from_adwc.go
+++ b/dataintegration/create_data_asset_from_adwc.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateDataAssetFromAdwc The ADWC data asset details.
+type CreateDataAssetFromAdwc struct {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"true" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"true" json:"identifier"`
+
+	// Currently not used on data asset creation. Reserved for future.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// The external key for the object
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	// assetProperties
+	AssetProperties map[string]string `mandatory:"false" json:"assetProperties"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+
+	// The service name for the data asset.
+	ServiceName *string `mandatory:"false" json:"serviceName"`
+
+	// The driver class for the data asset.
+	DriverClass *string `mandatory:"false" json:"driverClass"`
+
+	// The credential file content from a wallet for the data asset.
+	CredentialFileContent *string `mandatory:"false" json:"credentialFileContent"`
+
+	DefaultConnection *CreateConnectionFromAdwc `mandatory:"false" json:"defaultConnection"`
+}
+
+//GetKey returns Key
+func (m CreateDataAssetFromAdwc) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m CreateDataAssetFromAdwc) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetName returns Name
+func (m CreateDataAssetFromAdwc) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m CreateDataAssetFromAdwc) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m CreateDataAssetFromAdwc) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m CreateDataAssetFromAdwc) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetExternalKey returns ExternalKey
+func (m CreateDataAssetFromAdwc) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m CreateDataAssetFromAdwc) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m CreateDataAssetFromAdwc) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m CreateDataAssetFromAdwc) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateDataAssetFromAdwc) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateDataAssetFromAdwc CreateDataAssetFromAdwc
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeCreateDataAssetFromAdwc
+	}{
+		"ORACLE_ADWC_DATA_ASSET",
+		(MarshalTypeCreateDataAssetFromAdwc)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/create_data_asset_from_atp.go
+++ b/dataintegration/create_data_asset_from_atp.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateDataAssetFromAtp The ATP data asset details.
+type CreateDataAssetFromAtp struct {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"true" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"true" json:"identifier"`
+
+	// Currently not used on data asset creation. Reserved for future.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// The external key for the object
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	// assetProperties
+	AssetProperties map[string]string `mandatory:"false" json:"assetProperties"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+
+	// The service name for the data asset.
+	ServiceName *string `mandatory:"false" json:"serviceName"`
+
+	// The driver class for the data asset.
+	DriverClass *string `mandatory:"false" json:"driverClass"`
+
+	// The credential file content from a wallet for the data asset.
+	CredentialFileContent *string `mandatory:"false" json:"credentialFileContent"`
+
+	DefaultConnection *CreateConnectionFromAtp `mandatory:"false" json:"defaultConnection"`
+}
+
+//GetKey returns Key
+func (m CreateDataAssetFromAtp) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m CreateDataAssetFromAtp) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetName returns Name
+func (m CreateDataAssetFromAtp) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m CreateDataAssetFromAtp) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m CreateDataAssetFromAtp) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m CreateDataAssetFromAtp) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetExternalKey returns ExternalKey
+func (m CreateDataAssetFromAtp) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m CreateDataAssetFromAtp) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m CreateDataAssetFromAtp) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m CreateDataAssetFromAtp) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateDataAssetFromAtp) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateDataAssetFromAtp CreateDataAssetFromAtp
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeCreateDataAssetFromAtp
+	}{
+		"ORACLE_ATP_DATA_ASSET",
+		(MarshalTypeCreateDataAssetFromAtp)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/create_data_asset_from_object_storage.go
+++ b/dataintegration/create_data_asset_from_object_storage.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateDataAssetFromObjectStorage The Object Storage data asset details.
+type CreateDataAssetFromObjectStorage struct {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"true" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"true" json:"identifier"`
+
+	// Currently not used on data asset creation. Reserved for future.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// The external key for the object
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	// assetProperties
+	AssetProperties map[string]string `mandatory:"false" json:"assetProperties"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+
+	// url
+	Url *string `mandatory:"false" json:"url"`
+
+	// The OCI tenancy OCID.
+	TenancyId *string `mandatory:"false" json:"tenancyId"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Namespace *string `mandatory:"false" json:"namespace"`
+
+	DefaultConnection *CreateConnectionFromObjectStorage `mandatory:"false" json:"defaultConnection"`
+}
+
+//GetKey returns Key
+func (m CreateDataAssetFromObjectStorage) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m CreateDataAssetFromObjectStorage) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetName returns Name
+func (m CreateDataAssetFromObjectStorage) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m CreateDataAssetFromObjectStorage) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m CreateDataAssetFromObjectStorage) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m CreateDataAssetFromObjectStorage) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetExternalKey returns ExternalKey
+func (m CreateDataAssetFromObjectStorage) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m CreateDataAssetFromObjectStorage) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m CreateDataAssetFromObjectStorage) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m CreateDataAssetFromObjectStorage) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateDataAssetFromObjectStorage) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateDataAssetFromObjectStorage CreateDataAssetFromObjectStorage
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeCreateDataAssetFromObjectStorage
+	}{
+		"ORACLE_OBJECT_STORAGE_DATA_ASSET",
+		(MarshalTypeCreateDataAssetFromObjectStorage)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/create_data_asset_from_oracle.go
+++ b/dataintegration/create_data_asset_from_oracle.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateDataAssetFromOracle The Oracle data asset details.
+type CreateDataAssetFromOracle struct {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"true" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"true" json:"identifier"`
+
+	// Currently not used on data asset creation. Reserved for future.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// The external key for the object
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	// assetProperties
+	AssetProperties map[string]string `mandatory:"false" json:"assetProperties"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+
+	// The host details for the data asset.
+	Host *string `mandatory:"false" json:"host"`
+
+	// The port details for the data asset.
+	Port *string `mandatory:"false" json:"port"`
+
+	// The service name for the data asset.
+	ServiceName *string `mandatory:"false" json:"serviceName"`
+
+	// The driver class for the data asset.
+	DriverClass *string `mandatory:"false" json:"driverClass"`
+
+	// sid
+	Sid *string `mandatory:"false" json:"sid"`
+
+	// The credential file content from a wallet for the data asset.
+	CredentialFileContent *string `mandatory:"false" json:"credentialFileContent"`
+
+	DefaultConnection *CreateConnectionFromOracle `mandatory:"false" json:"defaultConnection"`
+}
+
+//GetKey returns Key
+func (m CreateDataAssetFromOracle) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m CreateDataAssetFromOracle) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetName returns Name
+func (m CreateDataAssetFromOracle) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m CreateDataAssetFromOracle) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m CreateDataAssetFromOracle) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m CreateDataAssetFromOracle) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetExternalKey returns ExternalKey
+func (m CreateDataAssetFromOracle) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m CreateDataAssetFromOracle) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m CreateDataAssetFromOracle) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m CreateDataAssetFromOracle) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateDataAssetFromOracle) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateDataAssetFromOracle CreateDataAssetFromOracle
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeCreateDataAssetFromOracle
+	}{
+		"ORACLE_DATA_ASSET",
+		(MarshalTypeCreateDataAssetFromOracle)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/create_data_asset_request_response.go
+++ b/dataintegration/create_data_asset_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateDataAssetRequest wrapper for the CreateDataAsset operation
+type CreateDataAssetRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// Request body parameter for data asset details
+	CreateDataAssetDetails `contributesTo:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Caller may provide "retry tokens" allowing them to retry an operation
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateDataAssetRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateDataAssetRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateDataAssetRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateDataAssetResponse wrapper for the CreateDataAsset operation
+type CreateDataAssetResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The DataAsset instance
+	DataAsset `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateDataAssetResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateDataAssetResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/create_data_flow_details.go
+++ b/dataintegration/create_data_flow_details.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateDataFlowDetails Properties used in data flow create operations.
+type CreateDataFlowDetails struct {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"true" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"true" json:"identifier"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"true" json:"registryMetadata"`
+
+	// Generated key that can be used in API calls to identify data flow. On scenarios where reference to the data flow is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// An array of nodes.
+	Nodes []FlowNode `mandatory:"false" json:"nodes"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	FlowConfigValues *ConfigValues `mandatory:"false" json:"flowConfigValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+}
+
+func (m CreateDataFlowDetails) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/create_data_flow_request_response.go
+++ b/dataintegration/create_data_flow_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateDataFlowRequest wrapper for the CreateDataFlow operation
+type CreateDataFlowRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// The details needed to create a new data flow.
+	CreateDataFlowDetails `contributesTo:"body"`
+
+	// Caller may provide "retry tokens" allowing them to retry an operation
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateDataFlowRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateDataFlowRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateDataFlowRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateDataFlowResponse wrapper for the CreateDataFlow operation
+type CreateDataFlowResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The DataFlow instance
+	DataFlow `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateDataFlowResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateDataFlowResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/create_data_flow_validation_details.go
+++ b/dataintegration/create_data_flow_validation_details.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateDataFlowValidationDetails The information about integration dataflow validation.
+type CreateDataFlowValidationDetails struct {
+
+	// Generated key that can be used in API calls to identify data flow. On scenarios where reference to the data flow is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// An array of nodes.
+	Nodes []FlowNode `mandatory:"false" json:"nodes"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	FlowConfigValues *ConfigValues `mandatory:"false" json:"flowConfigValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+}
+
+func (m CreateDataFlowValidationDetails) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/create_data_flow_validation_request_response.go
+++ b/dataintegration/create_data_flow_validation_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateDataFlowValidationRequest wrapper for the CreateDataFlowValidation operation
+type CreateDataFlowValidationRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// Details for the new DataFlow object.
+	CreateDataFlowValidationDetails `contributesTo:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Caller may provide "retry tokens" allowing them to retry an operation
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateDataFlowValidationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateDataFlowValidationRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateDataFlowValidationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateDataFlowValidationResponse wrapper for the CreateDataFlowValidation operation
+type CreateDataFlowValidationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The DataFlowValidation instance
+	DataFlowValidation `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateDataFlowValidationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateDataFlowValidationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/create_entity_shape_details.go
+++ b/dataintegration/create_entity_shape_details.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateEntityShapeDetails The data entity shape object.
+type CreateEntityShapeDetails interface {
+}
+
+type createentityshapedetails struct {
+	JsonData  []byte
+	ModelType string `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *createentityshapedetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalercreateentityshapedetails createentityshapedetails
+	s := struct {
+		Model Unmarshalercreateentityshapedetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *createentityshapedetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "FILE_ENTITY":
+		mm := CreateEntityShapeFromFile{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m createentityshapedetails) String() string {
+	return common.PointerString(m)
+}
+
+// CreateEntityShapeDetailsModelTypeEnum Enum with underlying type: string
+type CreateEntityShapeDetailsModelTypeEnum string
+
+// Set of constants representing the allowable values for CreateEntityShapeDetailsModelTypeEnum
+const (
+	CreateEntityShapeDetailsModelTypeFileEntity CreateEntityShapeDetailsModelTypeEnum = "FILE_ENTITY"
+)
+
+var mappingCreateEntityShapeDetailsModelType = map[string]CreateEntityShapeDetailsModelTypeEnum{
+	"FILE_ENTITY": CreateEntityShapeDetailsModelTypeFileEntity,
+}
+
+// GetCreateEntityShapeDetailsModelTypeEnumValues Enumerates the set of values for CreateEntityShapeDetailsModelTypeEnum
+func GetCreateEntityShapeDetailsModelTypeEnumValues() []CreateEntityShapeDetailsModelTypeEnum {
+	values := make([]CreateEntityShapeDetailsModelTypeEnum, 0)
+	for _, v := range mappingCreateEntityShapeDetailsModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/create_entity_shape_from_file.go
+++ b/dataintegration/create_entity_shape_from_file.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateEntityShapeFromFile The file data entity details.
+type CreateEntityShapeFromFile struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The external key for the object.
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	Shape *Shape `mandatory:"false" json:"shape"`
+
+	// The shape ID.
+	ShapeId *string `mandatory:"false" json:"shapeId"`
+
+	Types *TypeLibrary `mandatory:"false" json:"types"`
+
+	// Specifies other type label.
+	OtherTypeLabel *string `mandatory:"false" json:"otherTypeLabel"`
+
+	// An array of unique keys.
+	UniqueKeys []UniqueKey `mandatory:"false" json:"uniqueKeys"`
+
+	// An array of foreign keys.
+	ForeignKeys []ForeignKey `mandatory:"false" json:"foreignKeys"`
+
+	// The resource name.
+	ResourceName *string `mandatory:"false" json:"resourceName"`
+
+	DataFormat *DataFormat `mandatory:"false" json:"dataFormat"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The entity type.
+	EntityType CreateEntityShapeFromFileEntityTypeEnum `mandatory:"false" json:"entityType,omitempty"`
+}
+
+func (m CreateEntityShapeFromFile) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateEntityShapeFromFile) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateEntityShapeFromFile CreateEntityShapeFromFile
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeCreateEntityShapeFromFile
+	}{
+		"FILE_ENTITY",
+		(MarshalTypeCreateEntityShapeFromFile)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// CreateEntityShapeFromFileEntityTypeEnum Enum with underlying type: string
+type CreateEntityShapeFromFileEntityTypeEnum string
+
+// Set of constants representing the allowable values for CreateEntityShapeFromFileEntityTypeEnum
+const (
+	CreateEntityShapeFromFileEntityTypeTable  CreateEntityShapeFromFileEntityTypeEnum = "TABLE"
+	CreateEntityShapeFromFileEntityTypeView   CreateEntityShapeFromFileEntityTypeEnum = "VIEW"
+	CreateEntityShapeFromFileEntityTypeFile   CreateEntityShapeFromFileEntityTypeEnum = "FILE"
+	CreateEntityShapeFromFileEntityTypeQueue  CreateEntityShapeFromFileEntityTypeEnum = "QUEUE"
+	CreateEntityShapeFromFileEntityTypeStream CreateEntityShapeFromFileEntityTypeEnum = "STREAM"
+	CreateEntityShapeFromFileEntityTypeOther  CreateEntityShapeFromFileEntityTypeEnum = "OTHER"
+)
+
+var mappingCreateEntityShapeFromFileEntityType = map[string]CreateEntityShapeFromFileEntityTypeEnum{
+	"TABLE":  CreateEntityShapeFromFileEntityTypeTable,
+	"VIEW":   CreateEntityShapeFromFileEntityTypeView,
+	"FILE":   CreateEntityShapeFromFileEntityTypeFile,
+	"QUEUE":  CreateEntityShapeFromFileEntityTypeQueue,
+	"STREAM": CreateEntityShapeFromFileEntityTypeStream,
+	"OTHER":  CreateEntityShapeFromFileEntityTypeOther,
+}
+
+// GetCreateEntityShapeFromFileEntityTypeEnumValues Enumerates the set of values for CreateEntityShapeFromFileEntityTypeEnum
+func GetCreateEntityShapeFromFileEntityTypeEnumValues() []CreateEntityShapeFromFileEntityTypeEnum {
+	values := make([]CreateEntityShapeFromFileEntityTypeEnum, 0)
+	for _, v := range mappingCreateEntityShapeFromFileEntityType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/create_entity_shape_request_response.go
+++ b/dataintegration/create_entity_shape_request_response.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateEntityShapeRequest wrapper for the CreateEntityShape operation
+type CreateEntityShapeRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// The connection key
+	ConnectionKey *string `mandatory:"true" contributesTo:"path" name:"connectionKey"`
+
+	// Schema resource name used for retrieving schemas
+	SchemaResourceName *string `mandatory:"true" contributesTo:"path" name:"schemaResourceName"`
+
+	// The details of the data entity to use to infer the data entity shape.
+	CreateEntityShapeDetails `contributesTo:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Caller may provide "retry tokens" allowing them to retry an operation
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateEntityShapeRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateEntityShapeRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateEntityShapeRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateEntityShapeResponse wrapper for the CreateEntityShape operation
+type CreateEntityShapeResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The EntityShape instance
+	EntityShape `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateEntityShapeResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateEntityShapeResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/create_folder_details.go
+++ b/dataintegration/create_folder_details.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateFolderDetails The properties used in folder create operations.
+type CreateFolderDetails struct {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"true" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"true" json:"identifier"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"true" json:"registryMetadata"`
+
+	// Currently not used on folder creation. Reserved for future.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// categoryName
+	CategoryName *string `mandatory:"false" json:"categoryName"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+}
+
+func (m CreateFolderDetails) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/create_folder_request_response.go
+++ b/dataintegration/create_folder_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateFolderRequest wrapper for the CreateFolder operation
+type CreateFolderRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// The details needed to create a folder.
+	CreateFolderDetails `contributesTo:"body"`
+
+	// Caller may provide "retry tokens" allowing them to retry an operation
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateFolderRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateFolderRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateFolderRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateFolderResponse wrapper for the CreateFolder operation
+type CreateFolderResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Folder instance
+	Folder `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateFolderResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateFolderResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/create_patch_details.go
+++ b/dataintegration/create_patch_details.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreatePatchDetails Properties used in patch create operations.
+type CreatePatchDetails struct {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"true" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"true" json:"identifier"`
+
+	// The type of the patch applied or being applied on the application.
+	PatchType CreatePatchDetailsPatchTypeEnum `mandatory:"true" json:"patchType"`
+
+	// The array of object keys to publish into application.
+	ObjectKeys []string `mandatory:"true" json:"objectKeys"`
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+}
+
+func (m CreatePatchDetails) String() string {
+	return common.PointerString(m)
+}
+
+// CreatePatchDetailsPatchTypeEnum Enum with underlying type: string
+type CreatePatchDetailsPatchTypeEnum string
+
+// Set of constants representing the allowable values for CreatePatchDetailsPatchTypeEnum
+const (
+	CreatePatchDetailsPatchTypePublish   CreatePatchDetailsPatchTypeEnum = "PUBLISH"
+	CreatePatchDetailsPatchTypeUnpublish CreatePatchDetailsPatchTypeEnum = "UNPUBLISH"
+)
+
+var mappingCreatePatchDetailsPatchType = map[string]CreatePatchDetailsPatchTypeEnum{
+	"PUBLISH":   CreatePatchDetailsPatchTypePublish,
+	"UNPUBLISH": CreatePatchDetailsPatchTypeUnpublish,
+}
+
+// GetCreatePatchDetailsPatchTypeEnumValues Enumerates the set of values for CreatePatchDetailsPatchTypeEnum
+func GetCreatePatchDetailsPatchTypeEnumValues() []CreatePatchDetailsPatchTypeEnum {
+	values := make([]CreatePatchDetailsPatchTypeEnum, 0)
+	for _, v := range mappingCreatePatchDetailsPatchType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/create_patch_request_response.go
+++ b/dataintegration/create_patch_request_response.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreatePatchRequest wrapper for the CreatePatch operation
+type CreatePatchRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS application key
+	ApplicationKey *string `mandatory:"true" contributesTo:"path" name:"applicationKey"`
+
+	// Detailed needed to create a patch in an application.
+	CreatePatchDetails `contributesTo:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Caller may provide "retry tokens" allowing them to retry an operation
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreatePatchRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreatePatchRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreatePatchRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreatePatchResponse wrapper for the CreatePatch operation
+type CreatePatchResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Patch instance
+	Patch `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreatePatchResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreatePatchResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/create_project_details.go
+++ b/dataintegration/create_project_details.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateProjectDetails The properties used in project create operations.
+type CreateProjectDetails struct {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"true" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"true" json:"identifier"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Generated key that can be used in API calls to identify project.
+	Key *string `mandatory:"false" json:"key"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+}
+
+func (m CreateProjectDetails) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/create_project_request_response.go
+++ b/dataintegration/create_project_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateProjectRequest wrapper for the CreateProject operation
+type CreateProjectRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// The details needed to create a project in a workspace.
+	CreateProjectDetails `contributesTo:"body"`
+
+	// Caller may provide "retry tokens" allowing them to retry an operation
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateProjectRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateProjectRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateProjectRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateProjectResponse wrapper for the CreateProject operation
+type CreateProjectResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Project instance
+	Project `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateProjectResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateProjectResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/create_task_details.go
+++ b/dataintegration/create_task_details.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateTaskDetails Properties used in task create operations.
+type CreateTaskDetails interface {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	GetName() *string
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	GetIdentifier() *string
+
+	GetRegistryMetadata() *RegistryMetadata
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	GetKey() *string
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	GetParentRef() *ParentReference
+
+	// Detailed description for the object.
+	GetDescription() *string
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// An array of input ports.
+	GetInputPorts() []InputPort
+
+	// An array of output ports.
+	GetOutputPorts() []OutputPort
+
+	// An array of parameters.
+	GetParameters() []Parameter
+
+	GetOpConfigValues() *ConfigValues
+
+	GetConfigProviderDelegate() *CreateConfigProvider
+}
+
+type createtaskdetails struct {
+	JsonData               []byte
+	Name                   *string               `mandatory:"true" json:"name"`
+	Identifier             *string               `mandatory:"true" json:"identifier"`
+	RegistryMetadata       *RegistryMetadata     `mandatory:"true" json:"registryMetadata"`
+	Key                    *string               `mandatory:"false" json:"key"`
+	ModelVersion           *string               `mandatory:"false" json:"modelVersion"`
+	ParentRef              *ParentReference      `mandatory:"false" json:"parentRef"`
+	Description            *string               `mandatory:"false" json:"description"`
+	ObjectStatus           *int                  `mandatory:"false" json:"objectStatus"`
+	InputPorts             []InputPort           `mandatory:"false" json:"inputPorts"`
+	OutputPorts            []OutputPort          `mandatory:"false" json:"outputPorts"`
+	Parameters             []Parameter           `mandatory:"false" json:"parameters"`
+	OpConfigValues         *ConfigValues         `mandatory:"false" json:"opConfigValues"`
+	ConfigProviderDelegate *CreateConfigProvider `mandatory:"false" json:"configProviderDelegate"`
+	ModelType              string                `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *createtaskdetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalercreatetaskdetails createtaskdetails
+	s := struct {
+		Model Unmarshalercreatetaskdetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Name = s.Model.Name
+	m.Identifier = s.Model.Identifier
+	m.RegistryMetadata = s.Model.RegistryMetadata
+	m.Key = s.Model.Key
+	m.ModelVersion = s.Model.ModelVersion
+	m.ParentRef = s.Model.ParentRef
+	m.Description = s.Model.Description
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.InputPorts = s.Model.InputPorts
+	m.OutputPorts = s.Model.OutputPorts
+	m.Parameters = s.Model.Parameters
+	m.OpConfigValues = s.Model.OpConfigValues
+	m.ConfigProviderDelegate = s.Model.ConfigProviderDelegate
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *createtaskdetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "INTEGRATION_TASK":
+		mm := CreateTaskFromIntegrationTask{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "DATA_LOADER_TASK":
+		mm := CreateTaskFromDataLoaderTask{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetName returns Name
+func (m createtaskdetails) GetName() *string {
+	return m.Name
+}
+
+//GetIdentifier returns Identifier
+func (m createtaskdetails) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m createtaskdetails) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+//GetKey returns Key
+func (m createtaskdetails) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m createtaskdetails) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m createtaskdetails) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetDescription returns Description
+func (m createtaskdetails) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m createtaskdetails) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetInputPorts returns InputPorts
+func (m createtaskdetails) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m createtaskdetails) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetParameters returns Parameters
+func (m createtaskdetails) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m createtaskdetails) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+//GetConfigProviderDelegate returns ConfigProviderDelegate
+func (m createtaskdetails) GetConfigProviderDelegate() *CreateConfigProvider {
+	return m.ConfigProviderDelegate
+}
+
+func (m createtaskdetails) String() string {
+	return common.PointerString(m)
+}
+
+// CreateTaskDetailsModelTypeEnum Enum with underlying type: string
+type CreateTaskDetailsModelTypeEnum string
+
+// Set of constants representing the allowable values for CreateTaskDetailsModelTypeEnum
+const (
+	CreateTaskDetailsModelTypeIntegrationTask CreateTaskDetailsModelTypeEnum = "INTEGRATION_TASK"
+	CreateTaskDetailsModelTypeDataLoaderTask  CreateTaskDetailsModelTypeEnum = "DATA_LOADER_TASK"
+)
+
+var mappingCreateTaskDetailsModelType = map[string]CreateTaskDetailsModelTypeEnum{
+	"INTEGRATION_TASK": CreateTaskDetailsModelTypeIntegrationTask,
+	"DATA_LOADER_TASK": CreateTaskDetailsModelTypeDataLoaderTask,
+}
+
+// GetCreateTaskDetailsModelTypeEnumValues Enumerates the set of values for CreateTaskDetailsModelTypeEnum
+func GetCreateTaskDetailsModelTypeEnumValues() []CreateTaskDetailsModelTypeEnum {
+	values := make([]CreateTaskDetailsModelTypeEnum, 0)
+	for _, v := range mappingCreateTaskDetailsModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/create_task_from_data_loader_task.go
+++ b/dataintegration/create_task_from_data_loader_task.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateTaskFromDataLoaderTask The information about a data flow task.
+type CreateTaskFromDataLoaderTask struct {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"true" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"true" json:"identifier"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"true" json:"registryMetadata"`
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+
+	ConfigProviderDelegate *CreateConfigProvider `mandatory:"false" json:"configProviderDelegate"`
+
+	DataFlow *DataFlow `mandatory:"false" json:"dataFlow"`
+}
+
+//GetKey returns Key
+func (m CreateTaskFromDataLoaderTask) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m CreateTaskFromDataLoaderTask) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m CreateTaskFromDataLoaderTask) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m CreateTaskFromDataLoaderTask) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m CreateTaskFromDataLoaderTask) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m CreateTaskFromDataLoaderTask) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m CreateTaskFromDataLoaderTask) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetInputPorts returns InputPorts
+func (m CreateTaskFromDataLoaderTask) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m CreateTaskFromDataLoaderTask) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetParameters returns Parameters
+func (m CreateTaskFromDataLoaderTask) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m CreateTaskFromDataLoaderTask) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+//GetConfigProviderDelegate returns ConfigProviderDelegate
+func (m CreateTaskFromDataLoaderTask) GetConfigProviderDelegate() *CreateConfigProvider {
+	return m.ConfigProviderDelegate
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m CreateTaskFromDataLoaderTask) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m CreateTaskFromDataLoaderTask) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateTaskFromDataLoaderTask) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateTaskFromDataLoaderTask CreateTaskFromDataLoaderTask
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeCreateTaskFromDataLoaderTask
+	}{
+		"DATA_LOADER_TASK",
+		(MarshalTypeCreateTaskFromDataLoaderTask)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/create_task_from_integration_task.go
+++ b/dataintegration/create_task_from_integration_task.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateTaskFromIntegrationTask The information about the integration task.
+type CreateTaskFromIntegrationTask struct {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"true" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"true" json:"identifier"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"true" json:"registryMetadata"`
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+
+	ConfigProviderDelegate *CreateConfigProvider `mandatory:"false" json:"configProviderDelegate"`
+
+	DataFlow *DataFlow `mandatory:"false" json:"dataFlow"`
+}
+
+//GetKey returns Key
+func (m CreateTaskFromIntegrationTask) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m CreateTaskFromIntegrationTask) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m CreateTaskFromIntegrationTask) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m CreateTaskFromIntegrationTask) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m CreateTaskFromIntegrationTask) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m CreateTaskFromIntegrationTask) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m CreateTaskFromIntegrationTask) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetInputPorts returns InputPorts
+func (m CreateTaskFromIntegrationTask) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m CreateTaskFromIntegrationTask) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetParameters returns Parameters
+func (m CreateTaskFromIntegrationTask) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m CreateTaskFromIntegrationTask) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+//GetConfigProviderDelegate returns ConfigProviderDelegate
+func (m CreateTaskFromIntegrationTask) GetConfigProviderDelegate() *CreateConfigProvider {
+	return m.ConfigProviderDelegate
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m CreateTaskFromIntegrationTask) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m CreateTaskFromIntegrationTask) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateTaskFromIntegrationTask) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateTaskFromIntegrationTask CreateTaskFromIntegrationTask
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeCreateTaskFromIntegrationTask
+	}{
+		"INTEGRATION_TASK",
+		(MarshalTypeCreateTaskFromIntegrationTask)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/create_task_request_response.go
+++ b/dataintegration/create_task_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateTaskRequest wrapper for the CreateTask operation
+type CreateTaskRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// The details needed to create a new task.
+	CreateTaskDetails `contributesTo:"body"`
+
+	// Caller may provide "retry tokens" allowing them to retry an operation
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateTaskRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateTaskRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateTaskRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateTaskResponse wrapper for the CreateTask operation
+type CreateTaskResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Task instance
+	Task `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateTaskResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateTaskResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/create_task_run_details.go
+++ b/dataintegration/create_task_run_details.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateTaskRunDetails Properties used in task run create operations.
+type CreateTaskRunDetails struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	ConfigProvider *CreateConfigProvider `mandatory:"false" json:"configProvider"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+}
+
+func (m CreateTaskRunDetails) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/create_task_run_request_response.go
+++ b/dataintegration/create_task_run_request_response.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateTaskRunRequest wrapper for the CreateTaskRun operation
+type CreateTaskRunRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS application key
+	ApplicationKey *string `mandatory:"true" contributesTo:"path" name:"applicationKey"`
+
+	// The details needed to create a task run.
+	CreateTaskRunDetails `contributesTo:"body"`
+
+	// Caller may provide "retry tokens" allowing them to retry an operation
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateTaskRunRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateTaskRunRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateTaskRunRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateTaskRunResponse wrapper for the CreateTaskRun operation
+type CreateTaskRunResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The TaskRun instance
+	TaskRun `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateTaskRunResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateTaskRunResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/create_task_validation_details.go
+++ b/dataintegration/create_task_validation_details.go
@@ -1,0 +1,225 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateTaskValidationDetails The task type contains the audit summary information and the definition of the task.
+type CreateTaskValidationDetails interface {
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	GetKey() *string
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	GetParentRef() *ParentReference
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	GetName() *string
+
+	// Detailed description for the object.
+	GetDescription() *string
+
+	// The version of the object that is used to track changes in the object instance.
+	GetObjectVersion() *int
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	GetIdentifier() *string
+
+	// An array of input ports.
+	GetInputPorts() []InputPort
+
+	// An array of output ports.
+	GetOutputPorts() []OutputPort
+
+	// An array of parameters.
+	GetParameters() []Parameter
+
+	GetOpConfigValues() *ConfigValues
+
+	GetConfigProviderDelegate() *ConfigProvider
+
+	GetMetadata() *ObjectMetadata
+}
+
+type createtaskvalidationdetails struct {
+	JsonData               []byte
+	Key                    *string          `mandatory:"false" json:"key"`
+	ModelVersion           *string          `mandatory:"false" json:"modelVersion"`
+	ParentRef              *ParentReference `mandatory:"false" json:"parentRef"`
+	Name                   *string          `mandatory:"false" json:"name"`
+	Description            *string          `mandatory:"false" json:"description"`
+	ObjectVersion          *int             `mandatory:"false" json:"objectVersion"`
+	ObjectStatus           *int             `mandatory:"false" json:"objectStatus"`
+	Identifier             *string          `mandatory:"false" json:"identifier"`
+	InputPorts             []InputPort      `mandatory:"false" json:"inputPorts"`
+	OutputPorts            []OutputPort     `mandatory:"false" json:"outputPorts"`
+	Parameters             []Parameter      `mandatory:"false" json:"parameters"`
+	OpConfigValues         *ConfigValues    `mandatory:"false" json:"opConfigValues"`
+	ConfigProviderDelegate *ConfigProvider  `mandatory:"false" json:"configProviderDelegate"`
+	Metadata               *ObjectMetadata  `mandatory:"false" json:"metadata"`
+	ModelType              string           `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *createtaskvalidationdetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalercreatetaskvalidationdetails createtaskvalidationdetails
+	s := struct {
+		Model Unmarshalercreatetaskvalidationdetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Key = s.Model.Key
+	m.ModelVersion = s.Model.ModelVersion
+	m.ParentRef = s.Model.ParentRef
+	m.Name = s.Model.Name
+	m.Description = s.Model.Description
+	m.ObjectVersion = s.Model.ObjectVersion
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.Identifier = s.Model.Identifier
+	m.InputPorts = s.Model.InputPorts
+	m.OutputPorts = s.Model.OutputPorts
+	m.Parameters = s.Model.Parameters
+	m.OpConfigValues = s.Model.OpConfigValues
+	m.ConfigProviderDelegate = s.Model.ConfigProviderDelegate
+	m.Metadata = s.Model.Metadata
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *createtaskvalidationdetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "DATA_LOADER_TASK":
+		mm := CreateTaskValidationFromDataLoaderTask{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "INTEGRATION_TASK":
+		mm := CreateTaskValidationFromIntegrationTask{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetKey returns Key
+func (m createtaskvalidationdetails) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m createtaskvalidationdetails) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m createtaskvalidationdetails) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m createtaskvalidationdetails) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m createtaskvalidationdetails) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m createtaskvalidationdetails) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m createtaskvalidationdetails) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m createtaskvalidationdetails) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetInputPorts returns InputPorts
+func (m createtaskvalidationdetails) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m createtaskvalidationdetails) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetParameters returns Parameters
+func (m createtaskvalidationdetails) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m createtaskvalidationdetails) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+//GetConfigProviderDelegate returns ConfigProviderDelegate
+func (m createtaskvalidationdetails) GetConfigProviderDelegate() *ConfigProvider {
+	return m.ConfigProviderDelegate
+}
+
+//GetMetadata returns Metadata
+func (m createtaskvalidationdetails) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m createtaskvalidationdetails) String() string {
+	return common.PointerString(m)
+}
+
+// CreateTaskValidationDetailsModelTypeEnum Enum with underlying type: string
+type CreateTaskValidationDetailsModelTypeEnum string
+
+// Set of constants representing the allowable values for CreateTaskValidationDetailsModelTypeEnum
+const (
+	CreateTaskValidationDetailsModelTypeIntegrationTask CreateTaskValidationDetailsModelTypeEnum = "INTEGRATION_TASK"
+	CreateTaskValidationDetailsModelTypeDataLoaderTask  CreateTaskValidationDetailsModelTypeEnum = "DATA_LOADER_TASK"
+)
+
+var mappingCreateTaskValidationDetailsModelType = map[string]CreateTaskValidationDetailsModelTypeEnum{
+	"INTEGRATION_TASK": CreateTaskValidationDetailsModelTypeIntegrationTask,
+	"DATA_LOADER_TASK": CreateTaskValidationDetailsModelTypeDataLoaderTask,
+}
+
+// GetCreateTaskValidationDetailsModelTypeEnumValues Enumerates the set of values for CreateTaskValidationDetailsModelTypeEnum
+func GetCreateTaskValidationDetailsModelTypeEnumValues() []CreateTaskValidationDetailsModelTypeEnum {
+	values := make([]CreateTaskValidationDetailsModelTypeEnum, 0)
+	for _, v := range mappingCreateTaskValidationDetailsModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/create_task_validation_from_data_loader_task.go
+++ b/dataintegration/create_task_validation_from_data_loader_task.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateTaskValidationFromDataLoaderTask The information about a data flow task.
+type CreateTaskValidationFromDataLoaderTask struct {
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+
+	ConfigProviderDelegate *ConfigProvider `mandatory:"false" json:"configProviderDelegate"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	DataFlow *DataFlow `mandatory:"false" json:"dataFlow"`
+}
+
+//GetKey returns Key
+func (m CreateTaskValidationFromDataLoaderTask) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m CreateTaskValidationFromDataLoaderTask) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m CreateTaskValidationFromDataLoaderTask) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m CreateTaskValidationFromDataLoaderTask) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m CreateTaskValidationFromDataLoaderTask) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m CreateTaskValidationFromDataLoaderTask) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m CreateTaskValidationFromDataLoaderTask) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m CreateTaskValidationFromDataLoaderTask) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetInputPorts returns InputPorts
+func (m CreateTaskValidationFromDataLoaderTask) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m CreateTaskValidationFromDataLoaderTask) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetParameters returns Parameters
+func (m CreateTaskValidationFromDataLoaderTask) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m CreateTaskValidationFromDataLoaderTask) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+//GetConfigProviderDelegate returns ConfigProviderDelegate
+func (m CreateTaskValidationFromDataLoaderTask) GetConfigProviderDelegate() *ConfigProvider {
+	return m.ConfigProviderDelegate
+}
+
+//GetMetadata returns Metadata
+func (m CreateTaskValidationFromDataLoaderTask) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m CreateTaskValidationFromDataLoaderTask) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateTaskValidationFromDataLoaderTask) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateTaskValidationFromDataLoaderTask CreateTaskValidationFromDataLoaderTask
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeCreateTaskValidationFromDataLoaderTask
+	}{
+		"DATA_LOADER_TASK",
+		(MarshalTypeCreateTaskValidationFromDataLoaderTask)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/create_task_validation_from_integration_task.go
+++ b/dataintegration/create_task_validation_from_integration_task.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateTaskValidationFromIntegrationTask The information about the integration task.
+type CreateTaskValidationFromIntegrationTask struct {
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+
+	ConfigProviderDelegate *ConfigProvider `mandatory:"false" json:"configProviderDelegate"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	DataFlow *DataFlow `mandatory:"false" json:"dataFlow"`
+}
+
+//GetKey returns Key
+func (m CreateTaskValidationFromIntegrationTask) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m CreateTaskValidationFromIntegrationTask) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m CreateTaskValidationFromIntegrationTask) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m CreateTaskValidationFromIntegrationTask) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m CreateTaskValidationFromIntegrationTask) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m CreateTaskValidationFromIntegrationTask) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m CreateTaskValidationFromIntegrationTask) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m CreateTaskValidationFromIntegrationTask) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetInputPorts returns InputPorts
+func (m CreateTaskValidationFromIntegrationTask) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m CreateTaskValidationFromIntegrationTask) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetParameters returns Parameters
+func (m CreateTaskValidationFromIntegrationTask) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m CreateTaskValidationFromIntegrationTask) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+//GetConfigProviderDelegate returns ConfigProviderDelegate
+func (m CreateTaskValidationFromIntegrationTask) GetConfigProviderDelegate() *ConfigProvider {
+	return m.ConfigProviderDelegate
+}
+
+//GetMetadata returns Metadata
+func (m CreateTaskValidationFromIntegrationTask) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m CreateTaskValidationFromIntegrationTask) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateTaskValidationFromIntegrationTask) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateTaskValidationFromIntegrationTask CreateTaskValidationFromIntegrationTask
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeCreateTaskValidationFromIntegrationTask
+	}{
+		"INTEGRATION_TASK",
+		(MarshalTypeCreateTaskValidationFromIntegrationTask)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/create_task_validation_request_response.go
+++ b/dataintegration/create_task_validation_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateTaskValidationRequest wrapper for the CreateTaskValidation operation
+type CreateTaskValidationRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// Task info
+	CreateTaskValidationDetails `contributesTo:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Caller may provide "retry tokens" allowing them to retry an operation
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateTaskValidationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateTaskValidationRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateTaskValidationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateTaskValidationResponse wrapper for the CreateTaskValidation operation
+type CreateTaskValidationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The TaskValidation instance
+	TaskValidation `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateTaskValidationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateTaskValidationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/create_workspace_details.go
+++ b/dataintegration/create_workspace_details.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateWorkspaceDetails The information about new Workspace.
+type CreateWorkspaceDetails struct {
+
+	// A user-friendly display name for the workspace. Does not have to be unique, and can be modified. Avoid entering confidential information.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The OCID of the compartment containing the workspace.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The OCID of the VCN the subnet is in.
+	VcnId *string `mandatory:"false" json:"vcnId"`
+
+	// The OCID of the subnet for customer connected databases.
+	SubnetId *string `mandatory:"false" json:"subnetId"`
+
+	// The IP of the custom DNS.
+	DnsServerIp *string `mandatory:"false" json:"dnsServerIp"`
+
+	// The DNS zone of the custom DNS to use to resolve names.
+	DnsServerZone *string `mandatory:"false" json:"dnsServerZone"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. See Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace. See Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// A detailed description for the workspace.
+	Description *string `mandatory:"false" json:"description"`
+
+	// Whether the private network connection is enabled or disabled.
+	IsPrivateNetworkEnabled *bool `mandatory:"false" json:"isPrivateNetworkEnabled"`
+}
+
+func (m CreateWorkspaceDetails) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/create_workspace_request_response.go
+++ b/dataintegration/create_workspace_request_response.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateWorkspaceRequest wrapper for the CreateWorkspace operation
+type CreateWorkspaceRequest struct {
+
+	// Details for the new Data Integration Workspace.
+	CreateWorkspaceDetails `contributesTo:"body"`
+
+	// Caller may provide "retry tokens" allowing them to retry an operation
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateWorkspaceRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateWorkspaceRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateWorkspaceRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateWorkspaceResponse wrapper for the CreateWorkspace operation
+type CreateWorkspaceResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the work request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+	// with this ID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+}
+
+func (response CreateWorkspaceResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateWorkspaceResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/csv_format_attribute.go
+++ b/dataintegration/csv_format_attribute.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CsvFormatAttribute The CSV format attribute.
+type CsvFormatAttribute struct {
+
+	// The encoding for the file.
+	Encoding *string `mandatory:"false" json:"encoding"`
+
+	// The escape character for the CSV format.
+	EscapeCharacter *string `mandatory:"false" json:"escapeCharacter"`
+
+	// The delimiter for the CSV format.
+	Delimiter *string `mandatory:"false" json:"delimiter"`
+
+	// The quote character for the CSV format.
+	QuoteCharacter *string `mandatory:"false" json:"quoteCharacter"`
+
+	// Defines whether the file has a header row.
+	HasHeader *bool `mandatory:"false" json:"hasHeader"`
+
+	// Format for timestamp data.
+	TimestampFormat *string `mandatory:"false" json:"timestampFormat"`
+}
+
+func (m CsvFormatAttribute) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CsvFormatAttribute) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCsvFormatAttribute CsvFormatAttribute
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeCsvFormatAttribute
+	}{
+		"CSV_FORMAT",
+		(MarshalTypeCsvFormatAttribute)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/data_asset.go
+++ b/dataintegration/data_asset.go
@@ -1,0 +1,228 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataAsset The data asset type.
+type DataAsset interface {
+
+	// Generated key that can be used in API calls to identify data asset.
+	GetKey() *string
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	GetName() *string
+
+	// Detailed description for the object.
+	GetDescription() *string
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	GetIdentifier() *string
+
+	// The external key for the object
+	GetExternalKey() *string
+
+	// assetProperties
+	GetAssetProperties() map[string]string
+
+	GetNativeTypeSystem() *TypeSystem
+
+	// The version of the object that is used to track changes in the object instance.
+	GetObjectVersion() *int
+
+	GetParentRef() *ParentReference
+
+	GetMetadata() *ObjectMetadata
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	GetKeyMap() map[string]string
+}
+
+type dataasset struct {
+	JsonData         []byte
+	Key              *string           `mandatory:"false" json:"key"`
+	ModelVersion     *string           `mandatory:"false" json:"modelVersion"`
+	Name             *string           `mandatory:"false" json:"name"`
+	Description      *string           `mandatory:"false" json:"description"`
+	ObjectStatus     *int              `mandatory:"false" json:"objectStatus"`
+	Identifier       *string           `mandatory:"false" json:"identifier"`
+	ExternalKey      *string           `mandatory:"false" json:"externalKey"`
+	AssetProperties  map[string]string `mandatory:"false" json:"assetProperties"`
+	NativeTypeSystem *TypeSystem       `mandatory:"false" json:"nativeTypeSystem"`
+	ObjectVersion    *int              `mandatory:"false" json:"objectVersion"`
+	ParentRef        *ParentReference  `mandatory:"false" json:"parentRef"`
+	Metadata         *ObjectMetadata   `mandatory:"false" json:"metadata"`
+	KeyMap           map[string]string `mandatory:"false" json:"keyMap"`
+	ModelType        string            `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *dataasset) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerdataasset dataasset
+	s := struct {
+		Model Unmarshalerdataasset
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Key = s.Model.Key
+	m.ModelVersion = s.Model.ModelVersion
+	m.Name = s.Model.Name
+	m.Description = s.Model.Description
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.Identifier = s.Model.Identifier
+	m.ExternalKey = s.Model.ExternalKey
+	m.AssetProperties = s.Model.AssetProperties
+	m.NativeTypeSystem = s.Model.NativeTypeSystem
+	m.ObjectVersion = s.Model.ObjectVersion
+	m.ParentRef = s.Model.ParentRef
+	m.Metadata = s.Model.Metadata
+	m.KeyMap = s.Model.KeyMap
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *dataasset) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "ORACLE_DATA_ASSET":
+		mm := DataAssetFromOracleDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_ADWC_DATA_ASSET":
+		mm := DataAssetFromAdwcDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_OBJECT_STORAGE_DATA_ASSET":
+		mm := DataAssetFromObjectStorageDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_ATP_DATA_ASSET":
+		mm := DataAssetFromAtpDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetKey returns Key
+func (m dataasset) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m dataasset) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetName returns Name
+func (m dataasset) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m dataasset) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m dataasset) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m dataasset) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetExternalKey returns ExternalKey
+func (m dataasset) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m dataasset) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetNativeTypeSystem returns NativeTypeSystem
+func (m dataasset) GetNativeTypeSystem() *TypeSystem {
+	return m.NativeTypeSystem
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m dataasset) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetParentRef returns ParentRef
+func (m dataasset) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetMetadata returns Metadata
+func (m dataasset) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m dataasset) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m dataasset) String() string {
+	return common.PointerString(m)
+}
+
+// DataAssetModelTypeEnum Enum with underlying type: string
+type DataAssetModelTypeEnum string
+
+// Set of constants representing the allowable values for DataAssetModelTypeEnum
+const (
+	DataAssetModelTypeDataAsset              DataAssetModelTypeEnum = "ORACLE_DATA_ASSET"
+	DataAssetModelTypeObjectStorageDataAsset DataAssetModelTypeEnum = "ORACLE_OBJECT_STORAGE_DATA_ASSET"
+	DataAssetModelTypeAtpDataAsset           DataAssetModelTypeEnum = "ORACLE_ATP_DATA_ASSET"
+	DataAssetModelTypeAdwcDataAsset          DataAssetModelTypeEnum = "ORACLE_ADWC_DATA_ASSET"
+)
+
+var mappingDataAssetModelType = map[string]DataAssetModelTypeEnum{
+	"ORACLE_DATA_ASSET":                DataAssetModelTypeDataAsset,
+	"ORACLE_OBJECT_STORAGE_DATA_ASSET": DataAssetModelTypeObjectStorageDataAsset,
+	"ORACLE_ATP_DATA_ASSET":            DataAssetModelTypeAtpDataAsset,
+	"ORACLE_ADWC_DATA_ASSET":           DataAssetModelTypeAdwcDataAsset,
+}
+
+// GetDataAssetModelTypeEnumValues Enumerates the set of values for DataAssetModelTypeEnum
+func GetDataAssetModelTypeEnumValues() []DataAssetModelTypeEnum {
+	values := make([]DataAssetModelTypeEnum, 0)
+	for _, v := range mappingDataAssetModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/data_asset_from_adwc_details.go
+++ b/dataintegration/data_asset_from_adwc_details.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataAssetFromAdwcDetails The ADWC data asset details.
+type DataAssetFromAdwcDetails struct {
+
+	// Generated key that can be used in API calls to identify data asset.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The external key for the object
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	// assetProperties
+	AssetProperties map[string]string `mandatory:"false" json:"assetProperties"`
+
+	NativeTypeSystem *TypeSystem `mandatory:"false" json:"nativeTypeSystem"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+
+	// The service name for the data asset.
+	ServiceName *string `mandatory:"false" json:"serviceName"`
+
+	// Array of service names that are available for selection in the serviceName property.
+	ServiceNames []string `mandatory:"false" json:"serviceNames"`
+
+	// The driver class for the data asset.
+	DriverClass *string `mandatory:"false" json:"driverClass"`
+
+	DefaultConnection *ConnectionFromAdwcDetails `mandatory:"false" json:"defaultConnection"`
+}
+
+//GetKey returns Key
+func (m DataAssetFromAdwcDetails) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m DataAssetFromAdwcDetails) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetName returns Name
+func (m DataAssetFromAdwcDetails) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m DataAssetFromAdwcDetails) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m DataAssetFromAdwcDetails) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m DataAssetFromAdwcDetails) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetExternalKey returns ExternalKey
+func (m DataAssetFromAdwcDetails) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m DataAssetFromAdwcDetails) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetNativeTypeSystem returns NativeTypeSystem
+func (m DataAssetFromAdwcDetails) GetNativeTypeSystem() *TypeSystem {
+	return m.NativeTypeSystem
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m DataAssetFromAdwcDetails) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetParentRef returns ParentRef
+func (m DataAssetFromAdwcDetails) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetMetadata returns Metadata
+func (m DataAssetFromAdwcDetails) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m DataAssetFromAdwcDetails) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m DataAssetFromAdwcDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DataAssetFromAdwcDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDataAssetFromAdwcDetails DataAssetFromAdwcDetails
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDataAssetFromAdwcDetails
+	}{
+		"ORACLE_ADWC_DATA_ASSET",
+		(MarshalTypeDataAssetFromAdwcDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/data_asset_from_atp_details.go
+++ b/dataintegration/data_asset_from_atp_details.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataAssetFromAtpDetails The ATP data asset details.
+type DataAssetFromAtpDetails struct {
+
+	// Generated key that can be used in API calls to identify data asset.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The external key for the object
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	// assetProperties
+	AssetProperties map[string]string `mandatory:"false" json:"assetProperties"`
+
+	NativeTypeSystem *TypeSystem `mandatory:"false" json:"nativeTypeSystem"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+
+	// The service name for the data asset.
+	ServiceName *string `mandatory:"false" json:"serviceName"`
+
+	// Array of service names that are available for selection in the serviceName property.
+	ServiceNames []string `mandatory:"false" json:"serviceNames"`
+
+	// The driver class for the data asset.
+	DriverClass *string `mandatory:"false" json:"driverClass"`
+
+	DefaultConnection *ConnectionFromAtpDetails `mandatory:"false" json:"defaultConnection"`
+}
+
+//GetKey returns Key
+func (m DataAssetFromAtpDetails) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m DataAssetFromAtpDetails) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetName returns Name
+func (m DataAssetFromAtpDetails) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m DataAssetFromAtpDetails) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m DataAssetFromAtpDetails) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m DataAssetFromAtpDetails) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetExternalKey returns ExternalKey
+func (m DataAssetFromAtpDetails) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m DataAssetFromAtpDetails) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetNativeTypeSystem returns NativeTypeSystem
+func (m DataAssetFromAtpDetails) GetNativeTypeSystem() *TypeSystem {
+	return m.NativeTypeSystem
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m DataAssetFromAtpDetails) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetParentRef returns ParentRef
+func (m DataAssetFromAtpDetails) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetMetadata returns Metadata
+func (m DataAssetFromAtpDetails) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m DataAssetFromAtpDetails) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m DataAssetFromAtpDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DataAssetFromAtpDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDataAssetFromAtpDetails DataAssetFromAtpDetails
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDataAssetFromAtpDetails
+	}{
+		"ORACLE_ATP_DATA_ASSET",
+		(MarshalTypeDataAssetFromAtpDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/data_asset_from_object_storage_details.go
+++ b/dataintegration/data_asset_from_object_storage_details.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataAssetFromObjectStorageDetails The Object Storage data asset details.
+type DataAssetFromObjectStorageDetails struct {
+
+	// Generated key that can be used in API calls to identify data asset.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The external key for the object
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	// assetProperties
+	AssetProperties map[string]string `mandatory:"false" json:"assetProperties"`
+
+	NativeTypeSystem *TypeSystem `mandatory:"false" json:"nativeTypeSystem"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+
+	// url
+	Url *string `mandatory:"false" json:"url"`
+
+	// The OCI tenancy OCID.
+	TenancyId *string `mandatory:"false" json:"tenancyId"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Namespace *string `mandatory:"false" json:"namespace"`
+
+	DefaultConnection *ConnectionFromObjectStorageDetails `mandatory:"false" json:"defaultConnection"`
+}
+
+//GetKey returns Key
+func (m DataAssetFromObjectStorageDetails) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m DataAssetFromObjectStorageDetails) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetName returns Name
+func (m DataAssetFromObjectStorageDetails) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m DataAssetFromObjectStorageDetails) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m DataAssetFromObjectStorageDetails) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m DataAssetFromObjectStorageDetails) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetExternalKey returns ExternalKey
+func (m DataAssetFromObjectStorageDetails) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m DataAssetFromObjectStorageDetails) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetNativeTypeSystem returns NativeTypeSystem
+func (m DataAssetFromObjectStorageDetails) GetNativeTypeSystem() *TypeSystem {
+	return m.NativeTypeSystem
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m DataAssetFromObjectStorageDetails) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetParentRef returns ParentRef
+func (m DataAssetFromObjectStorageDetails) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetMetadata returns Metadata
+func (m DataAssetFromObjectStorageDetails) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m DataAssetFromObjectStorageDetails) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m DataAssetFromObjectStorageDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DataAssetFromObjectStorageDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDataAssetFromObjectStorageDetails DataAssetFromObjectStorageDetails
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDataAssetFromObjectStorageDetails
+	}{
+		"ORACLE_OBJECT_STORAGE_DATA_ASSET",
+		(MarshalTypeDataAssetFromObjectStorageDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/data_asset_from_oracle_details.go
+++ b/dataintegration/data_asset_from_oracle_details.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataAssetFromOracleDetails The Oracle data asset details.
+type DataAssetFromOracleDetails struct {
+
+	// Generated key that can be used in API calls to identify data asset.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The external key for the object
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	// assetProperties
+	AssetProperties map[string]string `mandatory:"false" json:"assetProperties"`
+
+	NativeTypeSystem *TypeSystem `mandatory:"false" json:"nativeTypeSystem"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+
+	// The host details for the data asset.
+	Host *string `mandatory:"false" json:"host"`
+
+	// The port details for the data asset.
+	Port *string `mandatory:"false" json:"port"`
+
+	// The service name for the data asset.
+	ServiceName *string `mandatory:"false" json:"serviceName"`
+
+	// The driver class for the data asset.
+	DriverClass *string `mandatory:"false" json:"driverClass"`
+
+	// sid
+	Sid *string `mandatory:"false" json:"sid"`
+
+	// The credential file content from a wallet for the data asset.
+	CredentialFileContent *string `mandatory:"false" json:"credentialFileContent"`
+
+	DefaultConnection *ConnectionFromOracleDetails `mandatory:"false" json:"defaultConnection"`
+}
+
+//GetKey returns Key
+func (m DataAssetFromOracleDetails) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m DataAssetFromOracleDetails) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetName returns Name
+func (m DataAssetFromOracleDetails) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m DataAssetFromOracleDetails) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m DataAssetFromOracleDetails) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m DataAssetFromOracleDetails) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetExternalKey returns ExternalKey
+func (m DataAssetFromOracleDetails) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m DataAssetFromOracleDetails) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetNativeTypeSystem returns NativeTypeSystem
+func (m DataAssetFromOracleDetails) GetNativeTypeSystem() *TypeSystem {
+	return m.NativeTypeSystem
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m DataAssetFromOracleDetails) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetParentRef returns ParentRef
+func (m DataAssetFromOracleDetails) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetMetadata returns Metadata
+func (m DataAssetFromOracleDetails) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m DataAssetFromOracleDetails) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m DataAssetFromOracleDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DataAssetFromOracleDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDataAssetFromOracleDetails DataAssetFromOracleDetails
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDataAssetFromOracleDetails
+	}{
+		"ORACLE_DATA_ASSET",
+		(MarshalTypeDataAssetFromOracleDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/data_asset_summary.go
+++ b/dataintegration/data_asset_summary.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataAssetSummary The summary object for data asset.
+type DataAssetSummary interface {
+
+	// Generated key that can be used in API calls to identify data asset.
+	GetKey() *string
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	GetName() *string
+
+	// Detailed description for the object.
+	GetDescription() *string
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	GetIdentifier() *string
+
+	// The external key for the object
+	GetExternalKey() *string
+
+	// assetProperties
+	GetAssetProperties() map[string]string
+
+	GetNativeTypeSystem() *TypeSystem
+
+	// The version of the object that is used to track changes in the object instance.
+	GetObjectVersion() *int
+
+	GetParentRef() *ParentReference
+
+	GetMetadata() *ObjectMetadata
+}
+
+type dataassetsummary struct {
+	JsonData         []byte
+	Key              *string           `mandatory:"false" json:"key"`
+	ModelVersion     *string           `mandatory:"false" json:"modelVersion"`
+	Name             *string           `mandatory:"false" json:"name"`
+	Description      *string           `mandatory:"false" json:"description"`
+	ObjectStatus     *int              `mandatory:"false" json:"objectStatus"`
+	Identifier       *string           `mandatory:"false" json:"identifier"`
+	ExternalKey      *string           `mandatory:"false" json:"externalKey"`
+	AssetProperties  map[string]string `mandatory:"false" json:"assetProperties"`
+	NativeTypeSystem *TypeSystem       `mandatory:"false" json:"nativeTypeSystem"`
+	ObjectVersion    *int              `mandatory:"false" json:"objectVersion"`
+	ParentRef        *ParentReference  `mandatory:"false" json:"parentRef"`
+	Metadata         *ObjectMetadata   `mandatory:"false" json:"metadata"`
+	ModelType        string            `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *dataassetsummary) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerdataassetsummary dataassetsummary
+	s := struct {
+		Model Unmarshalerdataassetsummary
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Key = s.Model.Key
+	m.ModelVersion = s.Model.ModelVersion
+	m.Name = s.Model.Name
+	m.Description = s.Model.Description
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.Identifier = s.Model.Identifier
+	m.ExternalKey = s.Model.ExternalKey
+	m.AssetProperties = s.Model.AssetProperties
+	m.NativeTypeSystem = s.Model.NativeTypeSystem
+	m.ObjectVersion = s.Model.ObjectVersion
+	m.ParentRef = s.Model.ParentRef
+	m.Metadata = s.Model.Metadata
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *dataassetsummary) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "ORACLE_ATP_DATA_ASSET":
+		mm := DataAssetSummaryFromAtp{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_ADWC_DATA_ASSET":
+		mm := DataAssetSummaryFromAdwc{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_OBJECT_STORAGE_DATA_ASSET":
+		mm := DataAssetSummaryFromObjectStorage{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_DATA_ASSET":
+		mm := DataAssetSummaryFromOracle{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetKey returns Key
+func (m dataassetsummary) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m dataassetsummary) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetName returns Name
+func (m dataassetsummary) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m dataassetsummary) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m dataassetsummary) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m dataassetsummary) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetExternalKey returns ExternalKey
+func (m dataassetsummary) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m dataassetsummary) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetNativeTypeSystem returns NativeTypeSystem
+func (m dataassetsummary) GetNativeTypeSystem() *TypeSystem {
+	return m.NativeTypeSystem
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m dataassetsummary) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetParentRef returns ParentRef
+func (m dataassetsummary) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetMetadata returns Metadata
+func (m dataassetsummary) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m dataassetsummary) String() string {
+	return common.PointerString(m)
+}
+
+// DataAssetSummaryModelTypeEnum Enum with underlying type: string
+type DataAssetSummaryModelTypeEnum string
+
+// Set of constants representing the allowable values for DataAssetSummaryModelTypeEnum
+const (
+	DataAssetSummaryModelTypeDataAsset              DataAssetSummaryModelTypeEnum = "ORACLE_DATA_ASSET"
+	DataAssetSummaryModelTypeObjectStorageDataAsset DataAssetSummaryModelTypeEnum = "ORACLE_OBJECT_STORAGE_DATA_ASSET"
+	DataAssetSummaryModelTypeAtpDataAsset           DataAssetSummaryModelTypeEnum = "ORACLE_ATP_DATA_ASSET"
+	DataAssetSummaryModelTypeAdwcDataAsset          DataAssetSummaryModelTypeEnum = "ORACLE_ADWC_DATA_ASSET"
+)
+
+var mappingDataAssetSummaryModelType = map[string]DataAssetSummaryModelTypeEnum{
+	"ORACLE_DATA_ASSET":                DataAssetSummaryModelTypeDataAsset,
+	"ORACLE_OBJECT_STORAGE_DATA_ASSET": DataAssetSummaryModelTypeObjectStorageDataAsset,
+	"ORACLE_ATP_DATA_ASSET":            DataAssetSummaryModelTypeAtpDataAsset,
+	"ORACLE_ADWC_DATA_ASSET":           DataAssetSummaryModelTypeAdwcDataAsset,
+}
+
+// GetDataAssetSummaryModelTypeEnumValues Enumerates the set of values for DataAssetSummaryModelTypeEnum
+func GetDataAssetSummaryModelTypeEnumValues() []DataAssetSummaryModelTypeEnum {
+	values := make([]DataAssetSummaryModelTypeEnum, 0)
+	for _, v := range mappingDataAssetSummaryModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/data_asset_summary_collection.go
+++ b/dataintegration/data_asset_summary_collection.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataAssetSummaryCollection This is the collection of data asset summaries, it may be a collection of lightweight details or full definitions.
+type DataAssetSummaryCollection struct {
+
+	// The array of DataAsset summaries
+	Items []DataAssetSummary `mandatory:"true" json:"items"`
+}
+
+func (m DataAssetSummaryCollection) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *DataAssetSummaryCollection) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Items []dataassetsummary `json:"items"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Items = make([]DataAssetSummary, len(model.Items))
+	for i, n := range model.Items {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.Items[i] = nn.(DataAssetSummary)
+		} else {
+			m.Items[i] = nil
+		}
+	}
+	return
+}

--- a/dataintegration/data_asset_summary_from_adwc.go
+++ b/dataintegration/data_asset_summary_from_adwc.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataAssetSummaryFromAdwc The Oracle data asset details.
+type DataAssetSummaryFromAdwc struct {
+
+	// Generated key that can be used in API calls to identify data asset.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The external key for the object
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	// assetProperties
+	AssetProperties map[string]string `mandatory:"false" json:"assetProperties"`
+
+	NativeTypeSystem *TypeSystem `mandatory:"false" json:"nativeTypeSystem"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// The service name for the data asset.
+	ServiceName *string `mandatory:"false" json:"serviceName"`
+
+	// Array of service names that are available for selection in the serviceName property.
+	ServiceNames []string `mandatory:"false" json:"serviceNames"`
+
+	// The driver class for the data asset.
+	DriverClass *string `mandatory:"false" json:"driverClass"`
+
+	DefaultConnection *ConnectionSummaryFromAdwc `mandatory:"false" json:"defaultConnection"`
+}
+
+//GetKey returns Key
+func (m DataAssetSummaryFromAdwc) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m DataAssetSummaryFromAdwc) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetName returns Name
+func (m DataAssetSummaryFromAdwc) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m DataAssetSummaryFromAdwc) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m DataAssetSummaryFromAdwc) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m DataAssetSummaryFromAdwc) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetExternalKey returns ExternalKey
+func (m DataAssetSummaryFromAdwc) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m DataAssetSummaryFromAdwc) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetNativeTypeSystem returns NativeTypeSystem
+func (m DataAssetSummaryFromAdwc) GetNativeTypeSystem() *TypeSystem {
+	return m.NativeTypeSystem
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m DataAssetSummaryFromAdwc) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetParentRef returns ParentRef
+func (m DataAssetSummaryFromAdwc) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetMetadata returns Metadata
+func (m DataAssetSummaryFromAdwc) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m DataAssetSummaryFromAdwc) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DataAssetSummaryFromAdwc) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDataAssetSummaryFromAdwc DataAssetSummaryFromAdwc
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDataAssetSummaryFromAdwc
+	}{
+		"ORACLE_ADWC_DATA_ASSET",
+		(MarshalTypeDataAssetSummaryFromAdwc)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/data_asset_summary_from_atp.go
+++ b/dataintegration/data_asset_summary_from_atp.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataAssetSummaryFromAtp The Oracle data asset details.
+type DataAssetSummaryFromAtp struct {
+
+	// Generated key that can be used in API calls to identify data asset.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The external key for the object
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	// assetProperties
+	AssetProperties map[string]string `mandatory:"false" json:"assetProperties"`
+
+	NativeTypeSystem *TypeSystem `mandatory:"false" json:"nativeTypeSystem"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// The service name for the data asset.
+	ServiceName *string `mandatory:"false" json:"serviceName"`
+
+	// Array of service names that are available for selection in the serviceName property.
+	ServiceNames []string `mandatory:"false" json:"serviceNames"`
+
+	// The driver class for the data asset.
+	DriverClass *string `mandatory:"false" json:"driverClass"`
+
+	DefaultConnection *ConnectionSummaryFromAtp `mandatory:"false" json:"defaultConnection"`
+}
+
+//GetKey returns Key
+func (m DataAssetSummaryFromAtp) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m DataAssetSummaryFromAtp) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetName returns Name
+func (m DataAssetSummaryFromAtp) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m DataAssetSummaryFromAtp) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m DataAssetSummaryFromAtp) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m DataAssetSummaryFromAtp) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetExternalKey returns ExternalKey
+func (m DataAssetSummaryFromAtp) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m DataAssetSummaryFromAtp) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetNativeTypeSystem returns NativeTypeSystem
+func (m DataAssetSummaryFromAtp) GetNativeTypeSystem() *TypeSystem {
+	return m.NativeTypeSystem
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m DataAssetSummaryFromAtp) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetParentRef returns ParentRef
+func (m DataAssetSummaryFromAtp) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetMetadata returns Metadata
+func (m DataAssetSummaryFromAtp) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m DataAssetSummaryFromAtp) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DataAssetSummaryFromAtp) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDataAssetSummaryFromAtp DataAssetSummaryFromAtp
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDataAssetSummaryFromAtp
+	}{
+		"ORACLE_ATP_DATA_ASSET",
+		(MarshalTypeDataAssetSummaryFromAtp)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/data_asset_summary_from_object_storage.go
+++ b/dataintegration/data_asset_summary_from_object_storage.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataAssetSummaryFromObjectStorage The Oracle data asset details.
+type DataAssetSummaryFromObjectStorage struct {
+
+	// Generated key that can be used in API calls to identify data asset.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The external key for the object
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	// assetProperties
+	AssetProperties map[string]string `mandatory:"false" json:"assetProperties"`
+
+	NativeTypeSystem *TypeSystem `mandatory:"false" json:"nativeTypeSystem"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// url
+	Url *string `mandatory:"false" json:"url"`
+
+	// The OCI tenancy OCID.
+	TenancyId *string `mandatory:"false" json:"tenancyId"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Namespace *string `mandatory:"false" json:"namespace"`
+
+	DefaultConnection *ConnectionSummaryFromObjectStorage `mandatory:"false" json:"defaultConnection"`
+}
+
+//GetKey returns Key
+func (m DataAssetSummaryFromObjectStorage) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m DataAssetSummaryFromObjectStorage) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetName returns Name
+func (m DataAssetSummaryFromObjectStorage) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m DataAssetSummaryFromObjectStorage) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m DataAssetSummaryFromObjectStorage) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m DataAssetSummaryFromObjectStorage) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetExternalKey returns ExternalKey
+func (m DataAssetSummaryFromObjectStorage) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m DataAssetSummaryFromObjectStorage) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetNativeTypeSystem returns NativeTypeSystem
+func (m DataAssetSummaryFromObjectStorage) GetNativeTypeSystem() *TypeSystem {
+	return m.NativeTypeSystem
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m DataAssetSummaryFromObjectStorage) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetParentRef returns ParentRef
+func (m DataAssetSummaryFromObjectStorage) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetMetadata returns Metadata
+func (m DataAssetSummaryFromObjectStorage) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m DataAssetSummaryFromObjectStorage) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DataAssetSummaryFromObjectStorage) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDataAssetSummaryFromObjectStorage DataAssetSummaryFromObjectStorage
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDataAssetSummaryFromObjectStorage
+	}{
+		"ORACLE_OBJECT_STORAGE_DATA_ASSET",
+		(MarshalTypeDataAssetSummaryFromObjectStorage)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/data_asset_summary_from_oracle.go
+++ b/dataintegration/data_asset_summary_from_oracle.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataAssetSummaryFromOracle The Oracle data asset details.
+type DataAssetSummaryFromOracle struct {
+
+	// Generated key that can be used in API calls to identify data asset.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The external key for the object
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	// assetProperties
+	AssetProperties map[string]string `mandatory:"false" json:"assetProperties"`
+
+	NativeTypeSystem *TypeSystem `mandatory:"false" json:"nativeTypeSystem"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// The host details for the data asset.
+	Host *string `mandatory:"false" json:"host"`
+
+	// The port details for the data asset.
+	Port *string `mandatory:"false" json:"port"`
+
+	// The service name for the data asset.
+	ServiceName *string `mandatory:"false" json:"serviceName"`
+
+	// The driver class for the data asset.
+	DriverClass *string `mandatory:"false" json:"driverClass"`
+
+	// sid
+	Sid *string `mandatory:"false" json:"sid"`
+
+	// The credential file content from a wallet for the data asset.
+	CredentialFileContent *string `mandatory:"false" json:"credentialFileContent"`
+
+	DefaultConnection *ConnectionSummaryFromOracle `mandatory:"false" json:"defaultConnection"`
+}
+
+//GetKey returns Key
+func (m DataAssetSummaryFromOracle) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m DataAssetSummaryFromOracle) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetName returns Name
+func (m DataAssetSummaryFromOracle) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m DataAssetSummaryFromOracle) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m DataAssetSummaryFromOracle) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m DataAssetSummaryFromOracle) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetExternalKey returns ExternalKey
+func (m DataAssetSummaryFromOracle) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m DataAssetSummaryFromOracle) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetNativeTypeSystem returns NativeTypeSystem
+func (m DataAssetSummaryFromOracle) GetNativeTypeSystem() *TypeSystem {
+	return m.NativeTypeSystem
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m DataAssetSummaryFromOracle) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetParentRef returns ParentRef
+func (m DataAssetSummaryFromOracle) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetMetadata returns Metadata
+func (m DataAssetSummaryFromOracle) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m DataAssetSummaryFromOracle) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DataAssetSummaryFromOracle) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDataAssetSummaryFromOracle DataAssetSummaryFromOracle
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDataAssetSummaryFromOracle
+	}{
+		"ORACLE_DATA_ASSET",
+		(MarshalTypeDataAssetSummaryFromOracle)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/data_entity.go
+++ b/dataintegration/data_entity.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataEntity The data entity object.
+type DataEntity interface {
+	GetMetadata() *ObjectMetadata
+}
+
+type dataentity struct {
+	JsonData  []byte
+	Metadata  *ObjectMetadata `mandatory:"false" json:"metadata"`
+	ModelType string          `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *dataentity) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerdataentity dataentity
+	s := struct {
+		Model Unmarshalerdataentity
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Metadata = s.Model.Metadata
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *dataentity) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "TABLE_ENTITY":
+		mm := DataEntityFromTable{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "VIEW_ENTITY":
+		mm := DataEntityFromView{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "FILE_ENTITY":
+		mm := DataEntityFromFile{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetMetadata returns Metadata
+func (m dataentity) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m dataentity) String() string {
+	return common.PointerString(m)
+}
+
+// DataEntityModelTypeEnum Enum with underlying type: string
+type DataEntityModelTypeEnum string
+
+// Set of constants representing the allowable values for DataEntityModelTypeEnum
+const (
+	DataEntityModelTypeViewEntity  DataEntityModelTypeEnum = "VIEW_ENTITY"
+	DataEntityModelTypeTableEntity DataEntityModelTypeEnum = "TABLE_ENTITY"
+	DataEntityModelTypeFileEntity  DataEntityModelTypeEnum = "FILE_ENTITY"
+)
+
+var mappingDataEntityModelType = map[string]DataEntityModelTypeEnum{
+	"VIEW_ENTITY":  DataEntityModelTypeViewEntity,
+	"TABLE_ENTITY": DataEntityModelTypeTableEntity,
+	"FILE_ENTITY":  DataEntityModelTypeFileEntity,
+}
+
+// GetDataEntityModelTypeEnumValues Enumerates the set of values for DataEntityModelTypeEnum
+func GetDataEntityModelTypeEnumValues() []DataEntityModelTypeEnum {
+	values := make([]DataEntityModelTypeEnum, 0)
+	for _, v := range mappingDataEntityModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/data_entity_details.go
+++ b/dataintegration/data_entity_details.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataEntityDetails The data entity details object.
+type DataEntityDetails interface {
+}
+
+type dataentitydetails struct {
+	JsonData  []byte
+	ModelType string `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *dataentitydetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerdataentitydetails dataentitydetails
+	s := struct {
+		Model Unmarshalerdataentitydetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *dataentitydetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "FILE_ENTITY":
+		mm := DataEntityFromFileEntityDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "VIEW_ENTITY":
+		mm := DataEntityFromViewEntityDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "TABLE_ENTITY":
+		mm := DataEntityFromTableEntityDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m dataentitydetails) String() string {
+	return common.PointerString(m)
+}
+
+// DataEntityDetailsModelTypeEnum Enum with underlying type: string
+type DataEntityDetailsModelTypeEnum string
+
+// Set of constants representing the allowable values for DataEntityDetailsModelTypeEnum
+const (
+	DataEntityDetailsModelTypeViewEntity  DataEntityDetailsModelTypeEnum = "VIEW_ENTITY"
+	DataEntityDetailsModelTypeTableEntity DataEntityDetailsModelTypeEnum = "TABLE_ENTITY"
+	DataEntityDetailsModelTypeFileEntity  DataEntityDetailsModelTypeEnum = "FILE_ENTITY"
+)
+
+var mappingDataEntityDetailsModelType = map[string]DataEntityDetailsModelTypeEnum{
+	"VIEW_ENTITY":  DataEntityDetailsModelTypeViewEntity,
+	"TABLE_ENTITY": DataEntityDetailsModelTypeTableEntity,
+	"FILE_ENTITY":  DataEntityDetailsModelTypeFileEntity,
+}
+
+// GetDataEntityDetailsModelTypeEnumValues Enumerates the set of values for DataEntityDetailsModelTypeEnum
+func GetDataEntityDetailsModelTypeEnumValues() []DataEntityDetailsModelTypeEnum {
+	values := make([]DataEntityDetailsModelTypeEnum, 0)
+	for _, v := range mappingDataEntityDetailsModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/data_entity_from_file.go
+++ b/dataintegration/data_entity_from_file.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataEntityFromFile The file data entity details.
+type DataEntityFromFile struct {
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The external key for the object.
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	Shape *Shape `mandatory:"false" json:"shape"`
+
+	// The shape ID.
+	ShapeId *string `mandatory:"false" json:"shapeId"`
+
+	Types *TypeLibrary `mandatory:"false" json:"types"`
+
+	// Specifies other type label.
+	OtherTypeLabel *string `mandatory:"false" json:"otherTypeLabel"`
+
+	// An array of unique keys.
+	UniqueKeys []UniqueKey `mandatory:"false" json:"uniqueKeys"`
+
+	// An array of foreign keys.
+	ForeignKeys []ForeignKey `mandatory:"false" json:"foreignKeys"`
+
+	// The resource name.
+	ResourceName *string `mandatory:"false" json:"resourceName"`
+
+	DataFormat *DataFormat `mandatory:"false" json:"dataFormat"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The entity type.
+	EntityType DataEntityFromFileEntityTypeEnum `mandatory:"false" json:"entityType,omitempty"`
+}
+
+//GetMetadata returns Metadata
+func (m DataEntityFromFile) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m DataEntityFromFile) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DataEntityFromFile) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDataEntityFromFile DataEntityFromFile
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDataEntityFromFile
+	}{
+		"FILE_ENTITY",
+		(MarshalTypeDataEntityFromFile)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// DataEntityFromFileEntityTypeEnum Enum with underlying type: string
+type DataEntityFromFileEntityTypeEnum string
+
+// Set of constants representing the allowable values for DataEntityFromFileEntityTypeEnum
+const (
+	DataEntityFromFileEntityTypeTable  DataEntityFromFileEntityTypeEnum = "TABLE"
+	DataEntityFromFileEntityTypeView   DataEntityFromFileEntityTypeEnum = "VIEW"
+	DataEntityFromFileEntityTypeFile   DataEntityFromFileEntityTypeEnum = "FILE"
+	DataEntityFromFileEntityTypeQueue  DataEntityFromFileEntityTypeEnum = "QUEUE"
+	DataEntityFromFileEntityTypeStream DataEntityFromFileEntityTypeEnum = "STREAM"
+	DataEntityFromFileEntityTypeOther  DataEntityFromFileEntityTypeEnum = "OTHER"
+)
+
+var mappingDataEntityFromFileEntityType = map[string]DataEntityFromFileEntityTypeEnum{
+	"TABLE":  DataEntityFromFileEntityTypeTable,
+	"VIEW":   DataEntityFromFileEntityTypeView,
+	"FILE":   DataEntityFromFileEntityTypeFile,
+	"QUEUE":  DataEntityFromFileEntityTypeQueue,
+	"STREAM": DataEntityFromFileEntityTypeStream,
+	"OTHER":  DataEntityFromFileEntityTypeOther,
+}
+
+// GetDataEntityFromFileEntityTypeEnumValues Enumerates the set of values for DataEntityFromFileEntityTypeEnum
+func GetDataEntityFromFileEntityTypeEnumValues() []DataEntityFromFileEntityTypeEnum {
+	values := make([]DataEntityFromFileEntityTypeEnum, 0)
+	for _, v := range mappingDataEntityFromFileEntityType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/data_entity_from_file_entity_details.go
+++ b/dataintegration/data_entity_from_file_entity_details.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataEntityFromFileEntityDetails The file data entity details.
+type DataEntityFromFileEntityDetails struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The external key for the object.
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	Shape *Shape `mandatory:"false" json:"shape"`
+
+	// The shape ID.
+	ShapeId *string `mandatory:"false" json:"shapeId"`
+
+	Types *TypeLibrary `mandatory:"false" json:"types"`
+
+	// Specifies other type label.
+	OtherTypeLabel *string `mandatory:"false" json:"otherTypeLabel"`
+
+	// An array of unique keys.
+	UniqueKeys []UniqueKey `mandatory:"false" json:"uniqueKeys"`
+
+	// An array of foreign keys.
+	ForeignKeys []ForeignKey `mandatory:"false" json:"foreignKeys"`
+
+	// The resource name.
+	ResourceName *string `mandatory:"false" json:"resourceName"`
+
+	DataFormat *DataFormat `mandatory:"false" json:"dataFormat"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The entity type.
+	EntityType DataEntityFromFileEntityDetailsEntityTypeEnum `mandatory:"false" json:"entityType,omitempty"`
+}
+
+func (m DataEntityFromFileEntityDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DataEntityFromFileEntityDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDataEntityFromFileEntityDetails DataEntityFromFileEntityDetails
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDataEntityFromFileEntityDetails
+	}{
+		"FILE_ENTITY",
+		(MarshalTypeDataEntityFromFileEntityDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// DataEntityFromFileEntityDetailsEntityTypeEnum Enum with underlying type: string
+type DataEntityFromFileEntityDetailsEntityTypeEnum string
+
+// Set of constants representing the allowable values for DataEntityFromFileEntityDetailsEntityTypeEnum
+const (
+	DataEntityFromFileEntityDetailsEntityTypeTable  DataEntityFromFileEntityDetailsEntityTypeEnum = "TABLE"
+	DataEntityFromFileEntityDetailsEntityTypeView   DataEntityFromFileEntityDetailsEntityTypeEnum = "VIEW"
+	DataEntityFromFileEntityDetailsEntityTypeFile   DataEntityFromFileEntityDetailsEntityTypeEnum = "FILE"
+	DataEntityFromFileEntityDetailsEntityTypeQueue  DataEntityFromFileEntityDetailsEntityTypeEnum = "QUEUE"
+	DataEntityFromFileEntityDetailsEntityTypeStream DataEntityFromFileEntityDetailsEntityTypeEnum = "STREAM"
+	DataEntityFromFileEntityDetailsEntityTypeOther  DataEntityFromFileEntityDetailsEntityTypeEnum = "OTHER"
+)
+
+var mappingDataEntityFromFileEntityDetailsEntityType = map[string]DataEntityFromFileEntityDetailsEntityTypeEnum{
+	"TABLE":  DataEntityFromFileEntityDetailsEntityTypeTable,
+	"VIEW":   DataEntityFromFileEntityDetailsEntityTypeView,
+	"FILE":   DataEntityFromFileEntityDetailsEntityTypeFile,
+	"QUEUE":  DataEntityFromFileEntityDetailsEntityTypeQueue,
+	"STREAM": DataEntityFromFileEntityDetailsEntityTypeStream,
+	"OTHER":  DataEntityFromFileEntityDetailsEntityTypeOther,
+}
+
+// GetDataEntityFromFileEntityDetailsEntityTypeEnumValues Enumerates the set of values for DataEntityFromFileEntityDetailsEntityTypeEnum
+func GetDataEntityFromFileEntityDetailsEntityTypeEnumValues() []DataEntityFromFileEntityDetailsEntityTypeEnum {
+	values := make([]DataEntityFromFileEntityDetailsEntityTypeEnum, 0)
+	for _, v := range mappingDataEntityFromFileEntityDetailsEntityType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/data_entity_from_table.go
+++ b/dataintegration/data_entity_from_table.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataEntityFromTable The table entity data entity.
+type DataEntityFromTable struct {
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The external key for the object.
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	Shape *Shape `mandatory:"false" json:"shape"`
+
+	// The shape ID.
+	ShapeId *string `mandatory:"false" json:"shapeId"`
+
+	Types *TypeLibrary `mandatory:"false" json:"types"`
+
+	// Specifies other type label.
+	OtherTypeLabel *string `mandatory:"false" json:"otherTypeLabel"`
+
+	// An array of unique keys.
+	UniqueKeys []UniqueKey `mandatory:"false" json:"uniqueKeys"`
+
+	// An array of foreign keys.
+	ForeignKeys []ForeignKey `mandatory:"false" json:"foreignKeys"`
+
+	// The resource name.
+	ResourceName *string `mandatory:"false" json:"resourceName"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The entity type.
+	EntityType DataEntityFromTableEntityTypeEnum `mandatory:"false" json:"entityType,omitempty"`
+}
+
+//GetMetadata returns Metadata
+func (m DataEntityFromTable) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m DataEntityFromTable) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DataEntityFromTable) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDataEntityFromTable DataEntityFromTable
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDataEntityFromTable
+	}{
+		"TABLE_ENTITY",
+		(MarshalTypeDataEntityFromTable)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// DataEntityFromTableEntityTypeEnum Enum with underlying type: string
+type DataEntityFromTableEntityTypeEnum string
+
+// Set of constants representing the allowable values for DataEntityFromTableEntityTypeEnum
+const (
+	DataEntityFromTableEntityTypeTable  DataEntityFromTableEntityTypeEnum = "TABLE"
+	DataEntityFromTableEntityTypeView   DataEntityFromTableEntityTypeEnum = "VIEW"
+	DataEntityFromTableEntityTypeFile   DataEntityFromTableEntityTypeEnum = "FILE"
+	DataEntityFromTableEntityTypeQueue  DataEntityFromTableEntityTypeEnum = "QUEUE"
+	DataEntityFromTableEntityTypeStream DataEntityFromTableEntityTypeEnum = "STREAM"
+	DataEntityFromTableEntityTypeOther  DataEntityFromTableEntityTypeEnum = "OTHER"
+)
+
+var mappingDataEntityFromTableEntityType = map[string]DataEntityFromTableEntityTypeEnum{
+	"TABLE":  DataEntityFromTableEntityTypeTable,
+	"VIEW":   DataEntityFromTableEntityTypeView,
+	"FILE":   DataEntityFromTableEntityTypeFile,
+	"QUEUE":  DataEntityFromTableEntityTypeQueue,
+	"STREAM": DataEntityFromTableEntityTypeStream,
+	"OTHER":  DataEntityFromTableEntityTypeOther,
+}
+
+// GetDataEntityFromTableEntityTypeEnumValues Enumerates the set of values for DataEntityFromTableEntityTypeEnum
+func GetDataEntityFromTableEntityTypeEnumValues() []DataEntityFromTableEntityTypeEnum {
+	values := make([]DataEntityFromTableEntityTypeEnum, 0)
+	for _, v := range mappingDataEntityFromTableEntityType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/data_entity_from_table_entity_details.go
+++ b/dataintegration/data_entity_from_table_entity_details.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataEntityFromTableEntityDetails The table entity data entity.
+type DataEntityFromTableEntityDetails struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The external key for the object.
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	Shape *Shape `mandatory:"false" json:"shape"`
+
+	// The shape ID.
+	ShapeId *string `mandatory:"false" json:"shapeId"`
+
+	Types *TypeLibrary `mandatory:"false" json:"types"`
+
+	// Specifies other type label.
+	OtherTypeLabel *string `mandatory:"false" json:"otherTypeLabel"`
+
+	// An array of unique keys.
+	UniqueKeys []UniqueKey `mandatory:"false" json:"uniqueKeys"`
+
+	// An array of foreign keys.
+	ForeignKeys []ForeignKey `mandatory:"false" json:"foreignKeys"`
+
+	// The resource name.
+	ResourceName *string `mandatory:"false" json:"resourceName"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The entity type.
+	EntityType DataEntityFromTableEntityDetailsEntityTypeEnum `mandatory:"false" json:"entityType,omitempty"`
+}
+
+func (m DataEntityFromTableEntityDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DataEntityFromTableEntityDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDataEntityFromTableEntityDetails DataEntityFromTableEntityDetails
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDataEntityFromTableEntityDetails
+	}{
+		"TABLE_ENTITY",
+		(MarshalTypeDataEntityFromTableEntityDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// DataEntityFromTableEntityDetailsEntityTypeEnum Enum with underlying type: string
+type DataEntityFromTableEntityDetailsEntityTypeEnum string
+
+// Set of constants representing the allowable values for DataEntityFromTableEntityDetailsEntityTypeEnum
+const (
+	DataEntityFromTableEntityDetailsEntityTypeTable  DataEntityFromTableEntityDetailsEntityTypeEnum = "TABLE"
+	DataEntityFromTableEntityDetailsEntityTypeView   DataEntityFromTableEntityDetailsEntityTypeEnum = "VIEW"
+	DataEntityFromTableEntityDetailsEntityTypeFile   DataEntityFromTableEntityDetailsEntityTypeEnum = "FILE"
+	DataEntityFromTableEntityDetailsEntityTypeQueue  DataEntityFromTableEntityDetailsEntityTypeEnum = "QUEUE"
+	DataEntityFromTableEntityDetailsEntityTypeStream DataEntityFromTableEntityDetailsEntityTypeEnum = "STREAM"
+	DataEntityFromTableEntityDetailsEntityTypeOther  DataEntityFromTableEntityDetailsEntityTypeEnum = "OTHER"
+)
+
+var mappingDataEntityFromTableEntityDetailsEntityType = map[string]DataEntityFromTableEntityDetailsEntityTypeEnum{
+	"TABLE":  DataEntityFromTableEntityDetailsEntityTypeTable,
+	"VIEW":   DataEntityFromTableEntityDetailsEntityTypeView,
+	"FILE":   DataEntityFromTableEntityDetailsEntityTypeFile,
+	"QUEUE":  DataEntityFromTableEntityDetailsEntityTypeQueue,
+	"STREAM": DataEntityFromTableEntityDetailsEntityTypeStream,
+	"OTHER":  DataEntityFromTableEntityDetailsEntityTypeOther,
+}
+
+// GetDataEntityFromTableEntityDetailsEntityTypeEnumValues Enumerates the set of values for DataEntityFromTableEntityDetailsEntityTypeEnum
+func GetDataEntityFromTableEntityDetailsEntityTypeEnumValues() []DataEntityFromTableEntityDetailsEntityTypeEnum {
+	values := make([]DataEntityFromTableEntityDetailsEntityTypeEnum, 0)
+	for _, v := range mappingDataEntityFromTableEntityDetailsEntityType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/data_entity_from_view.go
+++ b/dataintegration/data_entity_from_view.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataEntityFromView The view entity data entity details.
+type DataEntityFromView struct {
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The external key for the object
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	Shape *Shape `mandatory:"false" json:"shape"`
+
+	// The shape ID.
+	ShapeId *string `mandatory:"false" json:"shapeId"`
+
+	Types *TypeLibrary `mandatory:"false" json:"types"`
+
+	// Specifies other type label.
+	OtherTypeLabel *string `mandatory:"false" json:"otherTypeLabel"`
+
+	// An array of unique keys.
+	UniqueKeys []UniqueKey `mandatory:"false" json:"uniqueKeys"`
+
+	// An array of foreign keys.
+	ForeignKeys []ForeignKey `mandatory:"false" json:"foreignKeys"`
+
+	// The resource name.
+	ResourceName *string `mandatory:"false" json:"resourceName"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The entity type.
+	EntityType DataEntityFromViewEntityTypeEnum `mandatory:"false" json:"entityType,omitempty"`
+}
+
+//GetMetadata returns Metadata
+func (m DataEntityFromView) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m DataEntityFromView) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DataEntityFromView) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDataEntityFromView DataEntityFromView
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDataEntityFromView
+	}{
+		"VIEW_ENTITY",
+		(MarshalTypeDataEntityFromView)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// DataEntityFromViewEntityTypeEnum Enum with underlying type: string
+type DataEntityFromViewEntityTypeEnum string
+
+// Set of constants representing the allowable values for DataEntityFromViewEntityTypeEnum
+const (
+	DataEntityFromViewEntityTypeTable  DataEntityFromViewEntityTypeEnum = "TABLE"
+	DataEntityFromViewEntityTypeView   DataEntityFromViewEntityTypeEnum = "VIEW"
+	DataEntityFromViewEntityTypeFile   DataEntityFromViewEntityTypeEnum = "FILE"
+	DataEntityFromViewEntityTypeQueue  DataEntityFromViewEntityTypeEnum = "QUEUE"
+	DataEntityFromViewEntityTypeStream DataEntityFromViewEntityTypeEnum = "STREAM"
+	DataEntityFromViewEntityTypeOther  DataEntityFromViewEntityTypeEnum = "OTHER"
+)
+
+var mappingDataEntityFromViewEntityType = map[string]DataEntityFromViewEntityTypeEnum{
+	"TABLE":  DataEntityFromViewEntityTypeTable,
+	"VIEW":   DataEntityFromViewEntityTypeView,
+	"FILE":   DataEntityFromViewEntityTypeFile,
+	"QUEUE":  DataEntityFromViewEntityTypeQueue,
+	"STREAM": DataEntityFromViewEntityTypeStream,
+	"OTHER":  DataEntityFromViewEntityTypeOther,
+}
+
+// GetDataEntityFromViewEntityTypeEnumValues Enumerates the set of values for DataEntityFromViewEntityTypeEnum
+func GetDataEntityFromViewEntityTypeEnumValues() []DataEntityFromViewEntityTypeEnum {
+	values := make([]DataEntityFromViewEntityTypeEnum, 0)
+	for _, v := range mappingDataEntityFromViewEntityType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/data_entity_from_view_entity_details.go
+++ b/dataintegration/data_entity_from_view_entity_details.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataEntityFromViewEntityDetails The view entity data entity details.
+type DataEntityFromViewEntityDetails struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The external key for the object
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	Shape *Shape `mandatory:"false" json:"shape"`
+
+	// The shape ID.
+	ShapeId *string `mandatory:"false" json:"shapeId"`
+
+	Types *TypeLibrary `mandatory:"false" json:"types"`
+
+	// Specifies other type labels.
+	OtherTypeLabel *string `mandatory:"false" json:"otherTypeLabel"`
+
+	// An array of unique keys.
+	UniqueKeys []UniqueKey `mandatory:"false" json:"uniqueKeys"`
+
+	// An array of foreign keys.
+	ForeignKeys []ForeignKey `mandatory:"false" json:"foreignKeys"`
+
+	// The resource name.
+	ResourceName *string `mandatory:"false" json:"resourceName"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The entity type.
+	EntityType DataEntityFromViewEntityDetailsEntityTypeEnum `mandatory:"false" json:"entityType,omitempty"`
+}
+
+func (m DataEntityFromViewEntityDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DataEntityFromViewEntityDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDataEntityFromViewEntityDetails DataEntityFromViewEntityDetails
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDataEntityFromViewEntityDetails
+	}{
+		"VIEW_ENTITY",
+		(MarshalTypeDataEntityFromViewEntityDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// DataEntityFromViewEntityDetailsEntityTypeEnum Enum with underlying type: string
+type DataEntityFromViewEntityDetailsEntityTypeEnum string
+
+// Set of constants representing the allowable values for DataEntityFromViewEntityDetailsEntityTypeEnum
+const (
+	DataEntityFromViewEntityDetailsEntityTypeTable  DataEntityFromViewEntityDetailsEntityTypeEnum = "TABLE"
+	DataEntityFromViewEntityDetailsEntityTypeView   DataEntityFromViewEntityDetailsEntityTypeEnum = "VIEW"
+	DataEntityFromViewEntityDetailsEntityTypeFile   DataEntityFromViewEntityDetailsEntityTypeEnum = "FILE"
+	DataEntityFromViewEntityDetailsEntityTypeQueue  DataEntityFromViewEntityDetailsEntityTypeEnum = "QUEUE"
+	DataEntityFromViewEntityDetailsEntityTypeStream DataEntityFromViewEntityDetailsEntityTypeEnum = "STREAM"
+	DataEntityFromViewEntityDetailsEntityTypeOther  DataEntityFromViewEntityDetailsEntityTypeEnum = "OTHER"
+)
+
+var mappingDataEntityFromViewEntityDetailsEntityType = map[string]DataEntityFromViewEntityDetailsEntityTypeEnum{
+	"TABLE":  DataEntityFromViewEntityDetailsEntityTypeTable,
+	"VIEW":   DataEntityFromViewEntityDetailsEntityTypeView,
+	"FILE":   DataEntityFromViewEntityDetailsEntityTypeFile,
+	"QUEUE":  DataEntityFromViewEntityDetailsEntityTypeQueue,
+	"STREAM": DataEntityFromViewEntityDetailsEntityTypeStream,
+	"OTHER":  DataEntityFromViewEntityDetailsEntityTypeOther,
+}
+
+// GetDataEntityFromViewEntityDetailsEntityTypeEnumValues Enumerates the set of values for DataEntityFromViewEntityDetailsEntityTypeEnum
+func GetDataEntityFromViewEntityDetailsEntityTypeEnumValues() []DataEntityFromViewEntityDetailsEntityTypeEnum {
+	values := make([]DataEntityFromViewEntityDetailsEntityTypeEnum, 0)
+	for _, v := range mappingDataEntityFromViewEntityDetailsEntityType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/data_entity_summary.go
+++ b/dataintegration/data_entity_summary.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataEntitySummary The data entity summary object.
+type DataEntitySummary interface {
+	GetMetadata() *ObjectMetadata
+}
+
+type dataentitysummary struct {
+	JsonData  []byte
+	Metadata  *ObjectMetadata `mandatory:"false" json:"metadata"`
+	ModelType string          `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *dataentitysummary) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerdataentitysummary dataentitysummary
+	s := struct {
+		Model Unmarshalerdataentitysummary
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Metadata = s.Model.Metadata
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *dataentitysummary) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "FILE_ENTITY":
+		mm := DataEntitySummaryFromFile{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "TABLE_ENTITY":
+		mm := DataEntitySummaryFromTable{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "VIEW_ENTITY":
+		mm := DataEntitySummaryFromView{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetMetadata returns Metadata
+func (m dataentitysummary) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m dataentitysummary) String() string {
+	return common.PointerString(m)
+}
+
+// DataEntitySummaryModelTypeEnum Enum with underlying type: string
+type DataEntitySummaryModelTypeEnum string
+
+// Set of constants representing the allowable values for DataEntitySummaryModelTypeEnum
+const (
+	DataEntitySummaryModelTypeViewEntity  DataEntitySummaryModelTypeEnum = "VIEW_ENTITY"
+	DataEntitySummaryModelTypeTableEntity DataEntitySummaryModelTypeEnum = "TABLE_ENTITY"
+	DataEntitySummaryModelTypeFileEntity  DataEntitySummaryModelTypeEnum = "FILE_ENTITY"
+)
+
+var mappingDataEntitySummaryModelType = map[string]DataEntitySummaryModelTypeEnum{
+	"VIEW_ENTITY":  DataEntitySummaryModelTypeViewEntity,
+	"TABLE_ENTITY": DataEntitySummaryModelTypeTableEntity,
+	"FILE_ENTITY":  DataEntitySummaryModelTypeFileEntity,
+}
+
+// GetDataEntitySummaryModelTypeEnumValues Enumerates the set of values for DataEntitySummaryModelTypeEnum
+func GetDataEntitySummaryModelTypeEnumValues() []DataEntitySummaryModelTypeEnum {
+	values := make([]DataEntitySummaryModelTypeEnum, 0)
+	for _, v := range mappingDataEntitySummaryModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/data_entity_summary_collection.go
+++ b/dataintegration/data_entity_summary_collection.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataEntitySummaryCollection This is the collection of data entity summaries, it may be a collection of lightweight details or full definitions.
+type DataEntitySummaryCollection struct {
+
+	// The array of DataEntity summaries
+	Items []DataEntitySummary `mandatory:"true" json:"items"`
+}
+
+func (m DataEntitySummaryCollection) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *DataEntitySummaryCollection) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Items []dataentitysummary `json:"items"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Items = make([]DataEntitySummary, len(model.Items))
+	for i, n := range model.Items {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.Items[i] = nn.(DataEntitySummary)
+		} else {
+			m.Items[i] = nil
+		}
+	}
+	return
+}

--- a/dataintegration/data_entity_summary_from_file.go
+++ b/dataintegration/data_entity_summary_from_file.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataEntitySummaryFromFile The file data entity details.
+type DataEntitySummaryFromFile struct {
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The external key for the object.
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	Shape *Shape `mandatory:"false" json:"shape"`
+
+	// The shape ID.
+	ShapeId *string `mandatory:"false" json:"shapeId"`
+
+	Types *TypeLibrary `mandatory:"false" json:"types"`
+
+	// Specifies other type label.
+	OtherTypeLabel *string `mandatory:"false" json:"otherTypeLabel"`
+
+	// An array of unique keys.
+	UniqueKeys []UniqueKey `mandatory:"false" json:"uniqueKeys"`
+
+	// An array of foreign keys.
+	ForeignKeys []ForeignKey `mandatory:"false" json:"foreignKeys"`
+
+	// The resource name.
+	ResourceName *string `mandatory:"false" json:"resourceName"`
+
+	DataFormat *DataFormat `mandatory:"false" json:"dataFormat"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The entity type.
+	EntityType DataEntitySummaryFromFileEntityTypeEnum `mandatory:"false" json:"entityType,omitempty"`
+}
+
+//GetMetadata returns Metadata
+func (m DataEntitySummaryFromFile) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m DataEntitySummaryFromFile) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DataEntitySummaryFromFile) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDataEntitySummaryFromFile DataEntitySummaryFromFile
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDataEntitySummaryFromFile
+	}{
+		"FILE_ENTITY",
+		(MarshalTypeDataEntitySummaryFromFile)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// DataEntitySummaryFromFileEntityTypeEnum Enum with underlying type: string
+type DataEntitySummaryFromFileEntityTypeEnum string
+
+// Set of constants representing the allowable values for DataEntitySummaryFromFileEntityTypeEnum
+const (
+	DataEntitySummaryFromFileEntityTypeTable  DataEntitySummaryFromFileEntityTypeEnum = "TABLE"
+	DataEntitySummaryFromFileEntityTypeView   DataEntitySummaryFromFileEntityTypeEnum = "VIEW"
+	DataEntitySummaryFromFileEntityTypeFile   DataEntitySummaryFromFileEntityTypeEnum = "FILE"
+	DataEntitySummaryFromFileEntityTypeQueue  DataEntitySummaryFromFileEntityTypeEnum = "QUEUE"
+	DataEntitySummaryFromFileEntityTypeStream DataEntitySummaryFromFileEntityTypeEnum = "STREAM"
+	DataEntitySummaryFromFileEntityTypeOther  DataEntitySummaryFromFileEntityTypeEnum = "OTHER"
+)
+
+var mappingDataEntitySummaryFromFileEntityType = map[string]DataEntitySummaryFromFileEntityTypeEnum{
+	"TABLE":  DataEntitySummaryFromFileEntityTypeTable,
+	"VIEW":   DataEntitySummaryFromFileEntityTypeView,
+	"FILE":   DataEntitySummaryFromFileEntityTypeFile,
+	"QUEUE":  DataEntitySummaryFromFileEntityTypeQueue,
+	"STREAM": DataEntitySummaryFromFileEntityTypeStream,
+	"OTHER":  DataEntitySummaryFromFileEntityTypeOther,
+}
+
+// GetDataEntitySummaryFromFileEntityTypeEnumValues Enumerates the set of values for DataEntitySummaryFromFileEntityTypeEnum
+func GetDataEntitySummaryFromFileEntityTypeEnumValues() []DataEntitySummaryFromFileEntityTypeEnum {
+	values := make([]DataEntitySummaryFromFileEntityTypeEnum, 0)
+	for _, v := range mappingDataEntitySummaryFromFileEntityType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/data_entity_summary_from_table.go
+++ b/dataintegration/data_entity_summary_from_table.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataEntitySummaryFromTable The table entity data entity.
+type DataEntitySummaryFromTable struct {
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The external key for the object.
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	Shape *Shape `mandatory:"false" json:"shape"`
+
+	// The shape ID.
+	ShapeId *string `mandatory:"false" json:"shapeId"`
+
+	Types *TypeLibrary `mandatory:"false" json:"types"`
+
+	// Specifies other type label.
+	OtherTypeLabel *string `mandatory:"false" json:"otherTypeLabel"`
+
+	// An array of unique keys.
+	UniqueKeys []UniqueKey `mandatory:"false" json:"uniqueKeys"`
+
+	// An array of foreign keys.
+	ForeignKeys []ForeignKey `mandatory:"false" json:"foreignKeys"`
+
+	// The resource name.
+	ResourceName *string `mandatory:"false" json:"resourceName"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The entity type.
+	EntityType DataEntitySummaryFromTableEntityTypeEnum `mandatory:"false" json:"entityType,omitempty"`
+}
+
+//GetMetadata returns Metadata
+func (m DataEntitySummaryFromTable) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m DataEntitySummaryFromTable) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DataEntitySummaryFromTable) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDataEntitySummaryFromTable DataEntitySummaryFromTable
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDataEntitySummaryFromTable
+	}{
+		"TABLE_ENTITY",
+		(MarshalTypeDataEntitySummaryFromTable)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// DataEntitySummaryFromTableEntityTypeEnum Enum with underlying type: string
+type DataEntitySummaryFromTableEntityTypeEnum string
+
+// Set of constants representing the allowable values for DataEntitySummaryFromTableEntityTypeEnum
+const (
+	DataEntitySummaryFromTableEntityTypeTable  DataEntitySummaryFromTableEntityTypeEnum = "TABLE"
+	DataEntitySummaryFromTableEntityTypeView   DataEntitySummaryFromTableEntityTypeEnum = "VIEW"
+	DataEntitySummaryFromTableEntityTypeFile   DataEntitySummaryFromTableEntityTypeEnum = "FILE"
+	DataEntitySummaryFromTableEntityTypeQueue  DataEntitySummaryFromTableEntityTypeEnum = "QUEUE"
+	DataEntitySummaryFromTableEntityTypeStream DataEntitySummaryFromTableEntityTypeEnum = "STREAM"
+	DataEntitySummaryFromTableEntityTypeOther  DataEntitySummaryFromTableEntityTypeEnum = "OTHER"
+)
+
+var mappingDataEntitySummaryFromTableEntityType = map[string]DataEntitySummaryFromTableEntityTypeEnum{
+	"TABLE":  DataEntitySummaryFromTableEntityTypeTable,
+	"VIEW":   DataEntitySummaryFromTableEntityTypeView,
+	"FILE":   DataEntitySummaryFromTableEntityTypeFile,
+	"QUEUE":  DataEntitySummaryFromTableEntityTypeQueue,
+	"STREAM": DataEntitySummaryFromTableEntityTypeStream,
+	"OTHER":  DataEntitySummaryFromTableEntityTypeOther,
+}
+
+// GetDataEntitySummaryFromTableEntityTypeEnumValues Enumerates the set of values for DataEntitySummaryFromTableEntityTypeEnum
+func GetDataEntitySummaryFromTableEntityTypeEnumValues() []DataEntitySummaryFromTableEntityTypeEnum {
+	values := make([]DataEntitySummaryFromTableEntityTypeEnum, 0)
+	for _, v := range mappingDataEntitySummaryFromTableEntityType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/data_entity_summary_from_view.go
+++ b/dataintegration/data_entity_summary_from_view.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataEntitySummaryFromView The view entity data entity details.
+type DataEntitySummaryFromView struct {
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The external key for the object
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	Shape *Shape `mandatory:"false" json:"shape"`
+
+	// The shape ID.
+	ShapeId *string `mandatory:"false" json:"shapeId"`
+
+	Types *TypeLibrary `mandatory:"false" json:"types"`
+
+	// Specifies other type label.
+	OtherTypeLabel *string `mandatory:"false" json:"otherTypeLabel"`
+
+	// An array of unique keys.
+	UniqueKeys []UniqueKey `mandatory:"false" json:"uniqueKeys"`
+
+	// An array of foreign keys.
+	ForeignKeys []ForeignKey `mandatory:"false" json:"foreignKeys"`
+
+	// The resource name.
+	ResourceName *string `mandatory:"false" json:"resourceName"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The entity type.
+	EntityType DataEntitySummaryFromViewEntityTypeEnum `mandatory:"false" json:"entityType,omitempty"`
+}
+
+//GetMetadata returns Metadata
+func (m DataEntitySummaryFromView) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m DataEntitySummaryFromView) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DataEntitySummaryFromView) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDataEntitySummaryFromView DataEntitySummaryFromView
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDataEntitySummaryFromView
+	}{
+		"VIEW_ENTITY",
+		(MarshalTypeDataEntitySummaryFromView)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// DataEntitySummaryFromViewEntityTypeEnum Enum with underlying type: string
+type DataEntitySummaryFromViewEntityTypeEnum string
+
+// Set of constants representing the allowable values for DataEntitySummaryFromViewEntityTypeEnum
+const (
+	DataEntitySummaryFromViewEntityTypeTable  DataEntitySummaryFromViewEntityTypeEnum = "TABLE"
+	DataEntitySummaryFromViewEntityTypeView   DataEntitySummaryFromViewEntityTypeEnum = "VIEW"
+	DataEntitySummaryFromViewEntityTypeFile   DataEntitySummaryFromViewEntityTypeEnum = "FILE"
+	DataEntitySummaryFromViewEntityTypeQueue  DataEntitySummaryFromViewEntityTypeEnum = "QUEUE"
+	DataEntitySummaryFromViewEntityTypeStream DataEntitySummaryFromViewEntityTypeEnum = "STREAM"
+	DataEntitySummaryFromViewEntityTypeOther  DataEntitySummaryFromViewEntityTypeEnum = "OTHER"
+)
+
+var mappingDataEntitySummaryFromViewEntityType = map[string]DataEntitySummaryFromViewEntityTypeEnum{
+	"TABLE":  DataEntitySummaryFromViewEntityTypeTable,
+	"VIEW":   DataEntitySummaryFromViewEntityTypeView,
+	"FILE":   DataEntitySummaryFromViewEntityTypeFile,
+	"QUEUE":  DataEntitySummaryFromViewEntityTypeQueue,
+	"STREAM": DataEntitySummaryFromViewEntityTypeStream,
+	"OTHER":  DataEntitySummaryFromViewEntityTypeOther,
+}
+
+// GetDataEntitySummaryFromViewEntityTypeEnumValues Enumerates the set of values for DataEntitySummaryFromViewEntityTypeEnum
+func GetDataEntitySummaryFromViewEntityTypeEnumValues() []DataEntitySummaryFromViewEntityTypeEnum {
+	values := make([]DataEntitySummaryFromViewEntityTypeEnum, 0)
+	for _, v := range mappingDataEntitySummaryFromViewEntityType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/data_flow.go
+++ b/dataintegration/data_flow.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataFlow The data flow type contains the audit summary information and the definition of the data flow.
+type DataFlow struct {
+
+	// Generated key that can be used in API calls to identify data flow. On scenarios where reference to the data flow is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// An array of nodes.
+	Nodes []FlowNode `mandatory:"false" json:"nodes"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	FlowConfigValues *ConfigValues `mandatory:"false" json:"flowConfigValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+}
+
+func (m DataFlow) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/data_flow_details.go
+++ b/dataintegration/data_flow_details.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataFlowDetails The information about a data flow.
+type DataFlowDetails struct {
+
+	// Generated key that can be used in API calls to identify data flow. On scenarios where reference to the data flow is needed, a value can be passed in create.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"true" json:"modelType"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"true" json:"objectVersion"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// An array of nodes.
+	Nodes []FlowNode `mandatory:"false" json:"nodes"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	FlowConfigValues *ConfigValues `mandatory:"false" json:"flowConfigValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+}
+
+func (m DataFlowDetails) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/data_flow_summary.go
+++ b/dataintegration/data_flow_summary.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataFlowSummary The data flow summary type contains the audit summary information and the definition of the data flow.
+type DataFlowSummary struct {
+
+	// Generated key that can be used in API calls to identify data flow. On scenarios where reference to the data flow is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// An array of nodes.
+	Nodes []FlowNode `mandatory:"false" json:"nodes"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	FlowConfigValues *ConfigValues `mandatory:"false" json:"flowConfigValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+}
+
+func (m DataFlowSummary) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/data_flow_summary_collection.go
+++ b/dataintegration/data_flow_summary_collection.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataFlowSummaryCollection This is the collection of data flow summaries, it may be a collection of lightweight details or full definitions.
+type DataFlowSummaryCollection struct {
+
+	// The array of DataFlow summaries
+	Items []DataFlowSummary `mandatory:"true" json:"items"`
+}
+
+func (m DataFlowSummaryCollection) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/data_flow_validation.go
+++ b/dataintegration/data_flow_validation.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataFlowValidation The information about dataflow validation
+type DataFlowValidation struct {
+
+	// Total number of validation messages
+	TotalMessageCount *int `mandatory:"false" json:"totalMessageCount"`
+
+	// Total number of validation error messages
+	ErrorMessageCount *int `mandatory:"false" json:"errorMessageCount"`
+
+	// Total number of validation warning messages
+	WarnMessageCount *int `mandatory:"false" json:"warnMessageCount"`
+
+	// Total number of validation information messages
+	InfoMessageCount *int `mandatory:"false" json:"infoMessageCount"`
+
+	// Detailed information of the DataFlow object validation.
+	ValidationMessages map[string][]ValidationMessage `mandatory:"false" json:"validationMessages"`
+
+	// Objects will use a 36 character key as unique ID. It is system generated and cannot be edited by user
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+}
+
+func (m DataFlowValidation) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/data_flow_validation_summary.go
+++ b/dataintegration/data_flow_validation_summary.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataFlowValidationSummary The information about dataflow validation
+type DataFlowValidationSummary struct {
+
+	// Total number of validation messages
+	TotalMessageCount *int `mandatory:"false" json:"totalMessageCount"`
+
+	// Total number of validation error messages
+	ErrorMessageCount *int `mandatory:"false" json:"errorMessageCount"`
+
+	// Total number of validation warning messages
+	WarnMessageCount *int `mandatory:"false" json:"warnMessageCount"`
+
+	// Total number of validation information messages
+	InfoMessageCount *int `mandatory:"false" json:"infoMessageCount"`
+
+	// Detailed information of the DataFlow object validation.
+	ValidationMessages map[string][]ValidationMessage `mandatory:"false" json:"validationMessages"`
+
+	// Objects will use a 36 character key as unique ID. It is system generated and cannot be edited by user
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+}
+
+func (m DataFlowValidationSummary) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/data_flow_validation_summary_collection.go
+++ b/dataintegration/data_flow_validation_summary_collection.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataFlowValidationSummaryCollection List of dataflow validation summaries
+type DataFlowValidationSummaryCollection struct {
+
+	// The array of validation summaries
+	Items []DataFlowValidationSummary `mandatory:"true" json:"items"`
+}
+
+func (m DataFlowValidationSummaryCollection) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/data_format.go
+++ b/dataintegration/data_format.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataFormat The data format object.
+type DataFormat struct {
+	FormatAttribute AbstractFormatAttribute `mandatory:"false" json:"formatAttribute"`
+
+	// type
+	Type DataFormatTypeEnum `mandatory:"false" json:"type,omitempty"`
+}
+
+func (m DataFormat) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *DataFormat) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		FormatAttribute abstractformatattribute `json:"formatAttribute"`
+		Type            DataFormatTypeEnum      `json:"type"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	nn, e = model.FormatAttribute.UnmarshalPolymorphicJSON(model.FormatAttribute.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.FormatAttribute = nn.(AbstractFormatAttribute)
+	} else {
+		m.FormatAttribute = nil
+	}
+
+	m.Type = model.Type
+	return
+}
+
+// DataFormatTypeEnum Enum with underlying type: string
+type DataFormatTypeEnum string
+
+// Set of constants representing the allowable values for DataFormatTypeEnum
+const (
+	DataFormatTypeXml     DataFormatTypeEnum = "XML"
+	DataFormatTypeJson    DataFormatTypeEnum = "JSON"
+	DataFormatTypeCsv     DataFormatTypeEnum = "CSV"
+	DataFormatTypeOrc     DataFormatTypeEnum = "ORC"
+	DataFormatTypeParquet DataFormatTypeEnum = "PARQUET"
+)
+
+var mappingDataFormatType = map[string]DataFormatTypeEnum{
+	"XML":     DataFormatTypeXml,
+	"JSON":    DataFormatTypeJson,
+	"CSV":     DataFormatTypeCsv,
+	"ORC":     DataFormatTypeOrc,
+	"PARQUET": DataFormatTypeParquet,
+}
+
+// GetDataFormatTypeEnumValues Enumerates the set of values for DataFormatTypeEnum
+func GetDataFormatTypeEnumValues() []DataFormatTypeEnum {
+	values := make([]DataFormatTypeEnum, 0)
+	for _, v := range mappingDataFormatType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/data_type.go
+++ b/dataintegration/data_type.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DataType A DataType object is a simple primitive type that describes the type of a single atomic unit of data.  For example, INT, VARCHAR, NUMBER, etc.
+type DataType struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// typeSystemName
+	TypeSystemName *string `mandatory:"false" json:"typeSystemName"`
+
+	ConfigDefinition *ConfigDefinition `mandatory:"false" json:"configDefinition"`
+
+	// dtType
+	DtType DataTypeDtTypeEnum `mandatory:"false" json:"dtType,omitempty"`
+}
+
+//GetKey returns Key
+func (m DataType) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m DataType) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m DataType) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m DataType) GetName() *string {
+	return m.Name
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m DataType) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetDescription returns Description
+func (m DataType) GetDescription() *string {
+	return m.Description
+}
+
+func (m DataType) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DataType) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDataType DataType
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDataType
+	}{
+		"DATA_TYPE",
+		(MarshalTypeDataType)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// DataTypeDtTypeEnum Enum with underlying type: string
+type DataTypeDtTypeEnum string
+
+// Set of constants representing the allowable values for DataTypeDtTypeEnum
+const (
+	DataTypeDtTypePrimitive  DataTypeDtTypeEnum = "PRIMITIVE"
+	DataTypeDtTypeStructured DataTypeDtTypeEnum = "STRUCTURED"
+)
+
+var mappingDataTypeDtType = map[string]DataTypeDtTypeEnum{
+	"PRIMITIVE":  DataTypeDtTypePrimitive,
+	"STRUCTURED": DataTypeDtTypeStructured,
+}
+
+// GetDataTypeDtTypeEnumValues Enumerates the set of values for DataTypeDtTypeEnum
+func GetDataTypeDtTypeEnumValues() []DataTypeDtTypeEnum {
+	values := make([]DataTypeDtTypeEnum, 0)
+	for _, v := range mappingDataTypeDtType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/dataintegration_client.go
+++ b/dataintegration/dataintegration_client.go
@@ -1,0 +1,3877 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"context"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+//DataIntegrationClient a client for DataIntegration
+type DataIntegrationClient struct {
+	common.BaseClient
+	config *common.ConfigurationProvider
+}
+
+// NewDataIntegrationClientWithConfigurationProvider Creates a new default DataIntegration client with the given configuration provider.
+// the configuration provider will be used for the default signer as well as reading the region
+func NewDataIntegrationClientWithConfigurationProvider(configProvider common.ConfigurationProvider) (client DataIntegrationClient, err error) {
+	baseClient, err := common.NewClientWithConfig(configProvider)
+	if err != nil {
+		return
+	}
+
+	return newDataIntegrationClientFromBaseClient(baseClient, configProvider)
+}
+
+// NewDataIntegrationClientWithOboToken Creates a new default DataIntegration client with the given configuration provider.
+// The obotoken will be added to default headers and signed; the configuration provider will be used for the signer
+//  as well as reading the region
+func NewDataIntegrationClientWithOboToken(configProvider common.ConfigurationProvider, oboToken string) (client DataIntegrationClient, err error) {
+	baseClient, err := common.NewClientWithOboToken(configProvider, oboToken)
+	if err != nil {
+		return
+	}
+
+	return newDataIntegrationClientFromBaseClient(baseClient, configProvider)
+}
+
+func newDataIntegrationClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client DataIntegrationClient, err error) {
+	client = DataIntegrationClient{BaseClient: baseClient}
+	client.BasePath = "20200430"
+	err = client.setConfigurationProvider(configProvider)
+	return
+}
+
+// SetRegion overrides the region of this client.
+func (client *DataIntegrationClient) SetRegion(region string) {
+	client.Host = common.StringToRegion(region).EndpointForTemplate("dataintegration", "https://dataintegration.{region}.oci.{secondLevelDomain}")
+}
+
+// SetConfigurationProvider sets the configuration provider including the region, returns an error if is not valid
+func (client *DataIntegrationClient) setConfigurationProvider(configProvider common.ConfigurationProvider) error {
+	if ok, err := common.IsConfigurationProviderValid(configProvider); !ok {
+		return err
+	}
+
+	// Error has been checked already
+	region, _ := configProvider.Region()
+	client.SetRegion(region)
+	client.config = &configProvider
+	return nil
+}
+
+// ConfigurationProvider the ConfigurationProvider used in this client, or null if none set
+func (client *DataIntegrationClient) ConfigurationProvider() *common.ConfigurationProvider {
+	return client.config
+}
+
+// ChangeCompartment The workspace will be moved to the desired compartment.
+func (client DataIntegrationClient) ChangeCompartment(ctx context.Context, request ChangeCompartmentRequest) (response ChangeCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.changeCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ChangeCompartmentResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ChangeCompartmentResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeCompartmentResponse")
+	}
+	return
+}
+
+// changeCompartment implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) changeCompartment(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/workspaces/{workspaceId}/actions/changeCompartment")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateApplication Creates an application.
+func (client DataIntegrationClient) CreateApplication(ctx context.Context, request CreateApplicationRequest) (response CreateApplicationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createApplication, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateApplicationResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateApplicationResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateApplicationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateApplicationResponse")
+	}
+	return
+}
+
+// createApplication implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) createApplication(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/workspaces/{workspaceId}/applications")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateApplicationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateConnection Creates a connection under an existing data asset.
+func (client DataIntegrationClient) CreateConnection(ctx context.Context, request CreateConnectionRequest) (response CreateConnectionResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createConnection, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateConnectionResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateConnectionResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateConnectionResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateConnectionResponse")
+	}
+	return
+}
+
+// createConnection implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) createConnection(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/workspaces/{workspaceId}/connections")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateConnectionResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponseWithPolymorphicBody(httpResponse, &response, &connection{})
+	return response, err
+}
+
+// CreateConnectionValidation Creates a connection validation.
+func (client DataIntegrationClient) CreateConnectionValidation(ctx context.Context, request CreateConnectionValidationRequest) (response CreateConnectionValidationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createConnectionValidation, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateConnectionValidationResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateConnectionValidationResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateConnectionValidationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateConnectionValidationResponse")
+	}
+	return
+}
+
+// createConnectionValidation implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) createConnectionValidation(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/workspaces/{workspaceId}/connectionValidations")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateConnectionValidationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateDataAsset Creates a data asset with default connection.
+func (client DataIntegrationClient) CreateDataAsset(ctx context.Context, request CreateDataAssetRequest) (response CreateDataAssetResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createDataAsset, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateDataAssetResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateDataAssetResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateDataAssetResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateDataAssetResponse")
+	}
+	return
+}
+
+// createDataAsset implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) createDataAsset(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/workspaces/{workspaceId}/dataAssets")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateDataAssetResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponseWithPolymorphicBody(httpResponse, &response, &dataasset{})
+	return response, err
+}
+
+// CreateDataFlow Creates a new data flow in a project or folder ready for performing data integrations.
+func (client DataIntegrationClient) CreateDataFlow(ctx context.Context, request CreateDataFlowRequest) (response CreateDataFlowResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createDataFlow, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateDataFlowResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateDataFlowResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateDataFlowResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateDataFlowResponse")
+	}
+	return
+}
+
+// createDataFlow implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) createDataFlow(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/workspaces/{workspaceId}/dataFlows")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateDataFlowResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateDataFlowValidation The endpoint accepts the DataFlow object definition in the request payload and creates a DataFlow object validation.
+func (client DataIntegrationClient) CreateDataFlowValidation(ctx context.Context, request CreateDataFlowValidationRequest) (response CreateDataFlowValidationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createDataFlowValidation, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateDataFlowValidationResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateDataFlowValidationResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateDataFlowValidationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateDataFlowValidationResponse")
+	}
+	return
+}
+
+// createDataFlowValidation implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) createDataFlowValidation(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/workspaces/{workspaceId}/dataFlowValidations")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateDataFlowValidationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateEntityShape Retrieves the data entity shape from the end data system. The input can specify the data entity to get the shape for. For databases, this can be retrieved from the database data dictionary. For files, some hints as to the file properties can also be supplied in the input.
+func (client DataIntegrationClient) CreateEntityShape(ctx context.Context, request CreateEntityShapeRequest) (response CreateEntityShapeResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createEntityShape, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateEntityShapeResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateEntityShapeResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateEntityShapeResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateEntityShapeResponse")
+	}
+	return
+}
+
+// createEntityShape implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) createEntityShape(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/workspaces/{workspaceId}/connections/{connectionKey}/schemas/{schemaResourceName}/entityShapes")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateEntityShapeResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponseWithPolymorphicBody(httpResponse, &response, &entityshape{})
+	return response, err
+}
+
+// CreateFolder Creates a folder in a project or in another folder, limited to two levels of folders. |
+// Folders are used to organize your design-time resources, such as tasks or data flows.
+func (client DataIntegrationClient) CreateFolder(ctx context.Context, request CreateFolderRequest) (response CreateFolderResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createFolder, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateFolderResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateFolderResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateFolderResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateFolderResponse")
+	}
+	return
+}
+
+// createFolder implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) createFolder(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/workspaces/{workspaceId}/folders")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateFolderResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreatePatch Creates a patch in an application.
+func (client DataIntegrationClient) CreatePatch(ctx context.Context, request CreatePatchRequest) (response CreatePatchResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createPatch, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreatePatchResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreatePatchResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreatePatchResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreatePatchResponse")
+	}
+	return
+}
+
+// createPatch implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) createPatch(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/workspaces/{workspaceId}/applications/{applicationKey}/patches")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreatePatchResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateProject Creates a project. Projects are organizational constructs within a workspace that you use to organize your design-time resources, such as tasks or data flows. Projects can be organized into folders.
+func (client DataIntegrationClient) CreateProject(ctx context.Context, request CreateProjectRequest) (response CreateProjectResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createProject, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateProjectResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateProjectResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateProjectResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateProjectResponse")
+	}
+	return
+}
+
+// createProject implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) createProject(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/workspaces/{workspaceId}/projects")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateProjectResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateTask Creates a new task ready for performing data integrations. There are specialized types of tasks that include data loader and integration tasks.
+func (client DataIntegrationClient) CreateTask(ctx context.Context, request CreateTaskRequest) (response CreateTaskResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createTask, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateTaskResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateTaskResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateTaskResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateTaskResponse")
+	}
+	return
+}
+
+// createTask implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) createTask(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/workspaces/{workspaceId}/tasks")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateTaskResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponseWithPolymorphicBody(httpResponse, &response, &task{})
+	return response, err
+}
+
+// CreateTaskRun Creates a data integration task or task run. The task can be based on a dataflow design or a task.
+func (client DataIntegrationClient) CreateTaskRun(ctx context.Context, request CreateTaskRunRequest) (response CreateTaskRunResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createTaskRun, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateTaskRunResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateTaskRunResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateTaskRunResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateTaskRunResponse")
+	}
+	return
+}
+
+// createTaskRun implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) createTaskRun(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/workspaces/{workspaceId}/applications/{applicationKey}/taskRuns")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateTaskRunResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateTaskValidation Validates a specific task.
+func (client DataIntegrationClient) CreateTaskValidation(ctx context.Context, request CreateTaskValidationRequest) (response CreateTaskValidationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createTaskValidation, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateTaskValidationResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateTaskValidationResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateTaskValidationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateTaskValidationResponse")
+	}
+	return
+}
+
+// createTaskValidation implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) createTaskValidation(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/workspaces/{workspaceId}/taskValidations")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateTaskValidationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateWorkspace Creates a new Data Integration Workspace ready for performing data integration.
+func (client DataIntegrationClient) CreateWorkspace(ctx context.Context, request CreateWorkspaceRequest) (response CreateWorkspaceResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createWorkspace, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateWorkspaceResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateWorkspaceResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateWorkspaceResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateWorkspaceResponse")
+	}
+	return
+}
+
+// createWorkspace implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) createWorkspace(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/workspaces")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateWorkspaceResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteApplication Removes an application using the specified identifier.
+func (client DataIntegrationClient) DeleteApplication(ctx context.Context, request DeleteApplicationRequest) (response DeleteApplicationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteApplication, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteApplicationResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteApplicationResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteApplicationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteApplicationResponse")
+	}
+	return
+}
+
+// deleteApplication implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) deleteApplication(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/workspaces/{workspaceId}/applications/{applicationKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteApplicationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteConnection Removes a connection using the specified identifier.
+func (client DataIntegrationClient) DeleteConnection(ctx context.Context, request DeleteConnectionRequest) (response DeleteConnectionResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteConnection, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteConnectionResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteConnectionResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteConnectionResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteConnectionResponse")
+	}
+	return
+}
+
+// deleteConnection implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) deleteConnection(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/workspaces/{workspaceId}/connections/{connectionKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteConnectionResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteConnectionValidation Successfully accepted the delete request. The connection validation will be deleted.
+func (client DataIntegrationClient) DeleteConnectionValidation(ctx context.Context, request DeleteConnectionValidationRequest) (response DeleteConnectionValidationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteConnectionValidation, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteConnectionValidationResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteConnectionValidationResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteConnectionValidationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteConnectionValidationResponse")
+	}
+	return
+}
+
+// deleteConnectionValidation implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) deleteConnectionValidation(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/workspaces/{workspaceId}/connectionValidations/{connectionValidationKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteConnectionValidationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteDataAsset Removes a data asset using the specified identifier.
+func (client DataIntegrationClient) DeleteDataAsset(ctx context.Context, request DeleteDataAssetRequest) (response DeleteDataAssetResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteDataAsset, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteDataAssetResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteDataAssetResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteDataAssetResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteDataAssetResponse")
+	}
+	return
+}
+
+// deleteDataAsset implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) deleteDataAsset(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/workspaces/{workspaceId}/dataAssets/{dataAssetKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteDataAssetResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteDataFlow Removes a data flow from a project or folder using the specified identifier.
+func (client DataIntegrationClient) DeleteDataFlow(ctx context.Context, request DeleteDataFlowRequest) (response DeleteDataFlowResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteDataFlow, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteDataFlowResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteDataFlowResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteDataFlowResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteDataFlowResponse")
+	}
+	return
+}
+
+// deleteDataFlow implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) deleteDataFlow(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/workspaces/{workspaceId}/dataFlows/{dataFlowKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteDataFlowResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteDataFlowValidation Removes a data flow validation using the specified identifier.
+func (client DataIntegrationClient) DeleteDataFlowValidation(ctx context.Context, request DeleteDataFlowValidationRequest) (response DeleteDataFlowValidationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteDataFlowValidation, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteDataFlowValidationResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteDataFlowValidationResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteDataFlowValidationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteDataFlowValidationResponse")
+	}
+	return
+}
+
+// deleteDataFlowValidation implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) deleteDataFlowValidation(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/workspaces/{workspaceId}/dataFlowValidations/{dataFlowValidationKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteDataFlowValidationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteFolder Removes a folder from a project using the specified identifier.
+func (client DataIntegrationClient) DeleteFolder(ctx context.Context, request DeleteFolderRequest) (response DeleteFolderResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteFolder, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteFolderResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteFolderResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteFolderResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteFolderResponse")
+	}
+	return
+}
+
+// deleteFolder implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) deleteFolder(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/workspaces/{workspaceId}/folders/{folderKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteFolderResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeletePatch Removes a patch using the specified identifier.
+func (client DataIntegrationClient) DeletePatch(ctx context.Context, request DeletePatchRequest) (response DeletePatchResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deletePatch, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeletePatchResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeletePatchResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeletePatchResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeletePatchResponse")
+	}
+	return
+}
+
+// deletePatch implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) deletePatch(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/workspaces/{workspaceId}/applications/{applicationKey}/patches/{patchKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeletePatchResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteProject Removes a project from the workspace using the specified identifier.
+func (client DataIntegrationClient) DeleteProject(ctx context.Context, request DeleteProjectRequest) (response DeleteProjectResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteProject, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteProjectResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteProjectResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteProjectResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteProjectResponse")
+	}
+	return
+}
+
+// deleteProject implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) deleteProject(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/workspaces/{workspaceId}/projects/{projectKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteProjectResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteTask Removes a task using the specified identifier.
+func (client DataIntegrationClient) DeleteTask(ctx context.Context, request DeleteTaskRequest) (response DeleteTaskResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteTask, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteTaskResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteTaskResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteTaskResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteTaskResponse")
+	}
+	return
+}
+
+// deleteTask implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) deleteTask(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/workspaces/{workspaceId}/tasks/{taskKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteTaskResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteTaskRun Deletes a task run using the specified identifier.
+func (client DataIntegrationClient) DeleteTaskRun(ctx context.Context, request DeleteTaskRunRequest) (response DeleteTaskRunResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteTaskRun, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteTaskRunResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteTaskRunResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteTaskRunResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteTaskRunResponse")
+	}
+	return
+}
+
+// deleteTaskRun implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) deleteTaskRun(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/workspaces/{workspaceId}/applications/{applicationKey}/taskRuns/{taskRunKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteTaskRunResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteTaskValidation Removes a task validation using the specified identifier.
+func (client DataIntegrationClient) DeleteTaskValidation(ctx context.Context, request DeleteTaskValidationRequest) (response DeleteTaskValidationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteTaskValidation, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteTaskValidationResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteTaskValidationResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteTaskValidationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteTaskValidationResponse")
+	}
+	return
+}
+
+// deleteTaskValidation implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) deleteTaskValidation(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/workspaces/{workspaceId}/taskValidations/{taskValidationKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteTaskValidationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteWorkspace Deletes a Data Integration Workspace resource by identifier
+func (client DataIntegrationClient) DeleteWorkspace(ctx context.Context, request DeleteWorkspaceRequest) (response DeleteWorkspaceResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteWorkspace, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteWorkspaceResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteWorkspaceResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteWorkspaceResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteWorkspaceResponse")
+	}
+	return
+}
+
+// deleteWorkspace implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) deleteWorkspace(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/workspaces/{workspaceId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteWorkspaceResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetApplication Retrieves an application using the specified identifier.
+func (client DataIntegrationClient) GetApplication(ctx context.Context, request GetApplicationRequest) (response GetApplicationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getApplication, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetApplicationResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetApplicationResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetApplicationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetApplicationResponse")
+	}
+	return
+}
+
+// getApplication implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) getApplication(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/applications/{applicationKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetApplicationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetConnection Retrieves the connection details using the specified identifier.
+func (client DataIntegrationClient) GetConnection(ctx context.Context, request GetConnectionRequest) (response GetConnectionResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getConnection, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetConnectionResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetConnectionResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetConnectionResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetConnectionResponse")
+	}
+	return
+}
+
+// getConnection implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) getConnection(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/connections/{connectionKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetConnectionResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponseWithPolymorphicBody(httpResponse, &response, &connection{})
+	return response, err
+}
+
+// GetConnectionValidation Retrieves a connection validation using the specified identifier.
+func (client DataIntegrationClient) GetConnectionValidation(ctx context.Context, request GetConnectionValidationRequest) (response GetConnectionValidationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getConnectionValidation, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetConnectionValidationResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetConnectionValidationResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetConnectionValidationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetConnectionValidationResponse")
+	}
+	return
+}
+
+// getConnectionValidation implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) getConnectionValidation(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/connectionValidations/{connectionValidationKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetConnectionValidationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetCountStatistic Retrieves statistics on a workspace. It returns an object with an array of property values, such as the number of projects, |
+//        applications, data assets, and so on.
+func (client DataIntegrationClient) GetCountStatistic(ctx context.Context, request GetCountStatisticRequest) (response GetCountStatisticResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getCountStatistic, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetCountStatisticResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetCountStatisticResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetCountStatisticResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetCountStatisticResponse")
+	}
+	return
+}
+
+// getCountStatistic implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) getCountStatistic(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/countStatistics/{countStatisticKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetCountStatisticResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetDataAsset Retrieves details of a data asset using the specified identifier.
+func (client DataIntegrationClient) GetDataAsset(ctx context.Context, request GetDataAssetRequest) (response GetDataAssetResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getDataAsset, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetDataAssetResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetDataAssetResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetDataAssetResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetDataAssetResponse")
+	}
+	return
+}
+
+// getDataAsset implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) getDataAsset(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/dataAssets/{dataAssetKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetDataAssetResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponseWithPolymorphicBody(httpResponse, &response, &dataasset{})
+	return response, err
+}
+
+// GetDataEntity Retrieves the data entity details with the given name from live schema.
+func (client DataIntegrationClient) GetDataEntity(ctx context.Context, request GetDataEntityRequest) (response GetDataEntityResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getDataEntity, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetDataEntityResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetDataEntityResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetDataEntityResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetDataEntityResponse")
+	}
+	return
+}
+
+// getDataEntity implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) getDataEntity(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/connections/{connectionKey}/schemas/{schemaResourceName}/dataEntities/{dataEntityKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetDataEntityResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponseWithPolymorphicBody(httpResponse, &response, &dataentity{})
+	return response, err
+}
+
+// GetDataFlow Retrieves a data flow using the specified identifier.
+func (client DataIntegrationClient) GetDataFlow(ctx context.Context, request GetDataFlowRequest) (response GetDataFlowResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getDataFlow, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetDataFlowResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetDataFlowResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetDataFlowResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetDataFlowResponse")
+	}
+	return
+}
+
+// getDataFlow implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) getDataFlow(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/dataFlows/{dataFlowKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetDataFlowResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetDataFlowValidation Retrieves a data flow validation using the specified identifier.
+func (client DataIntegrationClient) GetDataFlowValidation(ctx context.Context, request GetDataFlowValidationRequest) (response GetDataFlowValidationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getDataFlowValidation, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetDataFlowValidationResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetDataFlowValidationResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetDataFlowValidationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetDataFlowValidationResponse")
+	}
+	return
+}
+
+// getDataFlowValidation implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) getDataFlowValidation(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/dataFlowValidations/{dataFlowValidationKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetDataFlowValidationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetDependentObject Retrieves the details of a dependent object from an application.
+func (client DataIntegrationClient) GetDependentObject(ctx context.Context, request GetDependentObjectRequest) (response GetDependentObjectResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getDependentObject, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetDependentObjectResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetDependentObjectResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetDependentObjectResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetDependentObjectResponse")
+	}
+	return
+}
+
+// getDependentObject implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) getDependentObject(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/applications/{applicationKey}/dependentObjects/{dependentObjectKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetDependentObjectResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetFolder Retrieves a folder using the specified identifier.
+func (client DataIntegrationClient) GetFolder(ctx context.Context, request GetFolderRequest) (response GetFolderResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getFolder, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetFolderResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetFolderResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetFolderResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetFolderResponse")
+	}
+	return
+}
+
+// getFolder implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) getFolder(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/folders/{folderKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetFolderResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetPatch Retrieves a patch in an application using the specified identifier.
+func (client DataIntegrationClient) GetPatch(ctx context.Context, request GetPatchRequest) (response GetPatchResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getPatch, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetPatchResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetPatchResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetPatchResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetPatchResponse")
+	}
+	return
+}
+
+// getPatch implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) getPatch(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/applications/{applicationKey}/patches/{patchKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetPatchResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetProject Retrieves a project using the specified identifier.
+func (client DataIntegrationClient) GetProject(ctx context.Context, request GetProjectRequest) (response GetProjectResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getProject, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetProjectResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetProjectResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetProjectResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetProjectResponse")
+	}
+	return
+}
+
+// getProject implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) getProject(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/projects/{projectKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetProjectResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetPublishedObject Retrieves the details of a published object from an application.
+func (client DataIntegrationClient) GetPublishedObject(ctx context.Context, request GetPublishedObjectRequest) (response GetPublishedObjectResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getPublishedObject, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetPublishedObjectResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetPublishedObjectResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetPublishedObjectResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetPublishedObjectResponse")
+	}
+	return
+}
+
+// getPublishedObject implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) getPublishedObject(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/applications/{applicationKey}/publishedObjects/{publishedObjectKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetPublishedObjectResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponseWithPolymorphicBody(httpResponse, &response, &publishedobject{})
+	return response, err
+}
+
+// GetSchema Retrieves a schema that can be accessed using the specified connection.
+func (client DataIntegrationClient) GetSchema(ctx context.Context, request GetSchemaRequest) (response GetSchemaResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getSchema, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetSchemaResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetSchemaResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetSchemaResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetSchemaResponse")
+	}
+	return
+}
+
+// getSchema implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) getSchema(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/connections/{connectionKey}/schemas/{schemaResourceName}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetSchemaResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetTask Retrieves a task using the specified identifier.
+func (client DataIntegrationClient) GetTask(ctx context.Context, request GetTaskRequest) (response GetTaskResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getTask, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetTaskResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetTaskResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetTaskResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetTaskResponse")
+	}
+	return
+}
+
+// getTask implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) getTask(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/tasks/{taskKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetTaskResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponseWithPolymorphicBody(httpResponse, &response, &task{})
+	return response, err
+}
+
+// GetTaskRun Retrieves a task run using the specified identifier.
+func (client DataIntegrationClient) GetTaskRun(ctx context.Context, request GetTaskRunRequest) (response GetTaskRunResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getTaskRun, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetTaskRunResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetTaskRunResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetTaskRunResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetTaskRunResponse")
+	}
+	return
+}
+
+// getTaskRun implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) getTaskRun(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/applications/{applicationKey}/taskRuns/{taskRunKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetTaskRunResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetTaskValidation Retrieves a task validation using the specified identifier.
+func (client DataIntegrationClient) GetTaskValidation(ctx context.Context, request GetTaskValidationRequest) (response GetTaskValidationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getTaskValidation, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetTaskValidationResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetTaskValidationResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetTaskValidationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetTaskValidationResponse")
+	}
+	return
+}
+
+// getTaskValidation implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) getTaskValidation(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/taskValidations/{taskValidationKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetTaskValidationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetWorkRequest Gets the status of the work request with the given ID.
+func (client DataIntegrationClient) GetWorkRequest(ctx context.Context, request GetWorkRequestRequest) (response GetWorkRequestResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getWorkRequest, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetWorkRequestResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetWorkRequestResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetWorkRequestResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetWorkRequestResponse")
+	}
+	return
+}
+
+// getWorkRequest implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) getWorkRequest(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests/{workRequestId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetWorkRequestResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetWorkspace Gets a Data Integration Workspace by identifier
+func (client DataIntegrationClient) GetWorkspace(ctx context.Context, request GetWorkspaceRequest) (response GetWorkspaceResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getWorkspace, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetWorkspaceResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetWorkspaceResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetWorkspaceResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetWorkspaceResponse")
+	}
+	return
+}
+
+// getWorkspace implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) getWorkspace(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetWorkspaceResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListApplications Retrieves a list of applications and provides options to filter the list.
+func (client DataIntegrationClient) ListApplications(ctx context.Context, request ListApplicationsRequest) (response ListApplicationsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listApplications, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListApplicationsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListApplicationsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListApplicationsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListApplicationsResponse")
+	}
+	return
+}
+
+// listApplications implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listApplications(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/applications")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListApplicationsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListConnectionValidations Retrieves a list of connection validations within the specified workspace.
+func (client DataIntegrationClient) ListConnectionValidations(ctx context.Context, request ListConnectionValidationsRequest) (response ListConnectionValidationsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listConnectionValidations, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListConnectionValidationsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListConnectionValidationsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListConnectionValidationsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListConnectionValidationsResponse")
+	}
+	return
+}
+
+// listConnectionValidations implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listConnectionValidations(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/connectionValidations")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListConnectionValidationsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListConnections Retrieves a list of all connections.
+func (client DataIntegrationClient) ListConnections(ctx context.Context, request ListConnectionsRequest) (response ListConnectionsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listConnections, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListConnectionsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListConnectionsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListConnectionsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListConnectionsResponse")
+	}
+	return
+}
+
+// listConnections implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listConnections(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/connections")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListConnectionsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListDataAssets This endpoint can be used to list all data asset summaries
+func (client DataIntegrationClient) ListDataAssets(ctx context.Context, request ListDataAssetsRequest) (response ListDataAssetsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listDataAssets, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListDataAssetsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListDataAssetsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListDataAssetsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListDataAssetsResponse")
+	}
+	return
+}
+
+// listDataAssets implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listDataAssets(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/dataAssets")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListDataAssetsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListDataEntities Retrieves a list of summaries of data entities present in the schema identified by schema name. |
+// A live query is run on the data asset identified via the connection specified.
+func (client DataIntegrationClient) ListDataEntities(ctx context.Context, request ListDataEntitiesRequest) (response ListDataEntitiesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listDataEntities, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListDataEntitiesResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListDataEntitiesResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListDataEntitiesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListDataEntitiesResponse")
+	}
+	return
+}
+
+// listDataEntities implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listDataEntities(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/connections/{connectionKey}/schemas/{schemaResourceName}/dataEntities")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListDataEntitiesResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListDataFlowValidations Retrieves a list of data flow validations within the specified workspace
+func (client DataIntegrationClient) ListDataFlowValidations(ctx context.Context, request ListDataFlowValidationsRequest) (response ListDataFlowValidationsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listDataFlowValidations, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListDataFlowValidationsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListDataFlowValidationsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListDataFlowValidationsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListDataFlowValidationsResponse")
+	}
+	return
+}
+
+// listDataFlowValidations implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listDataFlowValidations(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/dataFlowValidations")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListDataFlowValidationsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListDataFlows Retrieves a list of data flows in a project or folder.
+func (client DataIntegrationClient) ListDataFlows(ctx context.Context, request ListDataFlowsRequest) (response ListDataFlowsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listDataFlows, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListDataFlowsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListDataFlowsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListDataFlowsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListDataFlowsResponse")
+	}
+	return
+}
+
+// listDataFlows implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listDataFlows(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/dataFlows")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListDataFlowsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListDependentObjects Retrieves a list of all dependent objects for a specific application.
+func (client DataIntegrationClient) ListDependentObjects(ctx context.Context, request ListDependentObjectsRequest) (response ListDependentObjectsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listDependentObjects, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListDependentObjectsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListDependentObjectsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListDependentObjectsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListDependentObjectsResponse")
+	}
+	return
+}
+
+// listDependentObjects implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listDependentObjects(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/applications/{applicationKey}/dependentObjects")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListDependentObjectsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListFolders Retrieves a list of folders in a project and provides options to filter the list.
+func (client DataIntegrationClient) ListFolders(ctx context.Context, request ListFoldersRequest) (response ListFoldersResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listFolders, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListFoldersResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListFoldersResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListFoldersResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListFoldersResponse")
+	}
+	return
+}
+
+// listFolders implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listFolders(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/folders")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListFoldersResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListPatches Retrieves a list of patches in an application and provides options to filter the list.
+func (client DataIntegrationClient) ListPatches(ctx context.Context, request ListPatchesRequest) (response ListPatchesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listPatches, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListPatchesResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListPatchesResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListPatchesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListPatchesResponse")
+	}
+	return
+}
+
+// listPatches implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listPatches(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/applications/{applicationKey}/patches")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListPatchesResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListProjects Retrieves a lists of projects in a workspace and provides options to filter the list.
+func (client DataIntegrationClient) ListProjects(ctx context.Context, request ListProjectsRequest) (response ListProjectsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listProjects, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListProjectsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListProjectsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListProjectsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListProjectsResponse")
+	}
+	return
+}
+
+// listProjects implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listProjects(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/projects")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListProjectsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListPublishedObjects Retrieves a list of all the published objects for a specified application.
+func (client DataIntegrationClient) ListPublishedObjects(ctx context.Context, request ListPublishedObjectsRequest) (response ListPublishedObjectsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listPublishedObjects, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListPublishedObjectsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListPublishedObjectsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListPublishedObjectsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListPublishedObjectsResponse")
+	}
+	return
+}
+
+// listPublishedObjects implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listPublishedObjects(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/applications/{applicationKey}/publishedObjects")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListPublishedObjectsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListSchemas Retrieves a list of all the schemas that can be accessed using the specified connection.
+func (client DataIntegrationClient) ListSchemas(ctx context.Context, request ListSchemasRequest) (response ListSchemasResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listSchemas, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListSchemasResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListSchemasResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListSchemasResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListSchemasResponse")
+	}
+	return
+}
+
+// listSchemas implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listSchemas(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/connections/{connectionKey}/schemas")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListSchemasResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListTaskRunLogs Get log entries for task runs using its key
+func (client DataIntegrationClient) ListTaskRunLogs(ctx context.Context, request ListTaskRunLogsRequest) (response ListTaskRunLogsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listTaskRunLogs, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListTaskRunLogsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListTaskRunLogsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListTaskRunLogsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListTaskRunLogsResponse")
+	}
+	return
+}
+
+// listTaskRunLogs implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listTaskRunLogs(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/applications/{applicationKey}/taskRuns/{taskRunKey}/logs")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListTaskRunLogsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListTaskRuns Retrieves a list of task runs and provides options to filter the list.
+func (client DataIntegrationClient) ListTaskRuns(ctx context.Context, request ListTaskRunsRequest) (response ListTaskRunsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listTaskRuns, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListTaskRunsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListTaskRunsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListTaskRunsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListTaskRunsResponse")
+	}
+	return
+}
+
+// listTaskRuns implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listTaskRuns(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/applications/{applicationKey}/taskRuns")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListTaskRunsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListTaskValidations Retrieves a list of task validations within the specified workspace.
+func (client DataIntegrationClient) ListTaskValidations(ctx context.Context, request ListTaskValidationsRequest) (response ListTaskValidationsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listTaskValidations, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListTaskValidationsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListTaskValidationsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListTaskValidationsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListTaskValidationsResponse")
+	}
+	return
+}
+
+// listTaskValidations implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listTaskValidations(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/taskValidations")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListTaskValidationsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListTasks Retrieves a list of all tasks in a specified project or folder.
+func (client DataIntegrationClient) ListTasks(ctx context.Context, request ListTasksRequest) (response ListTasksResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listTasks, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListTasksResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListTasksResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListTasksResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListTasksResponse")
+	}
+	return
+}
+
+// listTasks implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listTasks(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces/{workspaceId}/tasks")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListTasksResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListWorkRequestErrors Return a (paginated) list of errors for a given work request.
+func (client DataIntegrationClient) ListWorkRequestErrors(ctx context.Context, request ListWorkRequestErrorsRequest) (response ListWorkRequestErrorsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listWorkRequestErrors, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListWorkRequestErrorsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListWorkRequestErrorsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListWorkRequestErrorsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListWorkRequestErrorsResponse")
+	}
+	return
+}
+
+// listWorkRequestErrors implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listWorkRequestErrors(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests/{workRequestId}/workRequestErrors")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListWorkRequestErrorsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListWorkRequestLogs Return a (paginated) list of logs for a given work request.
+func (client DataIntegrationClient) ListWorkRequestLogs(ctx context.Context, request ListWorkRequestLogsRequest) (response ListWorkRequestLogsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listWorkRequestLogs, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListWorkRequestLogsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListWorkRequestLogsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListWorkRequestLogsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListWorkRequestLogsResponse")
+	}
+	return
+}
+
+// listWorkRequestLogs implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listWorkRequestLogs(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests/{workRequestId}/logs")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListWorkRequestLogsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListWorkRequests Lists the work requests in a compartment.
+func (client DataIntegrationClient) ListWorkRequests(ctx context.Context, request ListWorkRequestsRequest) (response ListWorkRequestsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listWorkRequests, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListWorkRequestsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListWorkRequestsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListWorkRequestsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListWorkRequestsResponse")
+	}
+	return
+}
+
+// listWorkRequests implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listWorkRequests(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListWorkRequestsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListWorkspaces Returns a list of Data Integration Workspaces.
+func (client DataIntegrationClient) ListWorkspaces(ctx context.Context, request ListWorkspacesRequest) (response ListWorkspacesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listWorkspaces, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListWorkspacesResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListWorkspacesResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListWorkspacesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListWorkspacesResponse")
+	}
+	return
+}
+
+// listWorkspaces implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) listWorkspaces(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workspaces")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListWorkspacesResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// StartWorkspace The workspace will be started.
+func (client DataIntegrationClient) StartWorkspace(ctx context.Context, request StartWorkspaceRequest) (response StartWorkspaceResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.startWorkspace, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = StartWorkspaceResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = StartWorkspaceResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(StartWorkspaceResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into StartWorkspaceResponse")
+	}
+	return
+}
+
+// startWorkspace implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) startWorkspace(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/workspaces/{workspaceId}/actions/start")
+	if err != nil {
+		return nil, err
+	}
+
+	var response StartWorkspaceResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// StopWorkspace The workspace will be stopped.
+func (client DataIntegrationClient) StopWorkspace(ctx context.Context, request StopWorkspaceRequest) (response StopWorkspaceResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.stopWorkspace, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = StopWorkspaceResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = StopWorkspaceResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(StopWorkspaceResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into StopWorkspaceResponse")
+	}
+	return
+}
+
+// stopWorkspace implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) stopWorkspace(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/workspaces/{workspaceId}/actions/stop")
+	if err != nil {
+		return nil, err
+	}
+
+	var response StopWorkspaceResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateApplication Updates an application.
+func (client DataIntegrationClient) UpdateApplication(ctx context.Context, request UpdateApplicationRequest) (response UpdateApplicationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateApplication, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateApplicationResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateApplicationResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateApplicationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateApplicationResponse")
+	}
+	return
+}
+
+// updateApplication implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) updateApplication(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/workspaces/{workspaceId}/applications/{applicationKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateApplicationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateConnection Updates a connection under a data asset.
+func (client DataIntegrationClient) UpdateConnection(ctx context.Context, request UpdateConnectionRequest) (response UpdateConnectionResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateConnection, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateConnectionResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateConnectionResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateConnectionResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateConnectionResponse")
+	}
+	return
+}
+
+// updateConnection implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) updateConnection(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/workspaces/{workspaceId}/connections/{connectionKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateConnectionResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponseWithPolymorphicBody(httpResponse, &response, &connection{})
+	return response, err
+}
+
+// UpdateDataAsset Updates a specific data asset with default connection.
+func (client DataIntegrationClient) UpdateDataAsset(ctx context.Context, request UpdateDataAssetRequest) (response UpdateDataAssetResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateDataAsset, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateDataAssetResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateDataAssetResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateDataAssetResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateDataAssetResponse")
+	}
+	return
+}
+
+// updateDataAsset implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) updateDataAsset(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/workspaces/{workspaceId}/dataAssets/{dataAssetKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateDataAssetResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponseWithPolymorphicBody(httpResponse, &response, &dataasset{})
+	return response, err
+}
+
+// UpdateDataFlow Updates a specific data flow.
+func (client DataIntegrationClient) UpdateDataFlow(ctx context.Context, request UpdateDataFlowRequest) (response UpdateDataFlowResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateDataFlow, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateDataFlowResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateDataFlowResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateDataFlowResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateDataFlowResponse")
+	}
+	return
+}
+
+// updateDataFlow implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) updateDataFlow(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/workspaces/{workspaceId}/dataFlows/{dataFlowKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateDataFlowResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateFolder Updates a specific folder.
+func (client DataIntegrationClient) UpdateFolder(ctx context.Context, request UpdateFolderRequest) (response UpdateFolderResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateFolder, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateFolderResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateFolderResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateFolderResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateFolderResponse")
+	}
+	return
+}
+
+// updateFolder implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) updateFolder(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/workspaces/{workspaceId}/folders/{folderKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateFolderResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateProject Updates a specific project.
+func (client DataIntegrationClient) UpdateProject(ctx context.Context, request UpdateProjectRequest) (response UpdateProjectResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateProject, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateProjectResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateProjectResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateProjectResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateProjectResponse")
+	}
+	return
+}
+
+// updateProject implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) updateProject(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/workspaces/{workspaceId}/projects/{projectKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateProjectResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateTask Updates a specific task. For example, you can update the task description or move the task to a different folder by changing the `aggregatorKey` to a different folder in the registry.
+func (client DataIntegrationClient) UpdateTask(ctx context.Context, request UpdateTaskRequest) (response UpdateTaskResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateTask, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateTaskResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateTaskResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateTaskResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateTaskResponse")
+	}
+	return
+}
+
+// updateTask implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) updateTask(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/workspaces/{workspaceId}/tasks/{taskKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateTaskResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponseWithPolymorphicBody(httpResponse, &response, &task{})
+	return response, err
+}
+
+// UpdateTaskRun Updates the status of the task run. For example, aborts a task run.
+func (client DataIntegrationClient) UpdateTaskRun(ctx context.Context, request UpdateTaskRunRequest) (response UpdateTaskRunResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateTaskRun, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateTaskRunResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateTaskRunResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateTaskRunResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateTaskRunResponse")
+	}
+	return
+}
+
+// updateTaskRun implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) updateTaskRun(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/workspaces/{workspaceId}/applications/{applicationKey}/taskRuns/{taskRunKey}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateTaskRunResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateWorkspace Updates the Data Integration Workspace
+func (client DataIntegrationClient) UpdateWorkspace(ctx context.Context, request UpdateWorkspaceRequest) (response UpdateWorkspaceResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateWorkspace, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateWorkspaceResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateWorkspaceResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateWorkspaceResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateWorkspaceResponse")
+	}
+	return
+}
+
+// updateWorkspace implements the OCIOperation interface (enables retrying operations)
+func (client DataIntegrationClient) updateWorkspace(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/workspaces/{workspaceId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateWorkspaceResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}

--- a/dataintegration/delete_application_request_response.go
+++ b/dataintegration/delete_application_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteApplicationRequest wrapper for the DeleteApplication operation
+type DeleteApplicationRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS application key
+	ApplicationKey *string `mandatory:"true" contributesTo:"path" name:"applicationKey"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteApplicationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteApplicationRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteApplicationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteApplicationResponse wrapper for the DeleteApplication operation
+type DeleteApplicationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteApplicationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteApplicationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/delete_connection_request_response.go
+++ b/dataintegration/delete_connection_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteConnectionRequest wrapper for the DeleteConnection operation
+type DeleteConnectionRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// The connection key
+	ConnectionKey *string `mandatory:"true" contributesTo:"path" name:"connectionKey"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteConnectionRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteConnectionRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteConnectionRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteConnectionResponse wrapper for the DeleteConnection operation
+type DeleteConnectionResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteConnectionResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteConnectionResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/delete_connection_validation_request_response.go
+++ b/dataintegration/delete_connection_validation_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteConnectionValidationRequest wrapper for the DeleteConnectionValidation operation
+type DeleteConnectionValidationRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// key of the connection validation.
+	ConnectionValidationKey *string `mandatory:"true" contributesTo:"path" name:"connectionValidationKey"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteConnectionValidationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteConnectionValidationRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteConnectionValidationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteConnectionValidationResponse wrapper for the DeleteConnectionValidation operation
+type DeleteConnectionValidationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteConnectionValidationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteConnectionValidationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/delete_data_asset_request_response.go
+++ b/dataintegration/delete_data_asset_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteDataAssetRequest wrapper for the DeleteDataAsset operation
+type DeleteDataAssetRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// Data asset key.
+	DataAssetKey *string `mandatory:"true" contributesTo:"path" name:"dataAssetKey"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteDataAssetRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteDataAssetRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteDataAssetRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteDataAssetResponse wrapper for the DeleteDataAsset operation
+type DeleteDataAssetResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteDataAssetResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteDataAssetResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/delete_data_flow_request_response.go
+++ b/dataintegration/delete_data_flow_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteDataFlowRequest wrapper for the DeleteDataFlow operation
+type DeleteDataFlowRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS DataFlow key
+	DataFlowKey *string `mandatory:"true" contributesTo:"path" name:"dataFlowKey"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteDataFlowRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteDataFlowRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteDataFlowRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteDataFlowResponse wrapper for the DeleteDataFlow operation
+type DeleteDataFlowResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteDataFlowResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteDataFlowResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/delete_data_flow_validation_request_response.go
+++ b/dataintegration/delete_data_flow_validation_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteDataFlowValidationRequest wrapper for the DeleteDataFlowValidation operation
+type DeleteDataFlowValidationRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// key of the dataflow validation.
+	DataFlowValidationKey *string `mandatory:"true" contributesTo:"path" name:"dataFlowValidationKey"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteDataFlowValidationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteDataFlowValidationRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteDataFlowValidationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteDataFlowValidationResponse wrapper for the DeleteDataFlowValidation operation
+type DeleteDataFlowValidationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteDataFlowValidationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteDataFlowValidationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/delete_folder_request_response.go
+++ b/dataintegration/delete_folder_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteFolderRequest wrapper for the DeleteFolder operation
+type DeleteFolderRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS Folder key
+	FolderKey *string `mandatory:"true" contributesTo:"path" name:"folderKey"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteFolderRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteFolderRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteFolderRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteFolderResponse wrapper for the DeleteFolder operation
+type DeleteFolderResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteFolderResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteFolderResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/delete_patch_request_response.go
+++ b/dataintegration/delete_patch_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeletePatchRequest wrapper for the DeletePatch operation
+type DeletePatchRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS application key
+	ApplicationKey *string `mandatory:"true" contributesTo:"path" name:"applicationKey"`
+
+	// DIS patch key
+	PatchKey *string `mandatory:"true" contributesTo:"path" name:"patchKey"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeletePatchRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeletePatchRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeletePatchRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeletePatchResponse wrapper for the DeletePatch operation
+type DeletePatchResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeletePatchResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeletePatchResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/delete_project_request_response.go
+++ b/dataintegration/delete_project_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteProjectRequest wrapper for the DeleteProject operation
+type DeleteProjectRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS Project key
+	ProjectKey *string `mandatory:"true" contributesTo:"path" name:"projectKey"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteProjectRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteProjectRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteProjectRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteProjectResponse wrapper for the DeleteProject operation
+type DeleteProjectResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteProjectResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteProjectResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/delete_task_request_response.go
+++ b/dataintegration/delete_task_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteTaskRequest wrapper for the DeleteTask operation
+type DeleteTaskRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS Task key
+	TaskKey *string `mandatory:"true" contributesTo:"path" name:"taskKey"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteTaskRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteTaskRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteTaskRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteTaskResponse wrapper for the DeleteTask operation
+type DeleteTaskResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteTaskResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteTaskResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/delete_task_run_request_response.go
+++ b/dataintegration/delete_task_run_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteTaskRunRequest wrapper for the DeleteTaskRun operation
+type DeleteTaskRunRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS application key
+	ApplicationKey *string `mandatory:"true" contributesTo:"path" name:"applicationKey"`
+
+	// DIS taskRun key
+	TaskRunKey *string `mandatory:"true" contributesTo:"path" name:"taskRunKey"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteTaskRunRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteTaskRunRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteTaskRunRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteTaskRunResponse wrapper for the DeleteTaskRun operation
+type DeleteTaskRunResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteTaskRunResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteTaskRunResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/delete_task_validation_request_response.go
+++ b/dataintegration/delete_task_validation_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteTaskValidationRequest wrapper for the DeleteTaskValidation operation
+type DeleteTaskValidationRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// key of the task validation.
+	TaskValidationKey *string `mandatory:"true" contributesTo:"path" name:"taskValidationKey"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteTaskValidationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteTaskValidationRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteTaskValidationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteTaskValidationResponse wrapper for the DeleteTaskValidation operation
+type DeleteTaskValidationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteTaskValidationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteTaskValidationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/delete_workspace_request_response.go
+++ b/dataintegration/delete_workspace_request_response.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteWorkspaceRequest wrapper for the DeleteWorkspace operation
+type DeleteWorkspaceRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// This parameter allows users to set the timeout for DIS to gracefully close down any running jobs before stopping the workspace.
+	QuiesceTimeout *int64 `mandatory:"false" contributesTo:"query" name:"quiesceTimeout"`
+
+	// This parameter allows users to force close down the workspace.
+	IsForceOperation *bool `mandatory:"false" contributesTo:"query" name:"isForceOperation"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteWorkspaceRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteWorkspaceRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteWorkspaceRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteWorkspaceResponse wrapper for the DeleteWorkspace operation
+type DeleteWorkspaceResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the work request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+	// with this ID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+}
+
+func (response DeleteWorkspaceResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteWorkspaceResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/dependent_object.go
+++ b/dataintegration/dependent_object.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DependentObject A DependentObject object.
+type DependentObject struct {
+
+	// Generated key that can be used in API calls to identify application.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// version
+	ApplicationVersion *int `mandatory:"false" json:"applicationVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// List of dependent objects in this patch.
+	DependentObjectMetadata []PatchObjectMetadata `mandatory:"false" json:"dependentObjectMetadata"`
+
+	// List of objects that are published / unpublished in this patch.
+	PublishedObjectMetadata map[string]PatchObjectMetadata `mandatory:"false" json:"publishedObjectMetadata"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+}
+
+func (m DependentObject) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/dependent_object_summary.go
+++ b/dataintegration/dependent_object_summary.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DependentObjectSummary Details of the dependent object.
+type DependentObjectSummary struct {
+
+	// The user that created the object.
+	CreatedBy *string `mandatory:"false" json:"createdBy"`
+
+	// The user that created the object.
+	CreatedByName *string `mandatory:"false" json:"createdByName"`
+
+	// The user that updated the object.
+	UpdatedBy *string `mandatory:"false" json:"updatedBy"`
+
+	// The user that updated the object.
+	UpdatedByName *string `mandatory:"false" json:"updatedByName"`
+
+	// The date and time that the object was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The date and time that the object was updated.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// The owning object key for this object.
+	AggregatorKey *string `mandatory:"false" json:"aggregatorKey"`
+
+	// The full path to identify this object.
+	IdentifierPath *string `mandatory:"false" json:"identifierPath"`
+
+	// infoFields
+	InfoFields map[string]string `mandatory:"false" json:"infoFields"`
+
+	// registryVersion
+	RegistryVersion *int `mandatory:"false" json:"registryVersion"`
+
+	// Labels are keywords or tags that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+	Labels []string `mandatory:"false" json:"labels"`
+}
+
+func (m DependentObjectSummary) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/dependent_object_summary_collection.go
+++ b/dataintegration/dependent_object_summary_collection.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DependentObjectSummaryCollection List of DependentObject summaries
+type DependentObjectSummaryCollection struct {
+
+	// The array of DependentObject summaries
+	Items []DependentObjectSummary `mandatory:"true" json:"items"`
+}
+
+func (m DependentObjectSummaryCollection) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/derived_field.go
+++ b/dataintegration/derived_field.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DerivedField The type representing the derived field concept. Derived fields have an expression to define how to derive the field.
+type DerivedField struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	Expr *Expression `mandatory:"false" json:"expr"`
+
+	// The type of the field.
+	Type *string `mandatory:"false" json:"type"`
+
+	// Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+	Labels []string `mandatory:"false" json:"labels"`
+}
+
+//GetKey returns Key
+func (m DerivedField) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m DerivedField) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m DerivedField) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetConfigValues returns ConfigValues
+func (m DerivedField) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m DerivedField) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetName returns Name
+func (m DerivedField) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m DerivedField) GetDescription() *string {
+	return m.Description
+}
+
+func (m DerivedField) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DerivedField) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDerivedField DerivedField
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDerivedField
+	}{
+		"DERIVED_FIELD",
+		(MarshalTypeDerivedField)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/derived_type.go
+++ b/dataintegration/derived_type.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DerivedType A DerivedType object represents a more complex type that is derived from a set of simple types, for example an Address or SSN data type;
+type DerivedType struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+}
+
+//GetKey returns Key
+func (m DerivedType) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m DerivedType) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m DerivedType) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m DerivedType) GetName() *string {
+	return m.Name
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m DerivedType) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetDescription returns Description
+func (m DerivedType) GetDescription() *string {
+	return m.Description
+}
+
+func (m DerivedType) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DerivedType) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDerivedType DerivedType
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDerivedType
+	}{
+		"DERIVED_TYPE",
+		(MarshalTypeDerivedType)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/direct_field_map.go
+++ b/dataintegration/direct_field_map.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DirectFieldMap The information about a field map.
+type DirectFieldMap struct {
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// Reference to a typed object
+	SourceTypedObject *string `mandatory:"false" json:"sourceTypedObject"`
+
+	// Reference to a typed object
+	TargetTypedObject *string `mandatory:"false" json:"targetTypedObject"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+}
+
+//GetDescription returns Description
+func (m DirectFieldMap) GetDescription() *string {
+	return m.Description
+}
+
+func (m DirectFieldMap) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DirectFieldMap) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDirectFieldMap DirectFieldMap
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDirectFieldMap
+	}{
+		"DIRECT_FIELD_MAP",
+		(MarshalTypeDirectFieldMap)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/direct_named_field_map.go
+++ b/dataintegration/direct_named_field_map.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DirectNamedFieldMap A named field map.
+type DirectNamedFieldMap struct {
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// Reference to a typed object.
+	SourceTypedObject *string `mandatory:"false" json:"sourceTypedObject"`
+
+	// Reference to a typed object
+	TargetTypedObject *string `mandatory:"false" json:"targetTypedObject"`
+
+	// The source field name.
+	SourceFieldName *string `mandatory:"false" json:"sourceFieldName"`
+
+	// The target field name.
+	TargetFieldName *string `mandatory:"false" json:"targetFieldName"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+}
+
+//GetDescription returns Description
+func (m DirectNamedFieldMap) GetDescription() *string {
+	return m.Description
+}
+
+func (m DirectNamedFieldMap) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DirectNamedFieldMap) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDirectNamedFieldMap DirectNamedFieldMap
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDirectNamedFieldMap
+	}{
+		"DIRECT_NAMED_FIELD_MAP",
+		(MarshalTypeDirectNamedFieldMap)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/dynamic_input_field.go
+++ b/dataintegration/dynamic_input_field.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DynamicInputField The type representing the dynamic field concept. Dynamic fields have a dynamic type handler to define how to generate the field.
+type DynamicInputField struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	Type BaseType `mandatory:"false" json:"type"`
+
+	// Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+	Labels []string `mandatory:"false" json:"labels"`
+}
+
+//GetKey returns Key
+func (m DynamicInputField) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m DynamicInputField) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m DynamicInputField) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetConfigValues returns ConfigValues
+func (m DynamicInputField) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m DynamicInputField) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetName returns Name
+func (m DynamicInputField) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m DynamicInputField) GetDescription() *string {
+	return m.Description
+}
+
+func (m DynamicInputField) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DynamicInputField) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDynamicInputField DynamicInputField
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDynamicInputField
+	}{
+		"DYNAMIC_INPUT_FIELD",
+		(MarshalTypeDynamicInputField)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *DynamicInputField) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key          *string          `json:"key"`
+		ModelVersion *string          `json:"modelVersion"`
+		ParentRef    *ParentReference `json:"parentRef"`
+		ConfigValues *ConfigValues    `json:"configValues"`
+		ObjectStatus *int             `json:"objectStatus"`
+		Name         *string          `json:"name"`
+		Description  *string          `json:"description"`
+		Type         basetype         `json:"type"`
+		Labels       []string         `json:"labels"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.ConfigValues = model.ConfigValues
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.Name = model.Name
+
+	m.Description = model.Description
+
+	nn, e = model.Type.UnmarshalPolymorphicJSON(model.Type.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.Type = nn.(BaseType)
+	} else {
+		m.Type = nil
+	}
+
+	m.Labels = make([]string, len(model.Labels))
+	for i, n := range model.Labels {
+		m.Labels[i] = n
+	}
+	return
+}

--- a/dataintegration/dynamic_proxy_field.go
+++ b/dataintegration/dynamic_proxy_field.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DynamicProxyField The type representing the dynamic proxy field concept. Dynamic proxy fields have a reference to another field.
+type DynamicProxyField struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	Type BaseType `mandatory:"false" json:"type"`
+
+	// Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+	Labels []string `mandatory:"false" json:"labels"`
+}
+
+//GetKey returns Key
+func (m DynamicProxyField) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m DynamicProxyField) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m DynamicProxyField) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetConfigValues returns ConfigValues
+func (m DynamicProxyField) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m DynamicProxyField) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetName returns Name
+func (m DynamicProxyField) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m DynamicProxyField) GetDescription() *string {
+	return m.Description
+}
+
+func (m DynamicProxyField) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DynamicProxyField) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDynamicProxyField DynamicProxyField
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDynamicProxyField
+	}{
+		"DYNAMIC_PROXY_FIELD",
+		(MarshalTypeDynamicProxyField)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *DynamicProxyField) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key          *string          `json:"key"`
+		ModelVersion *string          `json:"modelVersion"`
+		ParentRef    *ParentReference `json:"parentRef"`
+		ConfigValues *ConfigValues    `json:"configValues"`
+		ObjectStatus *int             `json:"objectStatus"`
+		Name         *string          `json:"name"`
+		Description  *string          `json:"description"`
+		Type         basetype         `json:"type"`
+		Labels       []string         `json:"labels"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.ConfigValues = model.ConfigValues
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.Name = model.Name
+
+	m.Description = model.Description
+
+	nn, e = model.Type.UnmarshalPolymorphicJSON(model.Type.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.Type = nn.(BaseType)
+	} else {
+		m.Type = nil
+	}
+
+	m.Labels = make([]string, len(model.Labels))
+	for i, n := range model.Labels {
+		m.Labels[i] = n
+	}
+	return
+}

--- a/dataintegration/dynamic_type.go
+++ b/dataintegration/dynamic_type.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DynamicType The dynamic type.
+type DynamicType struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	TypeHandler DynamicTypeHandler `mandatory:"false" json:"typeHandler"`
+
+	ConfigDefinition *ConfigDefinition `mandatory:"false" json:"configDefinition"`
+}
+
+//GetKey returns Key
+func (m DynamicType) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m DynamicType) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m DynamicType) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m DynamicType) GetName() *string {
+	return m.Name
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m DynamicType) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetDescription returns Description
+func (m DynamicType) GetDescription() *string {
+	return m.Description
+}
+
+func (m DynamicType) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m DynamicType) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDynamicType DynamicType
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeDynamicType
+	}{
+		"DYNAMIC_TYPE",
+		(MarshalTypeDynamicType)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *DynamicType) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key              *string            `json:"key"`
+		ModelVersion     *string            `json:"modelVersion"`
+		ParentRef        *ParentReference   `json:"parentRef"`
+		Name             *string            `json:"name"`
+		ObjectStatus     *int               `json:"objectStatus"`
+		Description      *string            `json:"description"`
+		TypeHandler      dynamictypehandler `json:"typeHandler"`
+		ConfigDefinition *ConfigDefinition  `json:"configDefinition"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.Name = model.Name
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.Description = model.Description
+
+	nn, e = model.TypeHandler.UnmarshalPolymorphicJSON(model.TypeHandler.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.TypeHandler = nn.(DynamicTypeHandler)
+	} else {
+		m.TypeHandler = nil
+	}
+
+	m.ConfigDefinition = model.ConfigDefinition
+	return
+}

--- a/dataintegration/dynamic_type_handler.go
+++ b/dataintegration/dynamic_type_handler.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// DynamicTypeHandler This type defines how to derived fields for the dynamic type itself.
+type DynamicTypeHandler interface {
+}
+
+type dynamictypehandler struct {
+	JsonData  []byte
+	ModelType string `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *dynamictypehandler) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerdynamictypehandler dynamictypehandler
+	s := struct {
+		Model Unmarshalerdynamictypehandler
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *dynamictypehandler) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "RULE_TYPE_CONFIGS":
+		mm := RuleTypeConfig{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m dynamictypehandler) String() string {
+	return common.PointerString(m)
+}
+
+// DynamicTypeHandlerModelTypeEnum Enum with underlying type: string
+type DynamicTypeHandlerModelTypeEnum string
+
+// Set of constants representing the allowable values for DynamicTypeHandlerModelTypeEnum
+const (
+	DynamicTypeHandlerModelTypeRuleTypeConfigs DynamicTypeHandlerModelTypeEnum = "RULE_TYPE_CONFIGS"
+)
+
+var mappingDynamicTypeHandlerModelType = map[string]DynamicTypeHandlerModelTypeEnum{
+	"RULE_TYPE_CONFIGS": DynamicTypeHandlerModelTypeRuleTypeConfigs,
+}
+
+// GetDynamicTypeHandlerModelTypeEnumValues Enumerates the set of values for DynamicTypeHandlerModelTypeEnum
+func GetDynamicTypeHandlerModelTypeEnumValues() []DynamicTypeHandlerModelTypeEnum {
+	values := make([]DynamicTypeHandlerModelTypeEnum, 0)
+	for _, v := range mappingDynamicTypeHandlerModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/entity_shape.go
+++ b/dataintegration/entity_shape.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// EntityShape The data entity shape object.
+type EntityShape interface {
+	GetMetadata() *ObjectMetadata
+}
+
+type entityshape struct {
+	JsonData  []byte
+	Metadata  *ObjectMetadata `mandatory:"false" json:"metadata"`
+	ModelType string          `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *entityshape) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerentityshape entityshape
+	s := struct {
+		Model Unmarshalerentityshape
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Metadata = s.Model.Metadata
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *entityshape) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "FILE_ENTITY":
+		mm := EntityShapeFromFile{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetMetadata returns Metadata
+func (m entityshape) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m entityshape) String() string {
+	return common.PointerString(m)
+}
+
+// EntityShapeModelTypeEnum Enum with underlying type: string
+type EntityShapeModelTypeEnum string
+
+// Set of constants representing the allowable values for EntityShapeModelTypeEnum
+const (
+	EntityShapeModelTypeFileEntity EntityShapeModelTypeEnum = "FILE_ENTITY"
+)
+
+var mappingEntityShapeModelType = map[string]EntityShapeModelTypeEnum{
+	"FILE_ENTITY": EntityShapeModelTypeFileEntity,
+}
+
+// GetEntityShapeModelTypeEnumValues Enumerates the set of values for EntityShapeModelTypeEnum
+func GetEntityShapeModelTypeEnumValues() []EntityShapeModelTypeEnum {
+	values := make([]EntityShapeModelTypeEnum, 0)
+	for _, v := range mappingEntityShapeModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/entity_shape_from_file.go
+++ b/dataintegration/entity_shape_from_file.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// EntityShapeFromFile The file data entity details.
+type EntityShapeFromFile struct {
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The external key for the object.
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	Shape *Shape `mandatory:"false" json:"shape"`
+
+	// The shape ID.
+	ShapeId *string `mandatory:"false" json:"shapeId"`
+
+	Types *TypeLibrary `mandatory:"false" json:"types"`
+
+	// Specifies other type label.
+	OtherTypeLabel *string `mandatory:"false" json:"otherTypeLabel"`
+
+	// An array of unique keys.
+	UniqueKeys []UniqueKey `mandatory:"false" json:"uniqueKeys"`
+
+	// An array of foreign keys.
+	ForeignKeys []ForeignKey `mandatory:"false" json:"foreignKeys"`
+
+	// The resource name.
+	ResourceName *string `mandatory:"false" json:"resourceName"`
+
+	DataFormat *DataFormat `mandatory:"false" json:"dataFormat"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The entity type.
+	EntityType EntityShapeFromFileEntityTypeEnum `mandatory:"false" json:"entityType,omitempty"`
+}
+
+//GetMetadata returns Metadata
+func (m EntityShapeFromFile) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m EntityShapeFromFile) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m EntityShapeFromFile) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeEntityShapeFromFile EntityShapeFromFile
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeEntityShapeFromFile
+	}{
+		"FILE_ENTITY",
+		(MarshalTypeEntityShapeFromFile)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// EntityShapeFromFileEntityTypeEnum Enum with underlying type: string
+type EntityShapeFromFileEntityTypeEnum string
+
+// Set of constants representing the allowable values for EntityShapeFromFileEntityTypeEnum
+const (
+	EntityShapeFromFileEntityTypeTable  EntityShapeFromFileEntityTypeEnum = "TABLE"
+	EntityShapeFromFileEntityTypeView   EntityShapeFromFileEntityTypeEnum = "VIEW"
+	EntityShapeFromFileEntityTypeFile   EntityShapeFromFileEntityTypeEnum = "FILE"
+	EntityShapeFromFileEntityTypeQueue  EntityShapeFromFileEntityTypeEnum = "QUEUE"
+	EntityShapeFromFileEntityTypeStream EntityShapeFromFileEntityTypeEnum = "STREAM"
+	EntityShapeFromFileEntityTypeOther  EntityShapeFromFileEntityTypeEnum = "OTHER"
+)
+
+var mappingEntityShapeFromFileEntityType = map[string]EntityShapeFromFileEntityTypeEnum{
+	"TABLE":  EntityShapeFromFileEntityTypeTable,
+	"VIEW":   EntityShapeFromFileEntityTypeView,
+	"FILE":   EntityShapeFromFileEntityTypeFile,
+	"QUEUE":  EntityShapeFromFileEntityTypeQueue,
+	"STREAM": EntityShapeFromFileEntityTypeStream,
+	"OTHER":  EntityShapeFromFileEntityTypeOther,
+}
+
+// GetEntityShapeFromFileEntityTypeEnumValues Enumerates the set of values for EntityShapeFromFileEntityTypeEnum
+func GetEntityShapeFromFileEntityTypeEnumValues() []EntityShapeFromFileEntityTypeEnum {
+	values := make([]EntityShapeFromFileEntityTypeEnum, 0)
+	for _, v := range mappingEntityShapeFromFileEntityType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/error_details.go
+++ b/dataintegration/error_details.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ErrorDetails The details of an error that occured.
+type ErrorDetails struct {
+
+	// A short error code that defines the error, meant for programmatic parsing. See
+	// API Errors (https://docs.cloud.oracle.com/Content/API/References/apierrors.htm).
+	Code *string `mandatory:"true" json:"code"`
+
+	// A user-friendly error message.
+	Message *string `mandatory:"true" json:"message"`
+}
+
+func (m ErrorDetails) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/expression.go
+++ b/dataintegration/expression.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Expression An expression node.
+type Expression struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// The expression string for the object.
+	ExprString *string `mandatory:"false" json:"exprString"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+}
+
+func (m Expression) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/field_map.go
+++ b/dataintegration/field_map.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// FieldMap A field map is a way to map a source row shape to a target row shape that may be different.
+type FieldMap interface {
+
+	// Detailed description for the object.
+	GetDescription() *string
+}
+
+type fieldmap struct {
+	JsonData    []byte
+	Description *string `mandatory:"false" json:"description"`
+	ModelType   string  `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *fieldmap) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerfieldmap fieldmap
+	s := struct {
+		Model Unmarshalerfieldmap
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Description = s.Model.Description
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *fieldmap) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "RULE_BASED_FIELD_MAP":
+		mm := RuleBasedFieldMap{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "DIRECT_FIELD_MAP":
+		mm := DirectFieldMap{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "COMPOSITE_FIELD_MAP":
+		mm := CompositeFieldMap{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "DIRECT_NAMED_FIELD_MAP":
+		mm := DirectNamedFieldMap{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetDescription returns Description
+func (m fieldmap) GetDescription() *string {
+	return m.Description
+}
+
+func (m fieldmap) String() string {
+	return common.PointerString(m)
+}
+
+// FieldMapModelTypeEnum Enum with underlying type: string
+type FieldMapModelTypeEnum string
+
+// Set of constants representing the allowable values for FieldMapModelTypeEnum
+const (
+	FieldMapModelTypeDirectNamedFieldMap FieldMapModelTypeEnum = "DIRECT_NAMED_FIELD_MAP"
+	FieldMapModelTypeCompositeFieldMap   FieldMapModelTypeEnum = "COMPOSITE_FIELD_MAP"
+	FieldMapModelTypeDirectFieldMap      FieldMapModelTypeEnum = "DIRECT_FIELD_MAP"
+	FieldMapModelTypeRuleBasedFieldMap   FieldMapModelTypeEnum = "RULE_BASED_FIELD_MAP"
+)
+
+var mappingFieldMapModelType = map[string]FieldMapModelTypeEnum{
+	"DIRECT_NAMED_FIELD_MAP": FieldMapModelTypeDirectNamedFieldMap,
+	"COMPOSITE_FIELD_MAP":    FieldMapModelTypeCompositeFieldMap,
+	"DIRECT_FIELD_MAP":       FieldMapModelTypeDirectFieldMap,
+	"RULE_BASED_FIELD_MAP":   FieldMapModelTypeRuleBasedFieldMap,
+}
+
+// GetFieldMapModelTypeEnumValues Enumerates the set of values for FieldMapModelTypeEnum
+func GetFieldMapModelTypeEnumValues() []FieldMapModelTypeEnum {
+	values := make([]FieldMapModelTypeEnum, 0)
+	for _, v := range mappingFieldMapModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/filter.go
+++ b/dataintegration/filter.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Filter The information about the filter object.
+type Filter struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+
+	FilterCondition *Expression `mandatory:"false" json:"filterCondition"`
+}
+
+//GetKey returns Key
+func (m Filter) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m Filter) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m Filter) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m Filter) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m Filter) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m Filter) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetInputPorts returns InputPorts
+func (m Filter) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m Filter) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m Filter) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m Filter) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetParameters returns Parameters
+func (m Filter) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m Filter) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+func (m Filter) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m Filter) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeFilter Filter
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeFilter
+	}{
+		"FILTER_OPERATOR",
+		(MarshalTypeFilter)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/filter_push.go
+++ b/dataintegration/filter_push.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// FilterPush The information about a filter operator. The filter operator lets you select certain attributes from the inbound port to continue downstream to the outbound port.
+type FilterPush struct {
+
+	// The filter condition.
+	FilterCondition *string `mandatory:"false" json:"filterCondition"`
+}
+
+func (m FilterPush) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m FilterPush) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeFilterPush FilterPush
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeFilterPush
+	}{
+		"FILTER",
+		(MarshalTypeFilterPush)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/flow_node.go
+++ b/dataintegration/flow_node.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// FlowNode The flow node can be connected to other nodes in a data flow with input and output links and is bound to an opertor which defines the semantics of the node.
+type FlowNode struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// inputLinks
+	InputLinks []InputLink `mandatory:"false" json:"inputLinks"`
+
+	// outputLinks
+	OutputLinks []OutputLink `mandatory:"false" json:"outputLinks"`
+
+	Operator Operator `mandatory:"false" json:"operator"`
+
+	UiProperties *UiProperties `mandatory:"false" json:"uiProperties"`
+
+	ConfigProviderDelegate *ConfigProvider `mandatory:"false" json:"configProviderDelegate"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+}
+
+func (m FlowNode) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *FlowNode) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key                    *string          `json:"key"`
+		ModelType              *string          `json:"modelType"`
+		ModelVersion           *string          `json:"modelVersion"`
+		ParentRef              *ParentReference `json:"parentRef"`
+		Name                   *string          `json:"name"`
+		Description            *string          `json:"description"`
+		InputLinks             []InputLink      `json:"inputLinks"`
+		OutputLinks            []OutputLink     `json:"outputLinks"`
+		Operator               operator         `json:"operator"`
+		UiProperties           *UiProperties    `json:"uiProperties"`
+		ConfigProviderDelegate *ConfigProvider  `json:"configProviderDelegate"`
+		ObjectStatus           *int             `json:"objectStatus"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelType = model.ModelType
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.Name = model.Name
+
+	m.Description = model.Description
+
+	m.InputLinks = make([]InputLink, len(model.InputLinks))
+	for i, n := range model.InputLinks {
+		m.InputLinks[i] = n
+	}
+
+	m.OutputLinks = make([]OutputLink, len(model.OutputLinks))
+	for i, n := range model.OutputLinks {
+		m.OutputLinks[i] = n
+	}
+
+	nn, e = model.Operator.UnmarshalPolymorphicJSON(model.Operator.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.Operator = nn.(Operator)
+	} else {
+		m.Operator = nil
+	}
+
+	m.UiProperties = model.UiProperties
+
+	m.ConfigProviderDelegate = model.ConfigProviderDelegate
+
+	m.ObjectStatus = model.ObjectStatus
+	return
+}

--- a/dataintegration/flow_port.go
+++ b/dataintegration/flow_port.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// FlowPort Each operator owns a set of InputPort and OutputPort objects (can scale to zero), which represent the ports that can be connected to/from the Operator.
+type FlowPort struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+}
+
+//GetKey returns Key
+func (m FlowPort) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m FlowPort) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m FlowPort) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetConfigValues returns ConfigValues
+func (m FlowPort) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m FlowPort) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetName returns Name
+func (m FlowPort) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m FlowPort) GetDescription() *string {
+	return m.Description
+}
+
+func (m FlowPort) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m FlowPort) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeFlowPort FlowPort
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeFlowPort
+	}{
+		"FLOW_PORT",
+		(MarshalTypeFlowPort)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/flow_port_link.go
+++ b/dataintegration/flow_port_link.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// FlowPortLink The details of the flow port links.
+type FlowPortLink interface {
+
+	// The key of the object.
+	GetKey() *string
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	GetParentRef() *ParentReference
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// Detailed description for the object.
+	GetDescription() *string
+
+	// Key of FlowPort reference
+	GetPort() *string
+}
+
+type flowportlink struct {
+	JsonData     []byte
+	Key          *string          `mandatory:"false" json:"key"`
+	ModelVersion *string          `mandatory:"false" json:"modelVersion"`
+	ParentRef    *ParentReference `mandatory:"false" json:"parentRef"`
+	ObjectStatus *int             `mandatory:"false" json:"objectStatus"`
+	Description  *string          `mandatory:"false" json:"description"`
+	Port         *string          `mandatory:"false" json:"port"`
+	ModelType    string           `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *flowportlink) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerflowportlink flowportlink
+	s := struct {
+		Model Unmarshalerflowportlink
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Key = s.Model.Key
+	m.ModelVersion = s.Model.ModelVersion
+	m.ParentRef = s.Model.ParentRef
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.Description = s.Model.Description
+	m.Port = s.Model.Port
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *flowportlink) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "INPUT_LINK":
+		mm := InputLink{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "OUTPUT_LINK":
+		mm := OutputLink{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "CONDITIONAL_INPUT_LINK":
+		mm := ConditionalInputLink{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetKey returns Key
+func (m flowportlink) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m flowportlink) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m flowportlink) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m flowportlink) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetDescription returns Description
+func (m flowportlink) GetDescription() *string {
+	return m.Description
+}
+
+//GetPort returns Port
+func (m flowportlink) GetPort() *string {
+	return m.Port
+}
+
+func (m flowportlink) String() string {
+	return common.PointerString(m)
+}
+
+// FlowPortLinkModelTypeEnum Enum with underlying type: string
+type FlowPortLinkModelTypeEnum string
+
+// Set of constants representing the allowable values for FlowPortLinkModelTypeEnum
+const (
+	FlowPortLinkModelTypeConditionalInputLink FlowPortLinkModelTypeEnum = "CONDITIONAL_INPUT_LINK"
+	FlowPortLinkModelTypeOutputLink           FlowPortLinkModelTypeEnum = "OUTPUT_LINK"
+	FlowPortLinkModelTypeInputLink            FlowPortLinkModelTypeEnum = "INPUT_LINK"
+)
+
+var mappingFlowPortLinkModelType = map[string]FlowPortLinkModelTypeEnum{
+	"CONDITIONAL_INPUT_LINK": FlowPortLinkModelTypeConditionalInputLink,
+	"OUTPUT_LINK":            FlowPortLinkModelTypeOutputLink,
+	"INPUT_LINK":             FlowPortLinkModelTypeInputLink,
+}
+
+// GetFlowPortLinkModelTypeEnumValues Enumerates the set of values for FlowPortLinkModelTypeEnum
+func GetFlowPortLinkModelTypeEnumValues() []FlowPortLinkModelTypeEnum {
+	values := make([]FlowPortLinkModelTypeEnum, 0)
+	for _, v := range mappingFlowPortLinkModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/folder.go
+++ b/dataintegration/folder.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Folder The folder type contains the audit summary information and the definition of the folder.
+type Folder struct {
+
+	// Generated key that can be used in API calls to identify folder.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// categoryName
+	CategoryName *string `mandatory:"false" json:"categoryName"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+}
+
+func (m Folder) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/folder_details.go
+++ b/dataintegration/folder_details.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// FolderDetails The details including name, description for the folder, which is a container of other folders, tasks and dataflows.
+type FolderDetails struct {
+
+	// Generated key that can be used in API calls to identify folder.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"true" json:"modelType"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"true" json:"objectVersion"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// categoryName
+	CategoryName *string `mandatory:"false" json:"categoryName"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+}
+
+func (m FolderDetails) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/folder_summary.go
+++ b/dataintegration/folder_summary.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// FolderSummary The folder summary type contains the audit summary information and the definition of the folder.
+type FolderSummary struct {
+
+	// Generated key that can be used in API calls to identify folder.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// categoryName
+	CategoryName *string `mandatory:"false" json:"categoryName"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+}
+
+func (m FolderSummary) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/folder_summary_collection.go
+++ b/dataintegration/folder_summary_collection.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// FolderSummaryCollection A collection of folder summaries. The collection can be lightweight details or full definitions.
+type FolderSummaryCollection struct {
+
+	// The array of Folder summaries
+	Items []FolderSummary `mandatory:"true" json:"items"`
+}
+
+func (m FolderSummaryCollection) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/foreign_key.go
+++ b/dataintegration/foreign_key.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ForeignKey The foreign key object.
+type ForeignKey struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// attributeRefs
+	AttributeRefs []KeyAttribute `mandatory:"false" json:"attributeRefs"`
+
+	// updateRule
+	UpdateRule *int `mandatory:"false" json:"updateRule"`
+
+	// deleteRule
+	DeleteRule *int `mandatory:"false" json:"deleteRule"`
+
+	ReferenceUniqueKey *UniqueKey `mandatory:"false" json:"referenceUniqueKey"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+}
+
+func (m ForeignKey) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ForeignKey) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeForeignKey ForeignKey
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeForeignKey
+	}{
+		"FOREIGN_KEY",
+		(MarshalTypeForeignKey)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/get_application_request_response.go
+++ b/dataintegration/get_application_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetApplicationRequest wrapper for the GetApplication operation
+type GetApplicationRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS application key
+	ApplicationKey *string `mandatory:"true" contributesTo:"path" name:"applicationKey"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetApplicationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetApplicationRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetApplicationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetApplicationResponse wrapper for the GetApplication operation
+type GetApplicationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Application instance
+	Application `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetApplicationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetApplicationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/get_connection_request_response.go
+++ b/dataintegration/get_connection_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetConnectionRequest wrapper for the GetConnection operation
+type GetConnectionRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// The connection key
+	ConnectionKey *string `mandatory:"true" contributesTo:"path" name:"connectionKey"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetConnectionRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetConnectionRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetConnectionRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetConnectionResponse wrapper for the GetConnection operation
+type GetConnectionResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Connection instance
+	Connection `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetConnectionResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetConnectionResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/get_connection_validation_request_response.go
+++ b/dataintegration/get_connection_validation_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetConnectionValidationRequest wrapper for the GetConnectionValidation operation
+type GetConnectionValidationRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// key of the connection validation.
+	ConnectionValidationKey *string `mandatory:"true" contributesTo:"path" name:"connectionValidationKey"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetConnectionValidationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetConnectionValidationRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetConnectionValidationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetConnectionValidationResponse wrapper for the GetConnectionValidation operation
+type GetConnectionValidationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ConnectionValidation instance
+	ConnectionValidation `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetConnectionValidationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetConnectionValidationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/get_count_statistic_request_response.go
+++ b/dataintegration/get_count_statistic_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetCountStatisticRequest wrapper for the GetCountStatistic operation
+type GetCountStatisticRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// A unique key of the container object, such as workspace, project, and so on, to count statistics for. The statistics is fetched for the given key.
+	CountStatisticKey *string `mandatory:"true" contributesTo:"path" name:"countStatisticKey"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetCountStatisticRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetCountStatisticRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetCountStatisticRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetCountStatisticResponse wrapper for the GetCountStatistic operation
+type GetCountStatisticResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The CountStatistic instance
+	CountStatistic `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response GetCountStatisticResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetCountStatisticResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/get_data_asset_request_response.go
+++ b/dataintegration/get_data_asset_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetDataAssetRequest wrapper for the GetDataAsset operation
+type GetDataAssetRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// Data asset key.
+	DataAssetKey *string `mandatory:"true" contributesTo:"path" name:"dataAssetKey"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetDataAssetRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetDataAssetRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetDataAssetRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetDataAssetResponse wrapper for the GetDataAsset operation
+type GetDataAssetResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The DataAsset instance
+	DataAsset `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetDataAssetResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetDataAssetResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/get_data_entity_request_response.go
+++ b/dataintegration/get_data_entity_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetDataEntityRequest wrapper for the GetDataEntity operation
+type GetDataEntityRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// The connection key
+	ConnectionKey *string `mandatory:"true" contributesTo:"path" name:"connectionKey"`
+
+	// Schema resource name used for retrieving schemas
+	SchemaResourceName *string `mandatory:"true" contributesTo:"path" name:"schemaResourceName"`
+
+	// Name of the data entity
+	DataEntityKey *string `mandatory:"true" contributesTo:"path" name:"dataEntityKey"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetDataEntityRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetDataEntityRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetDataEntityRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetDataEntityResponse wrapper for the GetDataEntity operation
+type GetDataEntityResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The DataEntity instance
+	DataEntity `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetDataEntityResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetDataEntityResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/get_data_flow_request_response.go
+++ b/dataintegration/get_data_flow_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetDataFlowRequest wrapper for the GetDataFlow operation
+type GetDataFlowRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS DataFlow key
+	DataFlowKey *string `mandatory:"true" contributesTo:"path" name:"dataFlowKey"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetDataFlowRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetDataFlowRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetDataFlowRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetDataFlowResponse wrapper for the GetDataFlow operation
+type GetDataFlowResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The DataFlow instance
+	DataFlow `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetDataFlowResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetDataFlowResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/get_data_flow_validation_request_response.go
+++ b/dataintegration/get_data_flow_validation_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetDataFlowValidationRequest wrapper for the GetDataFlowValidation operation
+type GetDataFlowValidationRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// key of the dataflow validation.
+	DataFlowValidationKey *string `mandatory:"true" contributesTo:"path" name:"dataFlowValidationKey"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetDataFlowValidationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetDataFlowValidationRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetDataFlowValidationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetDataFlowValidationResponse wrapper for the GetDataFlowValidation operation
+type GetDataFlowValidationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The DataFlowValidation instance
+	DataFlowValidation `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetDataFlowValidationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetDataFlowValidationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/get_dependent_object_request_response.go
+++ b/dataintegration/get_dependent_object_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetDependentObjectRequest wrapper for the GetDependentObject operation
+type GetDependentObjectRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS application key
+	ApplicationKey *string `mandatory:"true" contributesTo:"path" name:"applicationKey"`
+
+	// DIS dependent object key
+	DependentObjectKey *string `mandatory:"true" contributesTo:"path" name:"dependentObjectKey"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetDependentObjectRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetDependentObjectRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetDependentObjectRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetDependentObjectResponse wrapper for the GetDependentObject operation
+type GetDependentObjectResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The DependentObject instance
+	DependentObject `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetDependentObjectResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetDependentObjectResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/get_folder_request_response.go
+++ b/dataintegration/get_folder_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetFolderRequest wrapper for the GetFolder operation
+type GetFolderRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS Folder key
+	FolderKey *string `mandatory:"true" contributesTo:"path" name:"folderKey"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetFolderRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetFolderRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetFolderRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetFolderResponse wrapper for the GetFolder operation
+type GetFolderResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Folder instance
+	Folder `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetFolderResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetFolderResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/get_patch_request_response.go
+++ b/dataintegration/get_patch_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetPatchRequest wrapper for the GetPatch operation
+type GetPatchRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS application key
+	ApplicationKey *string `mandatory:"true" contributesTo:"path" name:"applicationKey"`
+
+	// DIS patch key
+	PatchKey *string `mandatory:"true" contributesTo:"path" name:"patchKey"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetPatchRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetPatchRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetPatchRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetPatchResponse wrapper for the GetPatch operation
+type GetPatchResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Patch instance
+	Patch `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetPatchResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetPatchResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/get_project_request_response.go
+++ b/dataintegration/get_project_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetProjectRequest wrapper for the GetProject operation
+type GetProjectRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS Project key
+	ProjectKey *string `mandatory:"true" contributesTo:"path" name:"projectKey"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetProjectRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetProjectRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetProjectRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetProjectResponse wrapper for the GetProject operation
+type GetProjectResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Project instance
+	Project `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetProjectResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetProjectResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/get_published_object_request_response.go
+++ b/dataintegration/get_published_object_request_response.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetPublishedObjectRequest wrapper for the GetPublishedObject operation
+type GetPublishedObjectRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS application key
+	ApplicationKey *string `mandatory:"true" contributesTo:"path" name:"applicationKey"`
+
+	// DIS published object key
+	PublishedObjectKey *string `mandatory:"true" contributesTo:"path" name:"publishedObjectKey"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// This is used to expand references of the object. If value is true, then all referenced objects will be expanded. If value is false, then shallow objects will be returned in place of references. Default is false. <br><br><B>Examples:-</B><br> <ul> <li><B>?expandReferences=true</B> returns all objects of type data loader task</li> </ul>
+	ExpandReferences *string `mandatory:"false" contributesTo:"query" name:"expandReferences"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetPublishedObjectRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetPublishedObjectRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetPublishedObjectRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetPublishedObjectResponse wrapper for the GetPublishedObject operation
+type GetPublishedObjectResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The PublishedObject instance
+	PublishedObject `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetPublishedObjectResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetPublishedObjectResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/get_schema_request_response.go
+++ b/dataintegration/get_schema_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetSchemaRequest wrapper for the GetSchema operation
+type GetSchemaRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// The connection key
+	ConnectionKey *string `mandatory:"true" contributesTo:"path" name:"connectionKey"`
+
+	// Schema resource name used for retrieving schemas
+	SchemaResourceName *string `mandatory:"true" contributesTo:"path" name:"schemaResourceName"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetSchemaRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetSchemaRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetSchemaRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetSchemaResponse wrapper for the GetSchema operation
+type GetSchemaResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Schema instance
+	Schema `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetSchemaResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetSchemaResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/get_task_request_response.go
+++ b/dataintegration/get_task_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetTaskRequest wrapper for the GetTask operation
+type GetTaskRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS Task key
+	TaskKey *string `mandatory:"true" contributesTo:"path" name:"taskKey"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetTaskRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetTaskRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetTaskRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetTaskResponse wrapper for the GetTask operation
+type GetTaskResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Task instance
+	Task `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetTaskResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetTaskResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/get_task_run_request_response.go
+++ b/dataintegration/get_task_run_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetTaskRunRequest wrapper for the GetTaskRun operation
+type GetTaskRunRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS application key
+	ApplicationKey *string `mandatory:"true" contributesTo:"path" name:"applicationKey"`
+
+	// DIS taskRun key
+	TaskRunKey *string `mandatory:"true" contributesTo:"path" name:"taskRunKey"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetTaskRunRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetTaskRunRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetTaskRunRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetTaskRunResponse wrapper for the GetTaskRun operation
+type GetTaskRunResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The TaskRun instance
+	TaskRun `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetTaskRunResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetTaskRunResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/get_task_validation_request_response.go
+++ b/dataintegration/get_task_validation_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetTaskValidationRequest wrapper for the GetTaskValidation operation
+type GetTaskValidationRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// key of the task validation.
+	TaskValidationKey *string `mandatory:"true" contributesTo:"path" name:"taskValidationKey"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetTaskValidationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetTaskValidationRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetTaskValidationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetTaskValidationResponse wrapper for the GetTaskValidation operation
+type GetTaskValidationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The TaskValidation instance
+	TaskValidation `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetTaskValidationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetTaskValidationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/get_work_request_request_response.go
+++ b/dataintegration/get_work_request_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetWorkRequestRequest wrapper for the GetWorkRequest operation
+type GetWorkRequestRequest struct {
+
+	// The ID of the asynchronous request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetWorkRequestRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetWorkRequestRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetWorkRequestRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetWorkRequestResponse wrapper for the GetWorkRequest operation
+type GetWorkRequestResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The WorkRequest instance
+	WorkRequest `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Indicates the number of seconds to wait before making a follow-up request.
+	RetryAfter *int `presentIn:"header" name:"retry-after"`
+}
+
+func (response GetWorkRequestResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetWorkRequestResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/get_workspace_request_response.go
+++ b/dataintegration/get_workspace_request_response.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetWorkspaceRequest wrapper for the GetWorkspace operation
+type GetWorkspaceRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetWorkspaceRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetWorkspaceRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetWorkspaceRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetWorkspaceResponse wrapper for the GetWorkspace operation
+type GetWorkspaceResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Workspace instance
+	Workspace `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetWorkspaceResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetWorkspaceResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/input_field.go
+++ b/dataintegration/input_field.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// InputField The input field for an operator.
+type InputField struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	Type BaseType `mandatory:"false" json:"type"`
+
+	// Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+	Labels []string `mandatory:"false" json:"labels"`
+}
+
+//GetKey returns Key
+func (m InputField) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m InputField) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m InputField) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetConfigValues returns ConfigValues
+func (m InputField) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m InputField) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetName returns Name
+func (m InputField) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m InputField) GetDescription() *string {
+	return m.Description
+}
+
+func (m InputField) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m InputField) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeInputField InputField
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeInputField
+	}{
+		"INPUT_FIELD",
+		(MarshalTypeInputField)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *InputField) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key          *string          `json:"key"`
+		ModelVersion *string          `json:"modelVersion"`
+		ParentRef    *ParentReference `json:"parentRef"`
+		ConfigValues *ConfigValues    `json:"configValues"`
+		ObjectStatus *int             `json:"objectStatus"`
+		Name         *string          `json:"name"`
+		Description  *string          `json:"description"`
+		Type         basetype         `json:"type"`
+		Labels       []string         `json:"labels"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.ConfigValues = model.ConfigValues
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.Name = model.Name
+
+	m.Description = model.Description
+
+	nn, e = model.Type.UnmarshalPolymorphicJSON(model.Type.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.Type = nn.(BaseType)
+	} else {
+		m.Type = nil
+	}
+
+	m.Labels = make([]string, len(model.Labels))
+	for i, n := range model.Labels {
+		m.Labels[i] = n
+	}
+	return
+}

--- a/dataintegration/input_link.go
+++ b/dataintegration/input_link.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// InputLink The information about input links.
+type InputLink struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// Key of FlowPort reference
+	Port *string `mandatory:"false" json:"port"`
+
+	// From link reference.
+	FromLink *string `mandatory:"false" json:"fromLink"`
+
+	FieldMap FieldMap `mandatory:"false" json:"fieldMap"`
+}
+
+//GetKey returns Key
+func (m InputLink) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m InputLink) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m InputLink) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m InputLink) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetDescription returns Description
+func (m InputLink) GetDescription() *string {
+	return m.Description
+}
+
+//GetPort returns Port
+func (m InputLink) GetPort() *string {
+	return m.Port
+}
+
+func (m InputLink) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m InputLink) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeInputLink InputLink
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeInputLink
+	}{
+		"INPUT_LINK",
+		(MarshalTypeInputLink)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *InputLink) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key          *string          `json:"key"`
+		ModelVersion *string          `json:"modelVersion"`
+		ParentRef    *ParentReference `json:"parentRef"`
+		ObjectStatus *int             `json:"objectStatus"`
+		Description  *string          `json:"description"`
+		Port         *string          `json:"port"`
+		FromLink     *string          `json:"fromLink"`
+		FieldMap     fieldmap         `json:"fieldMap"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.Description = model.Description
+
+	m.Port = model.Port
+
+	m.FromLink = model.FromLink
+
+	nn, e = model.FieldMap.UnmarshalPolymorphicJSON(model.FieldMap.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.FieldMap = nn.(FieldMap)
+	} else {
+		m.FieldMap = nil
+	}
+	return
+}

--- a/dataintegration/input_port.go
+++ b/dataintegration/input_port.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// InputPort The input port details.
+type InputPort struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// fields
+	Fields []TypedObject `mandatory:"false" json:"fields"`
+
+	// The port details for the data asset.Type
+	PortType InputPortPortTypeEnum `mandatory:"false" json:"portType,omitempty"`
+}
+
+//GetKey returns Key
+func (m InputPort) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m InputPort) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m InputPort) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetConfigValues returns ConfigValues
+func (m InputPort) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m InputPort) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetName returns Name
+func (m InputPort) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m InputPort) GetDescription() *string {
+	return m.Description
+}
+
+func (m InputPort) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m InputPort) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeInputPort InputPort
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeInputPort
+	}{
+		"INPUT_PORT",
+		(MarshalTypeInputPort)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *InputPort) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key          *string               `json:"key"`
+		ModelVersion *string               `json:"modelVersion"`
+		ParentRef    *ParentReference      `json:"parentRef"`
+		ConfigValues *ConfigValues         `json:"configValues"`
+		ObjectStatus *int                  `json:"objectStatus"`
+		Name         *string               `json:"name"`
+		Description  *string               `json:"description"`
+		PortType     InputPortPortTypeEnum `json:"portType"`
+		Fields       []typedobject         `json:"fields"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.ConfigValues = model.ConfigValues
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.Name = model.Name
+
+	m.Description = model.Description
+
+	m.PortType = model.PortType
+
+	m.Fields = make([]TypedObject, len(model.Fields))
+	for i, n := range model.Fields {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.Fields[i] = nn.(TypedObject)
+		} else {
+			m.Fields[i] = nil
+		}
+	}
+	return
+}
+
+// InputPortPortTypeEnum Enum with underlying type: string
+type InputPortPortTypeEnum string
+
+// Set of constants representing the allowable values for InputPortPortTypeEnum
+const (
+	InputPortPortTypeData    InputPortPortTypeEnum = "DATA"
+	InputPortPortTypeControl InputPortPortTypeEnum = "CONTROL"
+	InputPortPortTypeModel   InputPortPortTypeEnum = "MODEL"
+)
+
+var mappingInputPortPortType = map[string]InputPortPortTypeEnum{
+	"DATA":    InputPortPortTypeData,
+	"CONTROL": InputPortPortTypeControl,
+	"MODEL":   InputPortPortTypeModel,
+}
+
+// GetInputPortPortTypeEnumValues Enumerates the set of values for InputPortPortTypeEnum
+func GetInputPortPortTypeEnumValues() []InputPortPortTypeEnum {
+	values := make([]InputPortPortTypeEnum, 0)
+	for _, v := range mappingInputPortPortType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/java_type.go
+++ b/dataintegration/java_type.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// JavaType A java type object.
+type JavaType struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// javaTypeName
+	JavaTypeName *string `mandatory:"false" json:"javaTypeName"`
+
+	ConfigDefinition *ConfigDefinition `mandatory:"false" json:"configDefinition"`
+}
+
+//GetKey returns Key
+func (m JavaType) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m JavaType) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m JavaType) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m JavaType) GetName() *string {
+	return m.Name
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m JavaType) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetDescription returns Description
+func (m JavaType) GetDescription() *string {
+	return m.Description
+}
+
+func (m JavaType) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m JavaType) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeJavaType JavaType
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeJavaType
+	}{
+		"JAVA_TYPE",
+		(MarshalTypeJavaType)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/join.go
+++ b/dataintegration/join.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Join The information about the join operator. The join operator links data from multiple inbound sources.
+type Join struct {
+
+	// The join condition.
+	Condition *string `mandatory:"false" json:"condition"`
+
+	// The type of join.
+	Policy JoinPolicyEnum `mandatory:"false" json:"policy,omitempty"`
+}
+
+func (m Join) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m Join) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeJoin Join
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeJoin
+	}{
+		"JOIN",
+		(MarshalTypeJoin)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// JoinPolicyEnum Enum with underlying type: string
+type JoinPolicyEnum string
+
+// Set of constants representing the allowable values for JoinPolicyEnum
+const (
+	JoinPolicyInnerJoin JoinPolicyEnum = "INNER_JOIN"
+	JoinPolicyLeftJoin  JoinPolicyEnum = "LEFT_JOIN"
+	JoinPolicyRightJoin JoinPolicyEnum = "RIGHT_JOIN"
+	JoinPolicyFullJoin  JoinPolicyEnum = "FULL_JOIN"
+)
+
+var mappingJoinPolicy = map[string]JoinPolicyEnum{
+	"INNER_JOIN": JoinPolicyInnerJoin,
+	"LEFT_JOIN":  JoinPolicyLeftJoin,
+	"RIGHT_JOIN": JoinPolicyRightJoin,
+	"FULL_JOIN":  JoinPolicyFullJoin,
+}
+
+// GetJoinPolicyEnumValues Enumerates the set of values for JoinPolicyEnum
+func GetJoinPolicyEnumValues() []JoinPolicyEnum {
+	values := make([]JoinPolicyEnum, 0)
+	for _, v := range mappingJoinPolicy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/joiner.go
+++ b/dataintegration/joiner.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Joiner The information about a joiner object.
+type Joiner struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+
+	JoinCondition *Expression `mandatory:"false" json:"joinCondition"`
+
+	// joinType
+	JoinType JoinerJoinTypeEnum `mandatory:"false" json:"joinType,omitempty"`
+}
+
+//GetKey returns Key
+func (m Joiner) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m Joiner) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m Joiner) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m Joiner) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m Joiner) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m Joiner) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetInputPorts returns InputPorts
+func (m Joiner) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m Joiner) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m Joiner) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m Joiner) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetParameters returns Parameters
+func (m Joiner) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m Joiner) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+func (m Joiner) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m Joiner) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeJoiner Joiner
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeJoiner
+	}{
+		"JOINER_OPERATOR",
+		(MarshalTypeJoiner)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// JoinerJoinTypeEnum Enum with underlying type: string
+type JoinerJoinTypeEnum string
+
+// Set of constants representing the allowable values for JoinerJoinTypeEnum
+const (
+	JoinerJoinTypeInner JoinerJoinTypeEnum = "INNER"
+	JoinerJoinTypeFull  JoinerJoinTypeEnum = "FULL"
+	JoinerJoinTypeLeft  JoinerJoinTypeEnum = "LEFT"
+	JoinerJoinTypeRight JoinerJoinTypeEnum = "RIGHT"
+)
+
+var mappingJoinerJoinType = map[string]JoinerJoinTypeEnum{
+	"INNER": JoinerJoinTypeInner,
+	"FULL":  JoinerJoinTypeFull,
+	"LEFT":  JoinerJoinTypeLeft,
+	"RIGHT": JoinerJoinTypeRight,
+}
+
+// GetJoinerJoinTypeEnumValues Enumerates the set of values for JoinerJoinTypeEnum
+func GetJoinerJoinTypeEnumValues() []JoinerJoinTypeEnum {
+	values := make([]JoinerJoinTypeEnum, 0)
+	for _, v := range mappingJoinerJoinType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/json_format_attribute.go
+++ b/dataintegration/json_format_attribute.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// JsonFormatAttribute The JSON file format attribute.
+type JsonFormatAttribute struct {
+
+	// The encoding for the file.
+	Encoding *string `mandatory:"false" json:"encoding"`
+}
+
+func (m JsonFormatAttribute) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m JsonFormatAttribute) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeJsonFormatAttribute JsonFormatAttribute
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeJsonFormatAttribute
+	}{
+		"JSON_FORMAT",
+		(MarshalTypeJsonFormatAttribute)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/key.go
+++ b/dataintegration/key.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Key The key object.
+type Key interface {
+}
+
+type key struct {
+	JsonData  []byte
+	ModelType string `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *key) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerkey key
+	s := struct {
+		Model Unmarshalerkey
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *key) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "UNIQUE_KEY":
+		mm := UniqueKey{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "FOREIGN_KEY":
+		mm := ForeignKey{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m key) String() string {
+	return common.PointerString(m)
+}
+
+// KeyModelTypeEnum Enum with underlying type: string
+type KeyModelTypeEnum string
+
+// Set of constants representing the allowable values for KeyModelTypeEnum
+const (
+	KeyModelTypeForeignKey KeyModelTypeEnum = "FOREIGN_KEY"
+	KeyModelTypePrimaryKey KeyModelTypeEnum = "PRIMARY_KEY"
+	KeyModelTypeUniqueKey  KeyModelTypeEnum = "UNIQUE_KEY"
+)
+
+var mappingKeyModelType = map[string]KeyModelTypeEnum{
+	"FOREIGN_KEY": KeyModelTypeForeignKey,
+	"PRIMARY_KEY": KeyModelTypePrimaryKey,
+	"UNIQUE_KEY":  KeyModelTypeUniqueKey,
+}
+
+// GetKeyModelTypeEnumValues Enumerates the set of values for KeyModelTypeEnum
+func GetKeyModelTypeEnumValues() []KeyModelTypeEnum {
+	values := make([]KeyModelTypeEnum, 0)
+	for _, v := range mappingKeyModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/key_attribute.go
+++ b/dataintegration/key_attribute.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// KeyAttribute An attribute within a key.
+type KeyAttribute struct {
+
+	// The position of the attribute.
+	Position *int `mandatory:"false" json:"position"`
+
+	Attribute *ShapeField `mandatory:"false" json:"attribute"`
+}
+
+func (m KeyAttribute) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/key_range.go
+++ b/dataintegration/key_range.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// KeyRange The information about key range.
+type KeyRange struct {
+	Key *ShapeField `mandatory:"false" json:"key"`
+
+	// The key range.
+	Range []string `mandatory:"false" json:"range"`
+}
+
+func (m KeyRange) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/key_range_partition_config.go
+++ b/dataintegration/key_range_partition_config.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// KeyRangePartitionConfig The information about key range.
+type KeyRangePartitionConfig struct {
+
+	// The partition number for the key range.
+	PartitionNumber *int `mandatory:"false" json:"partitionNumber"`
+
+	KeyRange *KeyRange `mandatory:"false" json:"keyRange"`
+}
+
+func (m KeyRangePartitionConfig) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m KeyRangePartitionConfig) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeKeyRangePartitionConfig KeyRangePartitionConfig
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeKeyRangePartitionConfig
+	}{
+		"KEYRANGEPARTITIONCONFIG",
+		(MarshalTypeKeyRangePartitionConfig)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/list_applications_request_response.go
+++ b/dataintegration/list_applications_request_response.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListApplicationsRequest wrapper for the ListApplications operation
+type ListApplicationsRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// This filter parameter can be used to filter by the name of the object.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// This filter parameter can be used to filter by the identifier of the published object.
+	Identifier []string `contributesTo:"query" name:"identifier" collectionFormat:"multi"`
+
+	// This parameter allows users to specify which fields to get for an object.
+	Fields []string `contributesTo:"query" name:"fields" collectionFormat:"multi"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListApplicationsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListApplicationsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListApplicationsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListApplicationsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListApplicationsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListApplicationsResponse wrapper for the ListApplications operation
+type ListApplicationsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of ApplicationSummaryCollection instances
+	ApplicationSummaryCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+
+	// Total items in the entire list.
+	OpcTotalItems *int `presentIn:"header" name:"opc-total-items"`
+}
+
+func (response ListApplicationsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListApplicationsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListApplicationsSortOrderEnum Enum with underlying type: string
+type ListApplicationsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListApplicationsSortOrderEnum
+const (
+	ListApplicationsSortOrderAsc  ListApplicationsSortOrderEnum = "ASC"
+	ListApplicationsSortOrderDesc ListApplicationsSortOrderEnum = "DESC"
+)
+
+var mappingListApplicationsSortOrder = map[string]ListApplicationsSortOrderEnum{
+	"ASC":  ListApplicationsSortOrderAsc,
+	"DESC": ListApplicationsSortOrderDesc,
+}
+
+// GetListApplicationsSortOrderEnumValues Enumerates the set of values for ListApplicationsSortOrderEnum
+func GetListApplicationsSortOrderEnumValues() []ListApplicationsSortOrderEnum {
+	values := make([]ListApplicationsSortOrderEnum, 0)
+	for _, v := range mappingListApplicationsSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListApplicationsSortByEnum Enum with underlying type: string
+type ListApplicationsSortByEnum string
+
+// Set of constants representing the allowable values for ListApplicationsSortByEnum
+const (
+	ListApplicationsSortByTimeCreated ListApplicationsSortByEnum = "TIME_CREATED"
+	ListApplicationsSortByDisplayName ListApplicationsSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListApplicationsSortBy = map[string]ListApplicationsSortByEnum{
+	"TIME_CREATED": ListApplicationsSortByTimeCreated,
+	"DISPLAY_NAME": ListApplicationsSortByDisplayName,
+}
+
+// GetListApplicationsSortByEnumValues Enumerates the set of values for ListApplicationsSortByEnum
+func GetListApplicationsSortByEnumValues() []ListApplicationsSortByEnum {
+	values := make([]ListApplicationsSortByEnum, 0)
+	for _, v := range mappingListApplicationsSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_connection_validations_request_response.go
+++ b/dataintegration/list_connection_validations_request_response.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListConnectionValidationsRequest wrapper for the ListConnectionValidations operation
+type ListConnectionValidationsRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// This filter parameter can be used to filter by the key of the object.
+	Key *string `mandatory:"false" contributesTo:"query" name:"key"`
+
+	// This filter parameter can be used to filter by the name of the object.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// This filter parameter can be used to filter by the identifier of the object.
+	Identifier *string `mandatory:"false" contributesTo:"query" name:"identifier"`
+
+	// This parameter allows users to specify which fields to get for an object.
+	Fields []string `contributesTo:"query" name:"fields" collectionFormat:"multi"`
+
+	// This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListConnectionValidationsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListConnectionValidationsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListConnectionValidationsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListConnectionValidationsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListConnectionValidationsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListConnectionValidationsResponse wrapper for the ListConnectionValidations operation
+type ListConnectionValidationsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of ConnectionValidationSummaryCollection instances
+	ConnectionValidationSummaryCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+
+	// Total items in the entire list.
+	OpcTotalItems *int `presentIn:"header" name:"opc-total-items"`
+}
+
+func (response ListConnectionValidationsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListConnectionValidationsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListConnectionValidationsSortByEnum Enum with underlying type: string
+type ListConnectionValidationsSortByEnum string
+
+// Set of constants representing the allowable values for ListConnectionValidationsSortByEnum
+const (
+	ListConnectionValidationsSortByTimeCreated ListConnectionValidationsSortByEnum = "TIME_CREATED"
+	ListConnectionValidationsSortByDisplayName ListConnectionValidationsSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListConnectionValidationsSortBy = map[string]ListConnectionValidationsSortByEnum{
+	"TIME_CREATED": ListConnectionValidationsSortByTimeCreated,
+	"DISPLAY_NAME": ListConnectionValidationsSortByDisplayName,
+}
+
+// GetListConnectionValidationsSortByEnumValues Enumerates the set of values for ListConnectionValidationsSortByEnum
+func GetListConnectionValidationsSortByEnumValues() []ListConnectionValidationsSortByEnum {
+	values := make([]ListConnectionValidationsSortByEnum, 0)
+	for _, v := range mappingListConnectionValidationsSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListConnectionValidationsSortOrderEnum Enum with underlying type: string
+type ListConnectionValidationsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListConnectionValidationsSortOrderEnum
+const (
+	ListConnectionValidationsSortOrderAsc  ListConnectionValidationsSortOrderEnum = "ASC"
+	ListConnectionValidationsSortOrderDesc ListConnectionValidationsSortOrderEnum = "DESC"
+)
+
+var mappingListConnectionValidationsSortOrder = map[string]ListConnectionValidationsSortOrderEnum{
+	"ASC":  ListConnectionValidationsSortOrderAsc,
+	"DESC": ListConnectionValidationsSortOrderDesc,
+}
+
+// GetListConnectionValidationsSortOrderEnumValues Enumerates the set of values for ListConnectionValidationsSortOrderEnum
+func GetListConnectionValidationsSortOrderEnumValues() []ListConnectionValidationsSortOrderEnum {
+	values := make([]ListConnectionValidationsSortOrderEnum, 0)
+	for _, v := range mappingListConnectionValidationsSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_connections_request_response.go
+++ b/dataintegration/list_connections_request_response.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListConnectionsRequest wrapper for the ListConnections operation
+type ListConnectionsRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// This filter parameter can be used to filter by the data asset key of the object.
+	DataAssetKey *string `mandatory:"true" contributesTo:"query" name:"dataAssetKey"`
+
+	// This filter parameter can be used to filter by the name of the object.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// This parameter allows users to specify which fields to get for an object.
+	Fields []string `contributesTo:"query" name:"fields" collectionFormat:"multi"`
+
+	// Type of the object to filter the results with.
+	Type *string `mandatory:"false" contributesTo:"query" name:"type"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListConnectionsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListConnectionsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListConnectionsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListConnectionsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListConnectionsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListConnectionsResponse wrapper for the ListConnections operation
+type ListConnectionsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of ConnectionSummaryCollection instances
+	ConnectionSummaryCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+
+	// Total items in the entire list.
+	OpcTotalItems *int `presentIn:"header" name:"opc-total-items"`
+}
+
+func (response ListConnectionsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListConnectionsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListConnectionsSortByEnum Enum with underlying type: string
+type ListConnectionsSortByEnum string
+
+// Set of constants representing the allowable values for ListConnectionsSortByEnum
+const (
+	ListConnectionsSortByTimeCreated ListConnectionsSortByEnum = "TIME_CREATED"
+	ListConnectionsSortByDisplayName ListConnectionsSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListConnectionsSortBy = map[string]ListConnectionsSortByEnum{
+	"TIME_CREATED": ListConnectionsSortByTimeCreated,
+	"DISPLAY_NAME": ListConnectionsSortByDisplayName,
+}
+
+// GetListConnectionsSortByEnumValues Enumerates the set of values for ListConnectionsSortByEnum
+func GetListConnectionsSortByEnumValues() []ListConnectionsSortByEnum {
+	values := make([]ListConnectionsSortByEnum, 0)
+	for _, v := range mappingListConnectionsSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListConnectionsSortOrderEnum Enum with underlying type: string
+type ListConnectionsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListConnectionsSortOrderEnum
+const (
+	ListConnectionsSortOrderAsc  ListConnectionsSortOrderEnum = "ASC"
+	ListConnectionsSortOrderDesc ListConnectionsSortOrderEnum = "DESC"
+)
+
+var mappingListConnectionsSortOrder = map[string]ListConnectionsSortOrderEnum{
+	"ASC":  ListConnectionsSortOrderAsc,
+	"DESC": ListConnectionsSortOrderDesc,
+}
+
+// GetListConnectionsSortOrderEnumValues Enumerates the set of values for ListConnectionsSortOrderEnum
+func GetListConnectionsSortOrderEnumValues() []ListConnectionsSortOrderEnum {
+	values := make([]ListConnectionsSortOrderEnum, 0)
+	for _, v := range mappingListConnectionsSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_data_assets_request_response.go
+++ b/dataintegration/list_data_assets_request_response.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListDataAssetsRequest wrapper for the ListDataAssets operation
+type ListDataAssetsRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// This parameter allows users to specify which fields to get for an object.
+	Fields []string `contributesTo:"query" name:"fields" collectionFormat:"multi"`
+
+	// Type of the object to filter the results with.
+	Type *string `mandatory:"false" contributesTo:"query" name:"type"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListDataAssetsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListDataAssetsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// This filter parameter can be used to filter by the name of the object.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListDataAssetsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListDataAssetsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListDataAssetsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListDataAssetsResponse wrapper for the ListDataAssets operation
+type ListDataAssetsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of DataAssetSummaryCollection instances
+	DataAssetSummaryCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+
+	// Total items in the entire list.
+	OpcTotalItems *int `presentIn:"header" name:"opc-total-items"`
+}
+
+func (response ListDataAssetsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListDataAssetsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListDataAssetsSortByEnum Enum with underlying type: string
+type ListDataAssetsSortByEnum string
+
+// Set of constants representing the allowable values for ListDataAssetsSortByEnum
+const (
+	ListDataAssetsSortByTimeCreated ListDataAssetsSortByEnum = "TIME_CREATED"
+	ListDataAssetsSortByDisplayName ListDataAssetsSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListDataAssetsSortBy = map[string]ListDataAssetsSortByEnum{
+	"TIME_CREATED": ListDataAssetsSortByTimeCreated,
+	"DISPLAY_NAME": ListDataAssetsSortByDisplayName,
+}
+
+// GetListDataAssetsSortByEnumValues Enumerates the set of values for ListDataAssetsSortByEnum
+func GetListDataAssetsSortByEnumValues() []ListDataAssetsSortByEnum {
+	values := make([]ListDataAssetsSortByEnum, 0)
+	for _, v := range mappingListDataAssetsSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListDataAssetsSortOrderEnum Enum with underlying type: string
+type ListDataAssetsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListDataAssetsSortOrderEnum
+const (
+	ListDataAssetsSortOrderAsc  ListDataAssetsSortOrderEnum = "ASC"
+	ListDataAssetsSortOrderDesc ListDataAssetsSortOrderEnum = "DESC"
+)
+
+var mappingListDataAssetsSortOrder = map[string]ListDataAssetsSortOrderEnum{
+	"ASC":  ListDataAssetsSortOrderAsc,
+	"DESC": ListDataAssetsSortOrderDesc,
+}
+
+// GetListDataAssetsSortOrderEnumValues Enumerates the set of values for ListDataAssetsSortOrderEnum
+func GetListDataAssetsSortOrderEnumValues() []ListDataAssetsSortOrderEnum {
+	values := make([]ListDataAssetsSortOrderEnum, 0)
+	for _, v := range mappingListDataAssetsSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_data_entities_request_response.go
+++ b/dataintegration/list_data_entities_request_response.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListDataEntitiesRequest wrapper for the ListDataEntities operation
+type ListDataEntitiesRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// The connection key
+	ConnectionKey *string `mandatory:"true" contributesTo:"path" name:"connectionKey"`
+
+	// Schema resource name used for retrieving schemas
+	SchemaResourceName *string `mandatory:"true" contributesTo:"path" name:"schemaResourceName"`
+
+	// This filter parameter can be used to filter by the name of the object.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// Type of the object to filter the results with.
+	Type *string `mandatory:"false" contributesTo:"query" name:"type"`
+
+	// This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// This parameter allows users to specify which fields to get for an object.
+	Fields []string `contributesTo:"query" name:"fields" collectionFormat:"multi"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListDataEntitiesSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListDataEntitiesSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListDataEntitiesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListDataEntitiesRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListDataEntitiesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListDataEntitiesResponse wrapper for the ListDataEntities operation
+type ListDataEntitiesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of DataEntitySummaryCollection instances
+	DataEntitySummaryCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+
+	// Total items in the entire list.
+	OpcTotalItems *int `presentIn:"header" name:"opc-total-items"`
+}
+
+func (response ListDataEntitiesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListDataEntitiesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListDataEntitiesSortByEnum Enum with underlying type: string
+type ListDataEntitiesSortByEnum string
+
+// Set of constants representing the allowable values for ListDataEntitiesSortByEnum
+const (
+	ListDataEntitiesSortByTimeCreated ListDataEntitiesSortByEnum = "TIME_CREATED"
+	ListDataEntitiesSortByDisplayName ListDataEntitiesSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListDataEntitiesSortBy = map[string]ListDataEntitiesSortByEnum{
+	"TIME_CREATED": ListDataEntitiesSortByTimeCreated,
+	"DISPLAY_NAME": ListDataEntitiesSortByDisplayName,
+}
+
+// GetListDataEntitiesSortByEnumValues Enumerates the set of values for ListDataEntitiesSortByEnum
+func GetListDataEntitiesSortByEnumValues() []ListDataEntitiesSortByEnum {
+	values := make([]ListDataEntitiesSortByEnum, 0)
+	for _, v := range mappingListDataEntitiesSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListDataEntitiesSortOrderEnum Enum with underlying type: string
+type ListDataEntitiesSortOrderEnum string
+
+// Set of constants representing the allowable values for ListDataEntitiesSortOrderEnum
+const (
+	ListDataEntitiesSortOrderAsc  ListDataEntitiesSortOrderEnum = "ASC"
+	ListDataEntitiesSortOrderDesc ListDataEntitiesSortOrderEnum = "DESC"
+)
+
+var mappingListDataEntitiesSortOrder = map[string]ListDataEntitiesSortOrderEnum{
+	"ASC":  ListDataEntitiesSortOrderAsc,
+	"DESC": ListDataEntitiesSortOrderDesc,
+}
+
+// GetListDataEntitiesSortOrderEnumValues Enumerates the set of values for ListDataEntitiesSortOrderEnum
+func GetListDataEntitiesSortOrderEnumValues() []ListDataEntitiesSortOrderEnum {
+	values := make([]ListDataEntitiesSortOrderEnum, 0)
+	for _, v := range mappingListDataEntitiesSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_data_flow_validations_request_response.go
+++ b/dataintegration/list_data_flow_validations_request_response.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListDataFlowValidationsRequest wrapper for the ListDataFlowValidations operation
+type ListDataFlowValidationsRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// This filter parameter can be used to filter by the key of the object.
+	Key *string `mandatory:"false" contributesTo:"query" name:"key"`
+
+	// This filter parameter can be used to filter by the name of the object.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// This filter parameter can be used to filter by the identifier of the object.
+	Identifier *string `mandatory:"false" contributesTo:"query" name:"identifier"`
+
+	// This parameter allows users to specify which fields to get for an object.
+	Fields []string `contributesTo:"query" name:"fields" collectionFormat:"multi"`
+
+	// This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListDataFlowValidationsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListDataFlowValidationsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListDataFlowValidationsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListDataFlowValidationsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListDataFlowValidationsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListDataFlowValidationsResponse wrapper for the ListDataFlowValidations operation
+type ListDataFlowValidationsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of DataFlowValidationSummaryCollection instances
+	DataFlowValidationSummaryCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+
+	// Total items in the entire list.
+	OpcTotalItems *int `presentIn:"header" name:"opc-total-items"`
+}
+
+func (response ListDataFlowValidationsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListDataFlowValidationsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListDataFlowValidationsSortByEnum Enum with underlying type: string
+type ListDataFlowValidationsSortByEnum string
+
+// Set of constants representing the allowable values for ListDataFlowValidationsSortByEnum
+const (
+	ListDataFlowValidationsSortByTimeCreated ListDataFlowValidationsSortByEnum = "TIME_CREATED"
+	ListDataFlowValidationsSortByDisplayName ListDataFlowValidationsSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListDataFlowValidationsSortBy = map[string]ListDataFlowValidationsSortByEnum{
+	"TIME_CREATED": ListDataFlowValidationsSortByTimeCreated,
+	"DISPLAY_NAME": ListDataFlowValidationsSortByDisplayName,
+}
+
+// GetListDataFlowValidationsSortByEnumValues Enumerates the set of values for ListDataFlowValidationsSortByEnum
+func GetListDataFlowValidationsSortByEnumValues() []ListDataFlowValidationsSortByEnum {
+	values := make([]ListDataFlowValidationsSortByEnum, 0)
+	for _, v := range mappingListDataFlowValidationsSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListDataFlowValidationsSortOrderEnum Enum with underlying type: string
+type ListDataFlowValidationsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListDataFlowValidationsSortOrderEnum
+const (
+	ListDataFlowValidationsSortOrderAsc  ListDataFlowValidationsSortOrderEnum = "ASC"
+	ListDataFlowValidationsSortOrderDesc ListDataFlowValidationsSortOrderEnum = "DESC"
+)
+
+var mappingListDataFlowValidationsSortOrder = map[string]ListDataFlowValidationsSortOrderEnum{
+	"ASC":  ListDataFlowValidationsSortOrderAsc,
+	"DESC": ListDataFlowValidationsSortOrderDesc,
+}
+
+// GetListDataFlowValidationsSortOrderEnumValues Enumerates the set of values for ListDataFlowValidationsSortOrderEnum
+func GetListDataFlowValidationsSortOrderEnumValues() []ListDataFlowValidationsSortOrderEnum {
+	values := make([]ListDataFlowValidationsSortOrderEnum, 0)
+	for _, v := range mappingListDataFlowValidationsSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_data_flows_request_response.go
+++ b/dataintegration/list_data_flows_request_response.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListDataFlowsRequest wrapper for the ListDataFlows operation
+type ListDataFlowsRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Unique key of the folder
+	FolderId *string `mandatory:"false" contributesTo:"query" name:"folderId"`
+
+	// This parameter allows users to specify which fields to get for an object.
+	Fields []string `contributesTo:"query" name:"fields" collectionFormat:"multi"`
+
+	// This filter parameter can be used to filter by the name of the object.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// This filter parameter can be used to filter by the identifier of the object.
+	Identifier []string `contributesTo:"query" name:"identifier" collectionFormat:"multi"`
+
+	// This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListDataFlowsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListDataFlowsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListDataFlowsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListDataFlowsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListDataFlowsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListDataFlowsResponse wrapper for the ListDataFlows operation
+type ListDataFlowsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of DataFlowSummaryCollection instances
+	DataFlowSummaryCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+
+	// Total items in the entire list.
+	OpcTotalItems *int `presentIn:"header" name:"opc-total-items"`
+}
+
+func (response ListDataFlowsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListDataFlowsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListDataFlowsSortOrderEnum Enum with underlying type: string
+type ListDataFlowsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListDataFlowsSortOrderEnum
+const (
+	ListDataFlowsSortOrderAsc  ListDataFlowsSortOrderEnum = "ASC"
+	ListDataFlowsSortOrderDesc ListDataFlowsSortOrderEnum = "DESC"
+)
+
+var mappingListDataFlowsSortOrder = map[string]ListDataFlowsSortOrderEnum{
+	"ASC":  ListDataFlowsSortOrderAsc,
+	"DESC": ListDataFlowsSortOrderDesc,
+}
+
+// GetListDataFlowsSortOrderEnumValues Enumerates the set of values for ListDataFlowsSortOrderEnum
+func GetListDataFlowsSortOrderEnumValues() []ListDataFlowsSortOrderEnum {
+	values := make([]ListDataFlowsSortOrderEnum, 0)
+	for _, v := range mappingListDataFlowsSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListDataFlowsSortByEnum Enum with underlying type: string
+type ListDataFlowsSortByEnum string
+
+// Set of constants representing the allowable values for ListDataFlowsSortByEnum
+const (
+	ListDataFlowsSortByTimeCreated ListDataFlowsSortByEnum = "TIME_CREATED"
+	ListDataFlowsSortByDisplayName ListDataFlowsSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListDataFlowsSortBy = map[string]ListDataFlowsSortByEnum{
+	"TIME_CREATED": ListDataFlowsSortByTimeCreated,
+	"DISPLAY_NAME": ListDataFlowsSortByDisplayName,
+}
+
+// GetListDataFlowsSortByEnumValues Enumerates the set of values for ListDataFlowsSortByEnum
+func GetListDataFlowsSortByEnumValues() []ListDataFlowsSortByEnum {
+	values := make([]ListDataFlowsSortByEnum, 0)
+	for _, v := range mappingListDataFlowsSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_dependent_objects_request_response.go
+++ b/dataintegration/list_dependent_objects_request_response.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListDependentObjectsRequest wrapper for the ListDependentObjects operation
+type ListDependentObjectsRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS application key
+	ApplicationKey *string `mandatory:"true" contributesTo:"path" name:"applicationKey"`
+
+	// This parameter allows users to specify which fields to get for an object.
+	Fields []string `contributesTo:"query" name:"fields" collectionFormat:"multi"`
+
+	// This filter parameter can be used to filter by the name of the object.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// This filter parameter can be used to filter by the identifier of the published object.
+	Identifier []string `contributesTo:"query" name:"identifier" collectionFormat:"multi"`
+
+	// This filter parameter can be used to filter by the object type of the object.
+	// This parameter can be suffixed with an optional filter operator InSubtree.
+	// For DIS APIs we will filter based on type Task.
+	Type []string `contributesTo:"query" name:"type" collectionFormat:"multi"`
+
+	// This is used in association with type parameter. If value is true,
+	// then type all sub types of the given type parameter is considered.
+	// If value is false, then sub types are not considered. Default is false.
+	TypeInSubtree *string `mandatory:"false" contributesTo:"query" name:"typeInSubtree"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListDependentObjectsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListDependentObjectsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListDependentObjectsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListDependentObjectsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListDependentObjectsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListDependentObjectsResponse wrapper for the ListDependentObjects operation
+type ListDependentObjectsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of DependentObjectSummaryCollection instances
+	DependentObjectSummaryCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+
+	// Total items in the entire list.
+	OpcTotalItems *int `presentIn:"header" name:"opc-total-items"`
+}
+
+func (response ListDependentObjectsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListDependentObjectsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListDependentObjectsSortOrderEnum Enum with underlying type: string
+type ListDependentObjectsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListDependentObjectsSortOrderEnum
+const (
+	ListDependentObjectsSortOrderAsc  ListDependentObjectsSortOrderEnum = "ASC"
+	ListDependentObjectsSortOrderDesc ListDependentObjectsSortOrderEnum = "DESC"
+)
+
+var mappingListDependentObjectsSortOrder = map[string]ListDependentObjectsSortOrderEnum{
+	"ASC":  ListDependentObjectsSortOrderAsc,
+	"DESC": ListDependentObjectsSortOrderDesc,
+}
+
+// GetListDependentObjectsSortOrderEnumValues Enumerates the set of values for ListDependentObjectsSortOrderEnum
+func GetListDependentObjectsSortOrderEnumValues() []ListDependentObjectsSortOrderEnum {
+	values := make([]ListDependentObjectsSortOrderEnum, 0)
+	for _, v := range mappingListDependentObjectsSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListDependentObjectsSortByEnum Enum with underlying type: string
+type ListDependentObjectsSortByEnum string
+
+// Set of constants representing the allowable values for ListDependentObjectsSortByEnum
+const (
+	ListDependentObjectsSortByTimeCreated ListDependentObjectsSortByEnum = "TIME_CREATED"
+	ListDependentObjectsSortByDisplayName ListDependentObjectsSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListDependentObjectsSortBy = map[string]ListDependentObjectsSortByEnum{
+	"TIME_CREATED": ListDependentObjectsSortByTimeCreated,
+	"DISPLAY_NAME": ListDependentObjectsSortByDisplayName,
+}
+
+// GetListDependentObjectsSortByEnumValues Enumerates the set of values for ListDependentObjectsSortByEnum
+func GetListDependentObjectsSortByEnumValues() []ListDependentObjectsSortByEnum {
+	values := make([]ListDependentObjectsSortByEnum, 0)
+	for _, v := range mappingListDependentObjectsSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_folders_request_response.go
+++ b/dataintegration/list_folders_request_response.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListFoldersRequest wrapper for the ListFolders operation
+type ListFoldersRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// This filter parameter can be used to filter by the project or the folder object.
+	AggregatorKey *string `mandatory:"false" contributesTo:"query" name:"aggregatorKey"`
+
+	// This parameter allows users to specify which fields to get for an object.
+	Fields []string `contributesTo:"query" name:"fields" collectionFormat:"multi"`
+
+	// This filter parameter can be used to filter by the name of the object.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// This filter parameter can be used to filter by the identifier of the object.
+	Identifier []string `contributesTo:"query" name:"identifier" collectionFormat:"multi"`
+
+	// This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListFoldersSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListFoldersSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListFoldersRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListFoldersRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListFoldersRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListFoldersResponse wrapper for the ListFolders operation
+type ListFoldersResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of FolderSummaryCollection instances
+	FolderSummaryCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+
+	// Total items in the entire list.
+	OpcTotalItems *int `presentIn:"header" name:"opc-total-items"`
+}
+
+func (response ListFoldersResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListFoldersResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListFoldersSortOrderEnum Enum with underlying type: string
+type ListFoldersSortOrderEnum string
+
+// Set of constants representing the allowable values for ListFoldersSortOrderEnum
+const (
+	ListFoldersSortOrderAsc  ListFoldersSortOrderEnum = "ASC"
+	ListFoldersSortOrderDesc ListFoldersSortOrderEnum = "DESC"
+)
+
+var mappingListFoldersSortOrder = map[string]ListFoldersSortOrderEnum{
+	"ASC":  ListFoldersSortOrderAsc,
+	"DESC": ListFoldersSortOrderDesc,
+}
+
+// GetListFoldersSortOrderEnumValues Enumerates the set of values for ListFoldersSortOrderEnum
+func GetListFoldersSortOrderEnumValues() []ListFoldersSortOrderEnum {
+	values := make([]ListFoldersSortOrderEnum, 0)
+	for _, v := range mappingListFoldersSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListFoldersSortByEnum Enum with underlying type: string
+type ListFoldersSortByEnum string
+
+// Set of constants representing the allowable values for ListFoldersSortByEnum
+const (
+	ListFoldersSortByTimeCreated ListFoldersSortByEnum = "TIME_CREATED"
+	ListFoldersSortByDisplayName ListFoldersSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListFoldersSortBy = map[string]ListFoldersSortByEnum{
+	"TIME_CREATED": ListFoldersSortByTimeCreated,
+	"DISPLAY_NAME": ListFoldersSortByDisplayName,
+}
+
+// GetListFoldersSortByEnumValues Enumerates the set of values for ListFoldersSortByEnum
+func GetListFoldersSortByEnumValues() []ListFoldersSortByEnum {
+	values := make([]ListFoldersSortByEnum, 0)
+	for _, v := range mappingListFoldersSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_patches_request_response.go
+++ b/dataintegration/list_patches_request_response.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListPatchesRequest wrapper for the ListPatches operation
+type ListPatchesRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS application key
+	ApplicationKey *string `mandatory:"true" contributesTo:"path" name:"applicationKey"`
+
+	// This filter parameter can be used to filter by the name of the object.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// This filter parameter can be used to filter by the identifier of the published object.
+	Identifier []string `contributesTo:"query" name:"identifier" collectionFormat:"multi"`
+
+	// This parameter allows users to specify which fields to get for an object.
+	Fields []string `contributesTo:"query" name:"fields" collectionFormat:"multi"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListPatchesSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListPatchesSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListPatchesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListPatchesRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListPatchesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListPatchesResponse wrapper for the ListPatches operation
+type ListPatchesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of PatchSummaryCollection instances
+	PatchSummaryCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+
+	// Total items in the entire list.
+	OpcTotalItems *int `presentIn:"header" name:"opc-total-items"`
+}
+
+func (response ListPatchesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListPatchesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListPatchesSortOrderEnum Enum with underlying type: string
+type ListPatchesSortOrderEnum string
+
+// Set of constants representing the allowable values for ListPatchesSortOrderEnum
+const (
+	ListPatchesSortOrderAsc  ListPatchesSortOrderEnum = "ASC"
+	ListPatchesSortOrderDesc ListPatchesSortOrderEnum = "DESC"
+)
+
+var mappingListPatchesSortOrder = map[string]ListPatchesSortOrderEnum{
+	"ASC":  ListPatchesSortOrderAsc,
+	"DESC": ListPatchesSortOrderDesc,
+}
+
+// GetListPatchesSortOrderEnumValues Enumerates the set of values for ListPatchesSortOrderEnum
+func GetListPatchesSortOrderEnumValues() []ListPatchesSortOrderEnum {
+	values := make([]ListPatchesSortOrderEnum, 0)
+	for _, v := range mappingListPatchesSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListPatchesSortByEnum Enum with underlying type: string
+type ListPatchesSortByEnum string
+
+// Set of constants representing the allowable values for ListPatchesSortByEnum
+const (
+	ListPatchesSortByTimeCreated ListPatchesSortByEnum = "TIME_CREATED"
+	ListPatchesSortByDisplayName ListPatchesSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListPatchesSortBy = map[string]ListPatchesSortByEnum{
+	"TIME_CREATED": ListPatchesSortByTimeCreated,
+	"DISPLAY_NAME": ListPatchesSortByDisplayName,
+}
+
+// GetListPatchesSortByEnumValues Enumerates the set of values for ListPatchesSortByEnum
+func GetListPatchesSortByEnumValues() []ListPatchesSortByEnum {
+	values := make([]ListPatchesSortByEnum, 0)
+	for _, v := range mappingListPatchesSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_projects_request_response.go
+++ b/dataintegration/list_projects_request_response.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListProjectsRequest wrapper for the ListProjects operation
+type ListProjectsRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// This parameter allows users to specify which fields to get for an object.
+	Fields []string `contributesTo:"query" name:"fields" collectionFormat:"multi"`
+
+	// This filter parameter can be used to filter by the name of the object.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// This filter parameter can be used to filter by the identifier of the object.
+	Identifier []string `contributesTo:"query" name:"identifier" collectionFormat:"multi"`
+
+	// This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListProjectsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListProjectsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListProjectsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListProjectsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListProjectsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListProjectsResponse wrapper for the ListProjects operation
+type ListProjectsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of ProjectSummaryCollection instances
+	ProjectSummaryCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+
+	// Total items in the entire list.
+	OpcTotalItems *int `presentIn:"header" name:"opc-total-items"`
+}
+
+func (response ListProjectsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListProjectsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListProjectsSortOrderEnum Enum with underlying type: string
+type ListProjectsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListProjectsSortOrderEnum
+const (
+	ListProjectsSortOrderAsc  ListProjectsSortOrderEnum = "ASC"
+	ListProjectsSortOrderDesc ListProjectsSortOrderEnum = "DESC"
+)
+
+var mappingListProjectsSortOrder = map[string]ListProjectsSortOrderEnum{
+	"ASC":  ListProjectsSortOrderAsc,
+	"DESC": ListProjectsSortOrderDesc,
+}
+
+// GetListProjectsSortOrderEnumValues Enumerates the set of values for ListProjectsSortOrderEnum
+func GetListProjectsSortOrderEnumValues() []ListProjectsSortOrderEnum {
+	values := make([]ListProjectsSortOrderEnum, 0)
+	for _, v := range mappingListProjectsSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListProjectsSortByEnum Enum with underlying type: string
+type ListProjectsSortByEnum string
+
+// Set of constants representing the allowable values for ListProjectsSortByEnum
+const (
+	ListProjectsSortByTimeCreated ListProjectsSortByEnum = "TIME_CREATED"
+	ListProjectsSortByDisplayName ListProjectsSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListProjectsSortBy = map[string]ListProjectsSortByEnum{
+	"TIME_CREATED": ListProjectsSortByTimeCreated,
+	"DISPLAY_NAME": ListProjectsSortByDisplayName,
+}
+
+// GetListProjectsSortByEnumValues Enumerates the set of values for ListProjectsSortByEnum
+func GetListProjectsSortByEnumValues() []ListProjectsSortByEnum {
+	values := make([]ListProjectsSortByEnum, 0)
+	for _, v := range mappingListProjectsSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_published_objects_request_response.go
+++ b/dataintegration/list_published_objects_request_response.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListPublishedObjectsRequest wrapper for the ListPublishedObjects operation
+type ListPublishedObjectsRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS application key
+	ApplicationKey *string `mandatory:"true" contributesTo:"path" name:"applicationKey"`
+
+	// This parameter allows users to specify which fields to get for an object.
+	Fields []string `contributesTo:"query" name:"fields" collectionFormat:"multi"`
+
+	// This filter parameter can be used to filter by the name of the object.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// This filter parameter can be used to filter by the identifier of the published object.
+	Identifier []string `contributesTo:"query" name:"identifier" collectionFormat:"multi"`
+
+	// This filter parameter can be used to filter by the object type of the object.
+	// This parameter can be suffixed with an optional filter operator InSubtree.
+	// For DIS APIs we will filter based on type Task.
+	Type []string `contributesTo:"query" name:"type" collectionFormat:"multi"`
+
+	// This is used in association with type parameter. If value is true,
+	// then type all sub types of the given type parameter is considered.
+	// If value is false, then sub types are not considered. Default is false.
+	TypeInSubtree *string `mandatory:"false" contributesTo:"query" name:"typeInSubtree"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListPublishedObjectsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListPublishedObjectsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListPublishedObjectsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListPublishedObjectsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListPublishedObjectsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListPublishedObjectsResponse wrapper for the ListPublishedObjects operation
+type ListPublishedObjectsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of PublishedObjectSummaryCollection instances
+	PublishedObjectSummaryCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+
+	// Total items in the entire list.
+	OpcTotalItems *int `presentIn:"header" name:"opc-total-items"`
+}
+
+func (response ListPublishedObjectsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListPublishedObjectsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListPublishedObjectsSortOrderEnum Enum with underlying type: string
+type ListPublishedObjectsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListPublishedObjectsSortOrderEnum
+const (
+	ListPublishedObjectsSortOrderAsc  ListPublishedObjectsSortOrderEnum = "ASC"
+	ListPublishedObjectsSortOrderDesc ListPublishedObjectsSortOrderEnum = "DESC"
+)
+
+var mappingListPublishedObjectsSortOrder = map[string]ListPublishedObjectsSortOrderEnum{
+	"ASC":  ListPublishedObjectsSortOrderAsc,
+	"DESC": ListPublishedObjectsSortOrderDesc,
+}
+
+// GetListPublishedObjectsSortOrderEnumValues Enumerates the set of values for ListPublishedObjectsSortOrderEnum
+func GetListPublishedObjectsSortOrderEnumValues() []ListPublishedObjectsSortOrderEnum {
+	values := make([]ListPublishedObjectsSortOrderEnum, 0)
+	for _, v := range mappingListPublishedObjectsSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListPublishedObjectsSortByEnum Enum with underlying type: string
+type ListPublishedObjectsSortByEnum string
+
+// Set of constants representing the allowable values for ListPublishedObjectsSortByEnum
+const (
+	ListPublishedObjectsSortByTimeCreated ListPublishedObjectsSortByEnum = "TIME_CREATED"
+	ListPublishedObjectsSortByDisplayName ListPublishedObjectsSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListPublishedObjectsSortBy = map[string]ListPublishedObjectsSortByEnum{
+	"TIME_CREATED": ListPublishedObjectsSortByTimeCreated,
+	"DISPLAY_NAME": ListPublishedObjectsSortByDisplayName,
+}
+
+// GetListPublishedObjectsSortByEnumValues Enumerates the set of values for ListPublishedObjectsSortByEnum
+func GetListPublishedObjectsSortByEnumValues() []ListPublishedObjectsSortByEnum {
+	values := make([]ListPublishedObjectsSortByEnum, 0)
+	for _, v := range mappingListPublishedObjectsSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_schemas_request_response.go
+++ b/dataintegration/list_schemas_request_response.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListSchemasRequest wrapper for the ListSchemas operation
+type ListSchemasRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// The connection key
+	ConnectionKey *string `mandatory:"true" contributesTo:"path" name:"connectionKey"`
+
+	// Schema resource name used for retrieving schemas
+	SchemaResourceName *string `mandatory:"true" contributesTo:"query" name:"schemaResourceName"`
+
+	// This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// This parameter allows users to specify which fields to get for an object.
+	Fields []string `contributesTo:"query" name:"fields" collectionFormat:"multi"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListSchemasSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListSchemasSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// This filter parameter can be used to filter by the name of the object.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListSchemasRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListSchemasRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListSchemasRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListSchemasResponse wrapper for the ListSchemas operation
+type ListSchemasResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of SchemaSummaryCollection instances
+	SchemaSummaryCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+
+	// Total items in the entire list.
+	OpcTotalItems *int `presentIn:"header" name:"opc-total-items"`
+}
+
+func (response ListSchemasResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListSchemasResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListSchemasSortByEnum Enum with underlying type: string
+type ListSchemasSortByEnum string
+
+// Set of constants representing the allowable values for ListSchemasSortByEnum
+const (
+	ListSchemasSortByTimeCreated ListSchemasSortByEnum = "TIME_CREATED"
+	ListSchemasSortByDisplayName ListSchemasSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListSchemasSortBy = map[string]ListSchemasSortByEnum{
+	"TIME_CREATED": ListSchemasSortByTimeCreated,
+	"DISPLAY_NAME": ListSchemasSortByDisplayName,
+}
+
+// GetListSchemasSortByEnumValues Enumerates the set of values for ListSchemasSortByEnum
+func GetListSchemasSortByEnumValues() []ListSchemasSortByEnum {
+	values := make([]ListSchemasSortByEnum, 0)
+	for _, v := range mappingListSchemasSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListSchemasSortOrderEnum Enum with underlying type: string
+type ListSchemasSortOrderEnum string
+
+// Set of constants representing the allowable values for ListSchemasSortOrderEnum
+const (
+	ListSchemasSortOrderAsc  ListSchemasSortOrderEnum = "ASC"
+	ListSchemasSortOrderDesc ListSchemasSortOrderEnum = "DESC"
+)
+
+var mappingListSchemasSortOrder = map[string]ListSchemasSortOrderEnum{
+	"ASC":  ListSchemasSortOrderAsc,
+	"DESC": ListSchemasSortOrderDesc,
+}
+
+// GetListSchemasSortOrderEnumValues Enumerates the set of values for ListSchemasSortOrderEnum
+func GetListSchemasSortOrderEnumValues() []ListSchemasSortOrderEnum {
+	values := make([]ListSchemasSortOrderEnum, 0)
+	for _, v := range mappingListSchemasSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_task_run_logs_request_response.go
+++ b/dataintegration/list_task_run_logs_request_response.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListTaskRunLogsRequest wrapper for the ListTaskRunLogs operation
+type ListTaskRunLogsRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS application key
+	ApplicationKey *string `mandatory:"true" contributesTo:"path" name:"applicationKey"`
+
+	// DIS taskRun key
+	TaskRunKey *string `mandatory:"true" contributesTo:"path" name:"taskRunKey"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListTaskRunLogsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListTaskRunLogsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListTaskRunLogsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListTaskRunLogsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListTaskRunLogsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListTaskRunLogsResponse wrapper for the ListTaskRunLogs operation
+type ListTaskRunLogsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []TaskRunLogSummary instances
+	Items []TaskRunLogSummary `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+
+	// Total items in the entire list.
+	OpcTotalItems *int `presentIn:"header" name:"opc-total-items"`
+}
+
+func (response ListTaskRunLogsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListTaskRunLogsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListTaskRunLogsSortOrderEnum Enum with underlying type: string
+type ListTaskRunLogsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListTaskRunLogsSortOrderEnum
+const (
+	ListTaskRunLogsSortOrderAsc  ListTaskRunLogsSortOrderEnum = "ASC"
+	ListTaskRunLogsSortOrderDesc ListTaskRunLogsSortOrderEnum = "DESC"
+)
+
+var mappingListTaskRunLogsSortOrder = map[string]ListTaskRunLogsSortOrderEnum{
+	"ASC":  ListTaskRunLogsSortOrderAsc,
+	"DESC": ListTaskRunLogsSortOrderDesc,
+}
+
+// GetListTaskRunLogsSortOrderEnumValues Enumerates the set of values for ListTaskRunLogsSortOrderEnum
+func GetListTaskRunLogsSortOrderEnumValues() []ListTaskRunLogsSortOrderEnum {
+	values := make([]ListTaskRunLogsSortOrderEnum, 0)
+	for _, v := range mappingListTaskRunLogsSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListTaskRunLogsSortByEnum Enum with underlying type: string
+type ListTaskRunLogsSortByEnum string
+
+// Set of constants representing the allowable values for ListTaskRunLogsSortByEnum
+const (
+	ListTaskRunLogsSortByTimeCreated ListTaskRunLogsSortByEnum = "TIME_CREATED"
+	ListTaskRunLogsSortByDisplayName ListTaskRunLogsSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListTaskRunLogsSortBy = map[string]ListTaskRunLogsSortByEnum{
+	"TIME_CREATED": ListTaskRunLogsSortByTimeCreated,
+	"DISPLAY_NAME": ListTaskRunLogsSortByDisplayName,
+}
+
+// GetListTaskRunLogsSortByEnumValues Enumerates the set of values for ListTaskRunLogsSortByEnum
+func GetListTaskRunLogsSortByEnumValues() []ListTaskRunLogsSortByEnum {
+	values := make([]ListTaskRunLogsSortByEnum, 0)
+	for _, v := range mappingListTaskRunLogsSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_task_runs_request_response.go
+++ b/dataintegration/list_task_runs_request_response.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListTaskRunsRequest wrapper for the ListTaskRuns operation
+type ListTaskRunsRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS application key
+	ApplicationKey *string `mandatory:"true" contributesTo:"path" name:"applicationKey"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// This parameter allows users to specify which fields to get for an object.
+	Fields []string `contributesTo:"query" name:"fields" collectionFormat:"multi"`
+
+	// This filter parameter can be used to filter by the name of the object.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// This filter parameter can be used to filter by the identifier of the object.
+	Identifier []string `contributesTo:"query" name:"identifier" collectionFormat:"multi"`
+
+	// This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListTaskRunsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListTaskRunsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListTaskRunsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListTaskRunsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListTaskRunsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListTaskRunsResponse wrapper for the ListTaskRuns operation
+type ListTaskRunsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of TaskRunSummaryCollection instances
+	TaskRunSummaryCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+
+	// Total items in the entire list.
+	OpcTotalItems *int `presentIn:"header" name:"opc-total-items"`
+}
+
+func (response ListTaskRunsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListTaskRunsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListTaskRunsSortOrderEnum Enum with underlying type: string
+type ListTaskRunsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListTaskRunsSortOrderEnum
+const (
+	ListTaskRunsSortOrderAsc  ListTaskRunsSortOrderEnum = "ASC"
+	ListTaskRunsSortOrderDesc ListTaskRunsSortOrderEnum = "DESC"
+)
+
+var mappingListTaskRunsSortOrder = map[string]ListTaskRunsSortOrderEnum{
+	"ASC":  ListTaskRunsSortOrderAsc,
+	"DESC": ListTaskRunsSortOrderDesc,
+}
+
+// GetListTaskRunsSortOrderEnumValues Enumerates the set of values for ListTaskRunsSortOrderEnum
+func GetListTaskRunsSortOrderEnumValues() []ListTaskRunsSortOrderEnum {
+	values := make([]ListTaskRunsSortOrderEnum, 0)
+	for _, v := range mappingListTaskRunsSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListTaskRunsSortByEnum Enum with underlying type: string
+type ListTaskRunsSortByEnum string
+
+// Set of constants representing the allowable values for ListTaskRunsSortByEnum
+const (
+	ListTaskRunsSortByTimeCreated ListTaskRunsSortByEnum = "TIME_CREATED"
+	ListTaskRunsSortByDisplayName ListTaskRunsSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListTaskRunsSortBy = map[string]ListTaskRunsSortByEnum{
+	"TIME_CREATED": ListTaskRunsSortByTimeCreated,
+	"DISPLAY_NAME": ListTaskRunsSortByDisplayName,
+}
+
+// GetListTaskRunsSortByEnumValues Enumerates the set of values for ListTaskRunsSortByEnum
+func GetListTaskRunsSortByEnumValues() []ListTaskRunsSortByEnum {
+	values := make([]ListTaskRunsSortByEnum, 0)
+	for _, v := range mappingListTaskRunsSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_task_validations_request_response.go
+++ b/dataintegration/list_task_validations_request_response.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListTaskValidationsRequest wrapper for the ListTaskValidations operation
+type ListTaskValidationsRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// This filter parameter can be used to filter by the key of the object.
+	Key *string `mandatory:"false" contributesTo:"query" name:"key"`
+
+	// This filter parameter can be used to filter by the name of the object.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// This filter parameter can be used to filter by the identifier of the object.
+	Identifier *string `mandatory:"false" contributesTo:"query" name:"identifier"`
+
+	// This parameter allows users to specify which fields to get for an object.
+	Fields []string `contributesTo:"query" name:"fields" collectionFormat:"multi"`
+
+	// This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListTaskValidationsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListTaskValidationsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListTaskValidationsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListTaskValidationsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListTaskValidationsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListTaskValidationsResponse wrapper for the ListTaskValidations operation
+type ListTaskValidationsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of TaskValidationSummaryCollection instances
+	TaskValidationSummaryCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+
+	// Total items in the entire list.
+	OpcTotalItems *int `presentIn:"header" name:"opc-total-items"`
+}
+
+func (response ListTaskValidationsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListTaskValidationsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListTaskValidationsSortByEnum Enum with underlying type: string
+type ListTaskValidationsSortByEnum string
+
+// Set of constants representing the allowable values for ListTaskValidationsSortByEnum
+const (
+	ListTaskValidationsSortByTimeCreated ListTaskValidationsSortByEnum = "TIME_CREATED"
+	ListTaskValidationsSortByDisplayName ListTaskValidationsSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListTaskValidationsSortBy = map[string]ListTaskValidationsSortByEnum{
+	"TIME_CREATED": ListTaskValidationsSortByTimeCreated,
+	"DISPLAY_NAME": ListTaskValidationsSortByDisplayName,
+}
+
+// GetListTaskValidationsSortByEnumValues Enumerates the set of values for ListTaskValidationsSortByEnum
+func GetListTaskValidationsSortByEnumValues() []ListTaskValidationsSortByEnum {
+	values := make([]ListTaskValidationsSortByEnum, 0)
+	for _, v := range mappingListTaskValidationsSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListTaskValidationsSortOrderEnum Enum with underlying type: string
+type ListTaskValidationsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListTaskValidationsSortOrderEnum
+const (
+	ListTaskValidationsSortOrderAsc  ListTaskValidationsSortOrderEnum = "ASC"
+	ListTaskValidationsSortOrderDesc ListTaskValidationsSortOrderEnum = "DESC"
+)
+
+var mappingListTaskValidationsSortOrder = map[string]ListTaskValidationsSortOrderEnum{
+	"ASC":  ListTaskValidationsSortOrderAsc,
+	"DESC": ListTaskValidationsSortOrderDesc,
+}
+
+// GetListTaskValidationsSortOrderEnumValues Enumerates the set of values for ListTaskValidationsSortOrderEnum
+func GetListTaskValidationsSortOrderEnumValues() []ListTaskValidationsSortOrderEnum {
+	values := make([]ListTaskValidationsSortOrderEnum, 0)
+	for _, v := range mappingListTaskValidationsSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_tasks_request_response.go
+++ b/dataintegration/list_tasks_request_response.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListTasksRequest wrapper for the ListTasks operation
+type ListTasksRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Unique key of the folder
+	FolderId *string `mandatory:"false" contributesTo:"query" name:"folderId"`
+
+	// This parameter allows users to specify which fields to get for an object.
+	Fields []string `contributesTo:"query" name:"fields" collectionFormat:"multi"`
+
+	// This filter parameter can be used to filter by the name of the object.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// This filter parameter can be used to filter by the key of the object.
+	Key []string `contributesTo:"query" name:"key" collectionFormat:"multi"`
+
+	// This filter parameter can be used to filter by the identifier of the object.
+	Identifier []string `contributesTo:"query" name:"identifier" collectionFormat:"multi"`
+
+	// This filter parameter can be used to filter by the object type of the object. This parameter can be suffixed with an optional filter operator InSubtree. If this operator is not specified, then exact match is considered. <br><br><B>Examples:-</B><br> <ul> <li><B>?type=DATA_LOADER_TASK&typeInSubtree=false</B> returns all objects of type data loader task</li> <li><B>?type=DATA_LOADER_TASK</B> returns all objects of type data loader task</li> <li><B>?type=DATA_LOADER_TASK&typeInSubtree=true</B> returns all objects of type data loader task</li> </ul>
+	Type []string `contributesTo:"query" name:"type" collectionFormat:"multi"`
+
+	// This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListTasksSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListTasksSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListTasksRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListTasksRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListTasksRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListTasksResponse wrapper for the ListTasks operation
+type ListTasksResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of TaskSummaryCollection instances
+	TaskSummaryCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+
+	// Total items in the entire list.
+	OpcTotalItems *int `presentIn:"header" name:"opc-total-items"`
+}
+
+func (response ListTasksResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListTasksResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListTasksSortOrderEnum Enum with underlying type: string
+type ListTasksSortOrderEnum string
+
+// Set of constants representing the allowable values for ListTasksSortOrderEnum
+const (
+	ListTasksSortOrderAsc  ListTasksSortOrderEnum = "ASC"
+	ListTasksSortOrderDesc ListTasksSortOrderEnum = "DESC"
+)
+
+var mappingListTasksSortOrder = map[string]ListTasksSortOrderEnum{
+	"ASC":  ListTasksSortOrderAsc,
+	"DESC": ListTasksSortOrderDesc,
+}
+
+// GetListTasksSortOrderEnumValues Enumerates the set of values for ListTasksSortOrderEnum
+func GetListTasksSortOrderEnumValues() []ListTasksSortOrderEnum {
+	values := make([]ListTasksSortOrderEnum, 0)
+	for _, v := range mappingListTasksSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListTasksSortByEnum Enum with underlying type: string
+type ListTasksSortByEnum string
+
+// Set of constants representing the allowable values for ListTasksSortByEnum
+const (
+	ListTasksSortByTimeCreated ListTasksSortByEnum = "TIME_CREATED"
+	ListTasksSortByDisplayName ListTasksSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListTasksSortBy = map[string]ListTasksSortByEnum{
+	"TIME_CREATED": ListTasksSortByTimeCreated,
+	"DISPLAY_NAME": ListTasksSortByDisplayName,
+}
+
+// GetListTasksSortByEnumValues Enumerates the set of values for ListTasksSortByEnum
+func GetListTasksSortByEnumValues() []ListTasksSortByEnum {
+	values := make([]ListTasksSortByEnum, 0)
+	for _, v := range mappingListTasksSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_work_request_errors_request_response.go
+++ b/dataintegration/list_work_request_errors_request_response.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListWorkRequestErrorsRequest wrapper for the ListWorkRequestErrors operation
+type ListWorkRequestErrorsRequest struct {
+
+	// The ID of the asynchronous request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListWorkRequestErrorsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListWorkRequestErrorsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListWorkRequestErrorsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListWorkRequestErrorsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListWorkRequestErrorsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListWorkRequestErrorsResponse wrapper for the ListWorkRequestErrors operation
+type ListWorkRequestErrorsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []WorkRequestError instances
+	Items []WorkRequestError `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListWorkRequestErrorsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListWorkRequestErrorsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListWorkRequestErrorsSortOrderEnum Enum with underlying type: string
+type ListWorkRequestErrorsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListWorkRequestErrorsSortOrderEnum
+const (
+	ListWorkRequestErrorsSortOrderAsc  ListWorkRequestErrorsSortOrderEnum = "ASC"
+	ListWorkRequestErrorsSortOrderDesc ListWorkRequestErrorsSortOrderEnum = "DESC"
+)
+
+var mappingListWorkRequestErrorsSortOrder = map[string]ListWorkRequestErrorsSortOrderEnum{
+	"ASC":  ListWorkRequestErrorsSortOrderAsc,
+	"DESC": ListWorkRequestErrorsSortOrderDesc,
+}
+
+// GetListWorkRequestErrorsSortOrderEnumValues Enumerates the set of values for ListWorkRequestErrorsSortOrderEnum
+func GetListWorkRequestErrorsSortOrderEnumValues() []ListWorkRequestErrorsSortOrderEnum {
+	values := make([]ListWorkRequestErrorsSortOrderEnum, 0)
+	for _, v := range mappingListWorkRequestErrorsSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListWorkRequestErrorsSortByEnum Enum with underlying type: string
+type ListWorkRequestErrorsSortByEnum string
+
+// Set of constants representing the allowable values for ListWorkRequestErrorsSortByEnum
+const (
+	ListWorkRequestErrorsSortByTimeCreated ListWorkRequestErrorsSortByEnum = "TIME_CREATED"
+	ListWorkRequestErrorsSortByDisplayName ListWorkRequestErrorsSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListWorkRequestErrorsSortBy = map[string]ListWorkRequestErrorsSortByEnum{
+	"TIME_CREATED": ListWorkRequestErrorsSortByTimeCreated,
+	"DISPLAY_NAME": ListWorkRequestErrorsSortByDisplayName,
+}
+
+// GetListWorkRequestErrorsSortByEnumValues Enumerates the set of values for ListWorkRequestErrorsSortByEnum
+func GetListWorkRequestErrorsSortByEnumValues() []ListWorkRequestErrorsSortByEnum {
+	values := make([]ListWorkRequestErrorsSortByEnum, 0)
+	for _, v := range mappingListWorkRequestErrorsSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_work_request_logs_request_response.go
+++ b/dataintegration/list_work_request_logs_request_response.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListWorkRequestLogsRequest wrapper for the ListWorkRequestLogs operation
+type ListWorkRequestLogsRequest struct {
+
+	// The ID of the asynchronous request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListWorkRequestLogsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListWorkRequestLogsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListWorkRequestLogsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListWorkRequestLogsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListWorkRequestLogsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListWorkRequestLogsResponse wrapper for the ListWorkRequestLogs operation
+type ListWorkRequestLogsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []WorkRequestLogEntry instances
+	Items []WorkRequestLogEntry `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListWorkRequestLogsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListWorkRequestLogsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListWorkRequestLogsSortOrderEnum Enum with underlying type: string
+type ListWorkRequestLogsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListWorkRequestLogsSortOrderEnum
+const (
+	ListWorkRequestLogsSortOrderAsc  ListWorkRequestLogsSortOrderEnum = "ASC"
+	ListWorkRequestLogsSortOrderDesc ListWorkRequestLogsSortOrderEnum = "DESC"
+)
+
+var mappingListWorkRequestLogsSortOrder = map[string]ListWorkRequestLogsSortOrderEnum{
+	"ASC":  ListWorkRequestLogsSortOrderAsc,
+	"DESC": ListWorkRequestLogsSortOrderDesc,
+}
+
+// GetListWorkRequestLogsSortOrderEnumValues Enumerates the set of values for ListWorkRequestLogsSortOrderEnum
+func GetListWorkRequestLogsSortOrderEnumValues() []ListWorkRequestLogsSortOrderEnum {
+	values := make([]ListWorkRequestLogsSortOrderEnum, 0)
+	for _, v := range mappingListWorkRequestLogsSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListWorkRequestLogsSortByEnum Enum with underlying type: string
+type ListWorkRequestLogsSortByEnum string
+
+// Set of constants representing the allowable values for ListWorkRequestLogsSortByEnum
+const (
+	ListWorkRequestLogsSortByTimeCreated ListWorkRequestLogsSortByEnum = "TIME_CREATED"
+	ListWorkRequestLogsSortByDisplayName ListWorkRequestLogsSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListWorkRequestLogsSortBy = map[string]ListWorkRequestLogsSortByEnum{
+	"TIME_CREATED": ListWorkRequestLogsSortByTimeCreated,
+	"DISPLAY_NAME": ListWorkRequestLogsSortByDisplayName,
+}
+
+// GetListWorkRequestLogsSortByEnumValues Enumerates the set of values for ListWorkRequestLogsSortByEnum
+func GetListWorkRequestLogsSortByEnumValues() []ListWorkRequestLogsSortByEnum {
+	values := make([]ListWorkRequestLogsSortByEnum, 0)
+	for _, v := range mappingListWorkRequestLogsSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_work_requests_request_response.go
+++ b/dataintegration/list_work_requests_request_response.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListWorkRequestsRequest wrapper for the ListWorkRequests operation
+type ListWorkRequestsRequest struct {
+
+	// The ID of the compartment in which to list resources.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Work Request status.
+	WorkRequestStatus ListWorkRequestsWorkRequestStatusEnum `mandatory:"false" contributesTo:"query" name:"workRequestStatus" omitEmpty:"true"`
+
+	// This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListWorkRequestsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListWorkRequestsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListWorkRequestsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListWorkRequestsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListWorkRequestsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListWorkRequestsResponse wrapper for the ListWorkRequests operation
+type ListWorkRequestsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []WorkRequestSummary instances
+	Items []WorkRequestSummary `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListWorkRequestsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListWorkRequestsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListWorkRequestsWorkRequestStatusEnum Enum with underlying type: string
+type ListWorkRequestsWorkRequestStatusEnum string
+
+// Set of constants representing the allowable values for ListWorkRequestsWorkRequestStatusEnum
+const (
+	ListWorkRequestsWorkRequestStatusAccepted   ListWorkRequestsWorkRequestStatusEnum = "ACCEPTED"
+	ListWorkRequestsWorkRequestStatusInProgress ListWorkRequestsWorkRequestStatusEnum = "IN_PROGRESS"
+	ListWorkRequestsWorkRequestStatusFailed     ListWorkRequestsWorkRequestStatusEnum = "FAILED"
+	ListWorkRequestsWorkRequestStatusSucceeded  ListWorkRequestsWorkRequestStatusEnum = "SUCCEEDED"
+	ListWorkRequestsWorkRequestStatusCanceling  ListWorkRequestsWorkRequestStatusEnum = "CANCELING"
+	ListWorkRequestsWorkRequestStatusCanceled   ListWorkRequestsWorkRequestStatusEnum = "CANCELED"
+)
+
+var mappingListWorkRequestsWorkRequestStatus = map[string]ListWorkRequestsWorkRequestStatusEnum{
+	"ACCEPTED":    ListWorkRequestsWorkRequestStatusAccepted,
+	"IN_PROGRESS": ListWorkRequestsWorkRequestStatusInProgress,
+	"FAILED":      ListWorkRequestsWorkRequestStatusFailed,
+	"SUCCEEDED":   ListWorkRequestsWorkRequestStatusSucceeded,
+	"CANCELING":   ListWorkRequestsWorkRequestStatusCanceling,
+	"CANCELED":    ListWorkRequestsWorkRequestStatusCanceled,
+}
+
+// GetListWorkRequestsWorkRequestStatusEnumValues Enumerates the set of values for ListWorkRequestsWorkRequestStatusEnum
+func GetListWorkRequestsWorkRequestStatusEnumValues() []ListWorkRequestsWorkRequestStatusEnum {
+	values := make([]ListWorkRequestsWorkRequestStatusEnum, 0)
+	for _, v := range mappingListWorkRequestsWorkRequestStatus {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListWorkRequestsSortOrderEnum Enum with underlying type: string
+type ListWorkRequestsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListWorkRequestsSortOrderEnum
+const (
+	ListWorkRequestsSortOrderAsc  ListWorkRequestsSortOrderEnum = "ASC"
+	ListWorkRequestsSortOrderDesc ListWorkRequestsSortOrderEnum = "DESC"
+)
+
+var mappingListWorkRequestsSortOrder = map[string]ListWorkRequestsSortOrderEnum{
+	"ASC":  ListWorkRequestsSortOrderAsc,
+	"DESC": ListWorkRequestsSortOrderDesc,
+}
+
+// GetListWorkRequestsSortOrderEnumValues Enumerates the set of values for ListWorkRequestsSortOrderEnum
+func GetListWorkRequestsSortOrderEnumValues() []ListWorkRequestsSortOrderEnum {
+	values := make([]ListWorkRequestsSortOrderEnum, 0)
+	for _, v := range mappingListWorkRequestsSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListWorkRequestsSortByEnum Enum with underlying type: string
+type ListWorkRequestsSortByEnum string
+
+// Set of constants representing the allowable values for ListWorkRequestsSortByEnum
+const (
+	ListWorkRequestsSortByTimeCreated ListWorkRequestsSortByEnum = "TIME_CREATED"
+	ListWorkRequestsSortByDisplayName ListWorkRequestsSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListWorkRequestsSortBy = map[string]ListWorkRequestsSortByEnum{
+	"TIME_CREATED": ListWorkRequestsSortByTimeCreated,
+	"DISPLAY_NAME": ListWorkRequestsSortByDisplayName,
+}
+
+// GetListWorkRequestsSortByEnumValues Enumerates the set of values for ListWorkRequestsSortByEnum
+func GetListWorkRequestsSortByEnumValues() []ListWorkRequestsSortByEnum {
+	values := make([]ListWorkRequestsSortByEnum, 0)
+	for _, v := range mappingListWorkRequestsSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/list_workspaces_request_response.go
+++ b/dataintegration/list_workspaces_request_response.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListWorkspacesRequest wrapper for the ListWorkspaces operation
+type ListWorkspacesRequest struct {
+
+	// The ID of the compartment in which to list resources.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// This filter parameter can be used to filter by the name of the object.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// This parameter allows users to set the maximum number of items to return per page.  The value must be between 1 and 100 (inclusive).  Default value is 100.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// This parameter will control pagination.  Values for the parameter should come from the `opc-next-page` or `opc-prev-page` header in previous response.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// Lifecycle state of the resource.
+	LifecycleState WorkspaceLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+
+	// This parameter is used to control the sort order.  Supported values are `ASC` (ascending) and `DESC` (descending).
+	SortOrder ListWorkspacesSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// This parameter allows users to specify a sort field.  Supported sort fields are `name`, `identifier`, `timeCreated`, and `timeUpdated`.  Default sort order is the descending order of `timeCreated` (most recently created objects at the top).  Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+	SortBy ListWorkspacesSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListWorkspacesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListWorkspacesRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListWorkspacesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListWorkspacesResponse wrapper for the ListWorkspaces operation
+type ListWorkspacesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []WorkspaceSummary instances
+	Items []WorkspaceSummary `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListWorkspacesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListWorkspacesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListWorkspacesSortOrderEnum Enum with underlying type: string
+type ListWorkspacesSortOrderEnum string
+
+// Set of constants representing the allowable values for ListWorkspacesSortOrderEnum
+const (
+	ListWorkspacesSortOrderAsc  ListWorkspacesSortOrderEnum = "ASC"
+	ListWorkspacesSortOrderDesc ListWorkspacesSortOrderEnum = "DESC"
+)
+
+var mappingListWorkspacesSortOrder = map[string]ListWorkspacesSortOrderEnum{
+	"ASC":  ListWorkspacesSortOrderAsc,
+	"DESC": ListWorkspacesSortOrderDesc,
+}
+
+// GetListWorkspacesSortOrderEnumValues Enumerates the set of values for ListWorkspacesSortOrderEnum
+func GetListWorkspacesSortOrderEnumValues() []ListWorkspacesSortOrderEnum {
+	values := make([]ListWorkspacesSortOrderEnum, 0)
+	for _, v := range mappingListWorkspacesSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListWorkspacesSortByEnum Enum with underlying type: string
+type ListWorkspacesSortByEnum string
+
+// Set of constants representing the allowable values for ListWorkspacesSortByEnum
+const (
+	ListWorkspacesSortByTimeCreated ListWorkspacesSortByEnum = "TIME_CREATED"
+	ListWorkspacesSortByDisplayName ListWorkspacesSortByEnum = "DISPLAY_NAME"
+)
+
+var mappingListWorkspacesSortBy = map[string]ListWorkspacesSortByEnum{
+	"TIME_CREATED": ListWorkspacesSortByTimeCreated,
+	"DISPLAY_NAME": ListWorkspacesSortByDisplayName,
+}
+
+// GetListWorkspacesSortByEnumValues Enumerates the set of values for ListWorkspacesSortByEnum
+func GetListWorkspacesSortByEnumValues() []ListWorkspacesSortByEnum {
+	values := make([]ListWorkspacesSortByEnum, 0)
+	for _, v := range mappingListWorkspacesSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/message.go
+++ b/dataintegration/message.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Message The details of a message.
+type Message struct {
+
+	// The type of message (error, warning, or info).
+	Type MessageTypeEnum `mandatory:"true" json:"type"`
+
+	// The message code
+	Code *string `mandatory:"true" json:"code"`
+
+	// The message text
+	Message *string `mandatory:"true" json:"message"`
+}
+
+func (m Message) String() string {
+	return common.PointerString(m)
+}
+
+// MessageTypeEnum Enum with underlying type: string
+type MessageTypeEnum string
+
+// Set of constants representing the allowable values for MessageTypeEnum
+const (
+	MessageTypeError   MessageTypeEnum = "ERROR"
+	MessageTypeWarning MessageTypeEnum = "WARNING"
+	MessageTypeInfo    MessageTypeEnum = "INFO"
+)
+
+var mappingMessageType = map[string]MessageTypeEnum{
+	"ERROR":   MessageTypeError,
+	"WARNING": MessageTypeWarning,
+	"INFO":    MessageTypeInfo,
+}
+
+// GetMessageTypeEnumValues Enumerates the set of values for MessageTypeEnum
+func GetMessageTypeEnumValues() []MessageTypeEnum {
+	values := make([]MessageTypeEnum, 0)
+	for _, v := range mappingMessageType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/model_select.go
+++ b/dataintegration/model_select.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ModelSelect The information about the select object.
+type ModelSelect struct {
+
+	// Specifies whether the object is distinct.
+	IsDistinct *bool `mandatory:"false" json:"isDistinct"`
+
+	// An array of selected columns.
+	SelectColumns []ShapeField `mandatory:"false" json:"selectColumns"`
+}
+
+func (m ModelSelect) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ModelSelect) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeModelSelect ModelSelect
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeModelSelect
+	}{
+		"SELECT",
+		(MarshalTypeModelSelect)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/name_list_rule.go
+++ b/dataintegration/name_list_rule.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// NameListRule The name list rule which defines how fields are projected. For example this may be all fields begining with STR.
+type NameListRule struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Specifies whether the rule uses a java regex syntax.
+	IsJavaRegexSyntax *bool `mandatory:"false" json:"isJavaRegexSyntax"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// skipRemainingRulesOnMatch
+	IsSkipRemainingRulesOnMatch *bool `mandatory:"false" json:"isSkipRemainingRulesOnMatch"`
+
+	// Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a TypedObject or a full TypedObject definition.
+	Scope *interface{} `mandatory:"false" json:"scope"`
+
+	// cascade
+	IsCascade *bool `mandatory:"false" json:"isCascade"`
+
+	// caseSensitive
+	IsCaseSensitive *bool `mandatory:"false" json:"isCaseSensitive"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Names []string `mandatory:"false" json:"names"`
+
+	// matchingStrategy
+	MatchingStrategy NameListRuleMatchingStrategyEnum `mandatory:"false" json:"matchingStrategy,omitempty"`
+
+	// ruleType
+	RuleType NameListRuleRuleTypeEnum `mandatory:"false" json:"ruleType,omitempty"`
+}
+
+//GetKey returns Key
+func (m NameListRule) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m NameListRule) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m NameListRule) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetIsJavaRegexSyntax returns IsJavaRegexSyntax
+func (m NameListRule) GetIsJavaRegexSyntax() *bool {
+	return m.IsJavaRegexSyntax
+}
+
+//GetConfigValues returns ConfigValues
+func (m NameListRule) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m NameListRule) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetDescription returns Description
+func (m NameListRule) GetDescription() *string {
+	return m.Description
+}
+
+func (m NameListRule) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m NameListRule) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeNameListRule NameListRule
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeNameListRule
+	}{
+		"NAME_LIST_RULE",
+		(MarshalTypeNameListRule)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// NameListRuleMatchingStrategyEnum Enum with underlying type: string
+type NameListRuleMatchingStrategyEnum string
+
+// Set of constants representing the allowable values for NameListRuleMatchingStrategyEnum
+const (
+	NameListRuleMatchingStrategyNameOrTags NameListRuleMatchingStrategyEnum = "NAME_OR_TAGS"
+	NameListRuleMatchingStrategyTagsOnly   NameListRuleMatchingStrategyEnum = "TAGS_ONLY"
+	NameListRuleMatchingStrategyNameOnly   NameListRuleMatchingStrategyEnum = "NAME_ONLY"
+)
+
+var mappingNameListRuleMatchingStrategy = map[string]NameListRuleMatchingStrategyEnum{
+	"NAME_OR_TAGS": NameListRuleMatchingStrategyNameOrTags,
+	"TAGS_ONLY":    NameListRuleMatchingStrategyTagsOnly,
+	"NAME_ONLY":    NameListRuleMatchingStrategyNameOnly,
+}
+
+// GetNameListRuleMatchingStrategyEnumValues Enumerates the set of values for NameListRuleMatchingStrategyEnum
+func GetNameListRuleMatchingStrategyEnumValues() []NameListRuleMatchingStrategyEnum {
+	values := make([]NameListRuleMatchingStrategyEnum, 0)
+	for _, v := range mappingNameListRuleMatchingStrategy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// NameListRuleRuleTypeEnum Enum with underlying type: string
+type NameListRuleRuleTypeEnum string
+
+// Set of constants representing the allowable values for NameListRuleRuleTypeEnum
+const (
+	NameListRuleRuleTypeInclude NameListRuleRuleTypeEnum = "INCLUDE"
+	NameListRuleRuleTypeExclude NameListRuleRuleTypeEnum = "EXCLUDE"
+)
+
+var mappingNameListRuleRuleType = map[string]NameListRuleRuleTypeEnum{
+	"INCLUDE": NameListRuleRuleTypeInclude,
+	"EXCLUDE": NameListRuleRuleTypeExclude,
+}
+
+// GetNameListRuleRuleTypeEnumValues Enumerates the set of values for NameListRuleRuleTypeEnum
+func GetNameListRuleRuleTypeEnumValues() []NameListRuleRuleTypeEnum {
+	values := make([]NameListRuleRuleTypeEnum, 0)
+	for _, v := range mappingNameListRuleRuleType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/name_pattern_rule.go
+++ b/dataintegration/name_pattern_rule.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// NamePatternRule This rule projects fields by a name pattern, for example it may start with STR_ or end with _DATE, this is defined using a regular expression.
+type NamePatternRule struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Specifies whether the rule uses a java regex syntax.
+	IsJavaRegexSyntax *bool `mandatory:"false" json:"isJavaRegexSyntax"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// skipRemainingRulesOnMatch
+	IsSkipRemainingRulesOnMatch *bool `mandatory:"false" json:"isSkipRemainingRulesOnMatch"`
+
+	// Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a TypedObject or a full TypedObject definition.
+	Scope *interface{} `mandatory:"false" json:"scope"`
+
+	// cascade
+	IsCascade *bool `mandatory:"false" json:"isCascade"`
+
+	// caseSensitive
+	IsCaseSensitive *bool `mandatory:"false" json:"isCaseSensitive"`
+
+	// pattern
+	Pattern *string `mandatory:"false" json:"pattern"`
+
+	// matchingStrategy
+	MatchingStrategy NamePatternRuleMatchingStrategyEnum `mandatory:"false" json:"matchingStrategy,omitempty"`
+
+	// ruleType
+	RuleType NamePatternRuleRuleTypeEnum `mandatory:"false" json:"ruleType,omitempty"`
+}
+
+//GetKey returns Key
+func (m NamePatternRule) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m NamePatternRule) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m NamePatternRule) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetIsJavaRegexSyntax returns IsJavaRegexSyntax
+func (m NamePatternRule) GetIsJavaRegexSyntax() *bool {
+	return m.IsJavaRegexSyntax
+}
+
+//GetConfigValues returns ConfigValues
+func (m NamePatternRule) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m NamePatternRule) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetDescription returns Description
+func (m NamePatternRule) GetDescription() *string {
+	return m.Description
+}
+
+func (m NamePatternRule) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m NamePatternRule) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeNamePatternRule NamePatternRule
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeNamePatternRule
+	}{
+		"NAME_PATTERN_RULE",
+		(MarshalTypeNamePatternRule)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// NamePatternRuleMatchingStrategyEnum Enum with underlying type: string
+type NamePatternRuleMatchingStrategyEnum string
+
+// Set of constants representing the allowable values for NamePatternRuleMatchingStrategyEnum
+const (
+	NamePatternRuleMatchingStrategyNameOrTags NamePatternRuleMatchingStrategyEnum = "NAME_OR_TAGS"
+	NamePatternRuleMatchingStrategyTagsOnly   NamePatternRuleMatchingStrategyEnum = "TAGS_ONLY"
+	NamePatternRuleMatchingStrategyNameOnly   NamePatternRuleMatchingStrategyEnum = "NAME_ONLY"
+)
+
+var mappingNamePatternRuleMatchingStrategy = map[string]NamePatternRuleMatchingStrategyEnum{
+	"NAME_OR_TAGS": NamePatternRuleMatchingStrategyNameOrTags,
+	"TAGS_ONLY":    NamePatternRuleMatchingStrategyTagsOnly,
+	"NAME_ONLY":    NamePatternRuleMatchingStrategyNameOnly,
+}
+
+// GetNamePatternRuleMatchingStrategyEnumValues Enumerates the set of values for NamePatternRuleMatchingStrategyEnum
+func GetNamePatternRuleMatchingStrategyEnumValues() []NamePatternRuleMatchingStrategyEnum {
+	values := make([]NamePatternRuleMatchingStrategyEnum, 0)
+	for _, v := range mappingNamePatternRuleMatchingStrategy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// NamePatternRuleRuleTypeEnum Enum with underlying type: string
+type NamePatternRuleRuleTypeEnum string
+
+// Set of constants representing the allowable values for NamePatternRuleRuleTypeEnum
+const (
+	NamePatternRuleRuleTypeInclude NamePatternRuleRuleTypeEnum = "INCLUDE"
+	NamePatternRuleRuleTypeExclude NamePatternRuleRuleTypeEnum = "EXCLUDE"
+)
+
+var mappingNamePatternRuleRuleType = map[string]NamePatternRuleRuleTypeEnum{
+	"INCLUDE": NamePatternRuleRuleTypeInclude,
+	"EXCLUDE": NamePatternRuleRuleTypeExclude,
+}
+
+// GetNamePatternRuleRuleTypeEnumValues Enumerates the set of values for NamePatternRuleRuleTypeEnum
+func GetNamePatternRuleRuleTypeEnumValues() []NamePatternRuleRuleTypeEnum {
+	values := make([]NamePatternRuleRuleTypeEnum, 0)
+	for _, v := range mappingNamePatternRuleRuleType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/native_shape_field.go
+++ b/dataintegration/native_shape_field.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// NativeShapeField The native shape field object.
+type NativeShapeField struct {
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// The model type reference.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The type reference.
+	Type *string `mandatory:"false" json:"type"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The position of the attribute.
+	Position *int `mandatory:"false" json:"position"`
+
+	// The default value.
+	DefaultValueString *string `mandatory:"false" json:"defaultValueString"`
+
+	// Specifies whether the field is mandatory.
+	IsMandatory *bool `mandatory:"false" json:"isMandatory"`
+}
+
+func (m NativeShapeField) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/object_metadata.go
+++ b/dataintegration/object_metadata.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ObjectMetadata A summary type containing information about the object including its key, name and when/who created/updated it
+type ObjectMetadata struct {
+
+	// The user that created the object.
+	CreatedBy *string `mandatory:"false" json:"createdBy"`
+
+	// The user that created the object.
+	CreatedByName *string `mandatory:"false" json:"createdByName"`
+
+	// The user that updated the object.
+	UpdatedBy *string `mandatory:"false" json:"updatedBy"`
+
+	// The user that updated the object.
+	UpdatedByName *string `mandatory:"false" json:"updatedByName"`
+
+	// The date and time that the object was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The date and time that the object was updated.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// The owning object key for this object.
+	AggregatorKey *string `mandatory:"false" json:"aggregatorKey"`
+
+	// The full path to identify this object.
+	IdentifierPath *string `mandatory:"false" json:"identifierPath"`
+
+	// infoFields
+	InfoFields map[string]string `mandatory:"false" json:"infoFields"`
+
+	// registryVersion
+	RegistryVersion *int `mandatory:"false" json:"registryVersion"`
+
+	// Labels are keywords or tags that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+	Labels []string `mandatory:"false" json:"labels"`
+}
+
+func (m ObjectMetadata) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/operator.go
+++ b/dataintegration/operator.go
@@ -1,0 +1,231 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Operator An operator defines some data integration semantics in a data flow. It may be reading/writing data or transforming the data.
+type Operator interface {
+
+	// The key of the object.
+	GetKey() *string
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	GetParentRef() *ParentReference
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	GetName() *string
+
+	// Detailed description for the object.
+	GetDescription() *string
+
+	// The version of the object that is used to track changes in the object instance.
+	GetObjectVersion() *int
+
+	// An array of input ports.
+	GetInputPorts() []InputPort
+
+	// An array of output ports.
+	GetOutputPorts() []OutputPort
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	GetIdentifier() *string
+
+	// An array of parameters.
+	GetParameters() []Parameter
+
+	GetOpConfigValues() *ConfigValues
+}
+
+type operator struct {
+	JsonData       []byte
+	Key            *string          `mandatory:"false" json:"key"`
+	ModelVersion   *string          `mandatory:"false" json:"modelVersion"`
+	ParentRef      *ParentReference `mandatory:"false" json:"parentRef"`
+	Name           *string          `mandatory:"false" json:"name"`
+	Description    *string          `mandatory:"false" json:"description"`
+	ObjectVersion  *int             `mandatory:"false" json:"objectVersion"`
+	InputPorts     []InputPort      `mandatory:"false" json:"inputPorts"`
+	OutputPorts    []OutputPort     `mandatory:"false" json:"outputPorts"`
+	ObjectStatus   *int             `mandatory:"false" json:"objectStatus"`
+	Identifier     *string          `mandatory:"false" json:"identifier"`
+	Parameters     []Parameter      `mandatory:"false" json:"parameters"`
+	OpConfigValues *ConfigValues    `mandatory:"false" json:"opConfigValues"`
+	ModelType      string           `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *operator) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshaleroperator operator
+	s := struct {
+		Model Unmarshaleroperator
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Key = s.Model.Key
+	m.ModelVersion = s.Model.ModelVersion
+	m.ParentRef = s.Model.ParentRef
+	m.Name = s.Model.Name
+	m.Description = s.Model.Description
+	m.ObjectVersion = s.Model.ObjectVersion
+	m.InputPorts = s.Model.InputPorts
+	m.OutputPorts = s.Model.OutputPorts
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.Identifier = s.Model.Identifier
+	m.Parameters = s.Model.Parameters
+	m.OpConfigValues = s.Model.OpConfigValues
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *operator) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "TARGET_OPERATOR":
+		mm := Target{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "JOINER_OPERATOR":
+		mm := Joiner{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "FILTER_OPERATOR":
+		mm := Filter{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "AGGREGATOR_OPERATOR":
+		mm := Aggregator{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "PROJECTION_OPERATOR":
+		mm := Projection{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "SOURCE_OPERATOR":
+		mm := Source{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetKey returns Key
+func (m operator) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m operator) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m operator) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m operator) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m operator) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m operator) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetInputPorts returns InputPorts
+func (m operator) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m operator) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m operator) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m operator) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetParameters returns Parameters
+func (m operator) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m operator) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+func (m operator) String() string {
+	return common.PointerString(m)
+}
+
+// OperatorModelTypeEnum Enum with underlying type: string
+type OperatorModelTypeEnum string
+
+// Set of constants representing the allowable values for OperatorModelTypeEnum
+const (
+	OperatorModelTypeSourceOperator     OperatorModelTypeEnum = "SOURCE_OPERATOR"
+	OperatorModelTypeFilterOperator     OperatorModelTypeEnum = "FILTER_OPERATOR"
+	OperatorModelTypeJoinerOperator     OperatorModelTypeEnum = "JOINER_OPERATOR"
+	OperatorModelTypeAggregatorOperator OperatorModelTypeEnum = "AGGREGATOR_OPERATOR"
+	OperatorModelTypeProjectionOperator OperatorModelTypeEnum = "PROJECTION_OPERATOR"
+	OperatorModelTypeTargetOperator     OperatorModelTypeEnum = "TARGET_OPERATOR"
+)
+
+var mappingOperatorModelType = map[string]OperatorModelTypeEnum{
+	"SOURCE_OPERATOR":     OperatorModelTypeSourceOperator,
+	"FILTER_OPERATOR":     OperatorModelTypeFilterOperator,
+	"JOINER_OPERATOR":     OperatorModelTypeJoinerOperator,
+	"AGGREGATOR_OPERATOR": OperatorModelTypeAggregatorOperator,
+	"PROJECTION_OPERATOR": OperatorModelTypeProjectionOperator,
+	"TARGET_OPERATOR":     OperatorModelTypeTargetOperator,
+}
+
+// GetOperatorModelTypeEnumValues Enumerates the set of values for OperatorModelTypeEnum
+func GetOperatorModelTypeEnumValues() []OperatorModelTypeEnum {
+	values := make([]OperatorModelTypeEnum, 0)
+	for _, v := range mappingOperatorModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/oracle_adwc_write_attribute.go
+++ b/dataintegration/oracle_adwc_write_attribute.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// OracleAdwcWriteAttribute Properties to configure writing to Oracle Autonomous Data Warehouse Cloud.
+type OracleAdwcWriteAttribute struct {
+
+	// The bucket name for the attribute.
+	BucketName *string `mandatory:"false" json:"bucketName"`
+
+	// The file name for the attribute.
+	StagingFileName *string `mandatory:"false" json:"stagingFileName"`
+
+	StagingDataAsset DataAsset `mandatory:"false" json:"stagingDataAsset"`
+
+	StagingConnection Connection `mandatory:"false" json:"stagingConnection"`
+}
+
+func (m OracleAdwcWriteAttribute) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m OracleAdwcWriteAttribute) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeOracleAdwcWriteAttribute OracleAdwcWriteAttribute
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeOracleAdwcWriteAttribute
+	}{
+		"ORACLEADWCWRITEATTRIBUTE",
+		(MarshalTypeOracleAdwcWriteAttribute)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *OracleAdwcWriteAttribute) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		BucketName        *string    `json:"bucketName"`
+		StagingFileName   *string    `json:"stagingFileName"`
+		StagingDataAsset  dataasset  `json:"stagingDataAsset"`
+		StagingConnection connection `json:"stagingConnection"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.BucketName = model.BucketName
+
+	m.StagingFileName = model.StagingFileName
+
+	nn, e = model.StagingDataAsset.UnmarshalPolymorphicJSON(model.StagingDataAsset.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.StagingDataAsset = nn.(DataAsset)
+	} else {
+		m.StagingDataAsset = nil
+	}
+
+	nn, e = model.StagingConnection.UnmarshalPolymorphicJSON(model.StagingConnection.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.StagingConnection = nn.(Connection)
+	} else {
+		m.StagingConnection = nil
+	}
+	return
+}

--- a/dataintegration/oracle_atp_write_attribute.go
+++ b/dataintegration/oracle_atp_write_attribute.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// OracleAtpWriteAttribute Properties to configure writing to Oracle Autonomous Transaction Processing.
+type OracleAtpWriteAttribute struct {
+
+	// The bucket name for the attribute.
+	BucketName *string `mandatory:"false" json:"bucketName"`
+
+	// The file name for the attribute.
+	StagingFileName *string `mandatory:"false" json:"stagingFileName"`
+
+	StagingDataAsset DataAsset `mandatory:"false" json:"stagingDataAsset"`
+
+	StagingConnection Connection `mandatory:"false" json:"stagingConnection"`
+}
+
+func (m OracleAtpWriteAttribute) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m OracleAtpWriteAttribute) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeOracleAtpWriteAttribute OracleAtpWriteAttribute
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeOracleAtpWriteAttribute
+	}{
+		"ORACLEATPWRITEATTRIBUTE",
+		(MarshalTypeOracleAtpWriteAttribute)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *OracleAtpWriteAttribute) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		BucketName        *string    `json:"bucketName"`
+		StagingFileName   *string    `json:"stagingFileName"`
+		StagingDataAsset  dataasset  `json:"stagingDataAsset"`
+		StagingConnection connection `json:"stagingConnection"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.BucketName = model.BucketName
+
+	m.StagingFileName = model.StagingFileName
+
+	nn, e = model.StagingDataAsset.UnmarshalPolymorphicJSON(model.StagingDataAsset.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.StagingDataAsset = nn.(DataAsset)
+	} else {
+		m.StagingDataAsset = nil
+	}
+
+	nn, e = model.StagingConnection.UnmarshalPolymorphicJSON(model.StagingConnection.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.StagingConnection = nn.(Connection)
+	} else {
+		m.StagingConnection = nil
+	}
+	return
+}

--- a/dataintegration/oracle_read_attribute.go
+++ b/dataintegration/oracle_read_attribute.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// OracleReadAttribute The Oracle read attribute
+type OracleReadAttribute struct {
+
+	// The fetch size for reading.
+	FetchSize *int `mandatory:"false" json:"fetchSize"`
+}
+
+func (m OracleReadAttribute) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m OracleReadAttribute) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeOracleReadAttribute OracleReadAttribute
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeOracleReadAttribute
+	}{
+		"ORACLEREADATTRIBUTE",
+		(MarshalTypeOracleReadAttribute)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/oracle_write_attribute.go
+++ b/dataintegration/oracle_write_attribute.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// OracleWriteAttribute The Oracle write attribute
+type OracleWriteAttribute struct {
+
+	// The batch size for writing.
+	BatchSize *int `mandatory:"false" json:"batchSize"`
+
+	// Specifies whether to truncate.
+	IsTruncate *bool `mandatory:"false" json:"isTruncate"`
+
+	// Specifies the isolation level.
+	IsolationLevel *string `mandatory:"false" json:"isolationLevel"`
+}
+
+func (m OracleWriteAttribute) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m OracleWriteAttribute) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeOracleWriteAttribute OracleWriteAttribute
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeOracleWriteAttribute
+	}{
+		"ORACLEWRITEATTRIBUTE",
+		(MarshalTypeOracleWriteAttribute)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/output_field.go
+++ b/dataintegration/output_field.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// OutputField Output fields of an operator.
+type OutputField struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	Type BaseType `mandatory:"false" json:"type"`
+
+	// Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+	Labels []string `mandatory:"false" json:"labels"`
+}
+
+//GetKey returns Key
+func (m OutputField) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m OutputField) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m OutputField) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetConfigValues returns ConfigValues
+func (m OutputField) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m OutputField) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetName returns Name
+func (m OutputField) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m OutputField) GetDescription() *string {
+	return m.Description
+}
+
+func (m OutputField) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m OutputField) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeOutputField OutputField
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeOutputField
+	}{
+		"OUTPUT_FIELD",
+		(MarshalTypeOutputField)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *OutputField) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key          *string          `json:"key"`
+		ModelVersion *string          `json:"modelVersion"`
+		ParentRef    *ParentReference `json:"parentRef"`
+		ConfigValues *ConfigValues    `json:"configValues"`
+		ObjectStatus *int             `json:"objectStatus"`
+		Name         *string          `json:"name"`
+		Description  *string          `json:"description"`
+		Type         basetype         `json:"type"`
+		Labels       []string         `json:"labels"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.ConfigValues = model.ConfigValues
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.Name = model.Name
+
+	m.Description = model.Description
+
+	nn, e = model.Type.UnmarshalPolymorphicJSON(model.Type.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.Type = nn.(BaseType)
+	} else {
+		m.Type = nil
+	}
+
+	m.Labels = make([]string, len(model.Labels))
+	for i, n := range model.Labels {
+		m.Labels[i] = n
+	}
+	return
+}

--- a/dataintegration/output_link.go
+++ b/dataintegration/output_link.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// OutputLink The information about output links.
+type OutputLink struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// Key of FlowPort reference
+	Port *string `mandatory:"false" json:"port"`
+
+	// The links from this output link to connect to other links in flow.
+	ToLinks []string `mandatory:"false" json:"toLinks"`
+}
+
+//GetKey returns Key
+func (m OutputLink) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m OutputLink) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m OutputLink) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m OutputLink) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetDescription returns Description
+func (m OutputLink) GetDescription() *string {
+	return m.Description
+}
+
+//GetPort returns Port
+func (m OutputLink) GetPort() *string {
+	return m.Port
+}
+
+func (m OutputLink) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m OutputLink) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeOutputLink OutputLink
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeOutputLink
+	}{
+		"OUTPUT_LINK",
+		(MarshalTypeOutputLink)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/output_port.go
+++ b/dataintegration/output_port.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// OutputPort The output port details.
+type OutputPort struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// fields
+	Fields []TypedObject `mandatory:"false" json:"fields"`
+
+	// The port details for the data asset.Type
+	PortType OutputPortPortTypeEnum `mandatory:"false" json:"portType,omitempty"`
+}
+
+//GetKey returns Key
+func (m OutputPort) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m OutputPort) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m OutputPort) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetConfigValues returns ConfigValues
+func (m OutputPort) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m OutputPort) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetName returns Name
+func (m OutputPort) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m OutputPort) GetDescription() *string {
+	return m.Description
+}
+
+func (m OutputPort) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m OutputPort) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeOutputPort OutputPort
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeOutputPort
+	}{
+		"OUTPUT_PORT",
+		(MarshalTypeOutputPort)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *OutputPort) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key          *string                `json:"key"`
+		ModelVersion *string                `json:"modelVersion"`
+		ParentRef    *ParentReference       `json:"parentRef"`
+		ConfigValues *ConfigValues          `json:"configValues"`
+		ObjectStatus *int                   `json:"objectStatus"`
+		Name         *string                `json:"name"`
+		Description  *string                `json:"description"`
+		PortType     OutputPortPortTypeEnum `json:"portType"`
+		Fields       []typedobject          `json:"fields"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.ConfigValues = model.ConfigValues
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.Name = model.Name
+
+	m.Description = model.Description
+
+	m.PortType = model.PortType
+
+	m.Fields = make([]TypedObject, len(model.Fields))
+	for i, n := range model.Fields {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.Fields[i] = nn.(TypedObject)
+		} else {
+			m.Fields[i] = nil
+		}
+	}
+	return
+}
+
+// OutputPortPortTypeEnum Enum with underlying type: string
+type OutputPortPortTypeEnum string
+
+// Set of constants representing the allowable values for OutputPortPortTypeEnum
+const (
+	OutputPortPortTypeData    OutputPortPortTypeEnum = "DATA"
+	OutputPortPortTypeControl OutputPortPortTypeEnum = "CONTROL"
+	OutputPortPortTypeModel   OutputPortPortTypeEnum = "MODEL"
+)
+
+var mappingOutputPortPortType = map[string]OutputPortPortTypeEnum{
+	"DATA":    OutputPortPortTypeData,
+	"CONTROL": OutputPortPortTypeControl,
+	"MODEL":   OutputPortPortTypeModel,
+}
+
+// GetOutputPortPortTypeEnumValues Enumerates the set of values for OutputPortPortTypeEnum
+func GetOutputPortPortTypeEnumValues() []OutputPortPortTypeEnum {
+	values := make([]OutputPortPortTypeEnum, 0)
+	for _, v := range mappingOutputPortPortType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/parameter.go
+++ b/dataintegration/parameter.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Parameter Parameters are created and assigned values that can be deferred to execution/runtime.
+type Parameter struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	Type BaseType `mandatory:"false" json:"type"`
+
+	// The default value of the parameter.
+	DefaultValue *interface{} `mandatory:"false" json:"defaultValue"`
+
+	// The default value of the parameter which can be an object in DIS, such as a data entity.
+	RootObjectDefaultValue *interface{} `mandatory:"false" json:"rootObjectDefaultValue"`
+
+	// Whether the parameter is input value.
+	IsInput *bool `mandatory:"false" json:"isInput"`
+
+	// Whether the parameter is output value.
+	IsOutput *bool `mandatory:"false" json:"isOutput"`
+
+	// The name of the object type.
+	TypeName *string `mandatory:"false" json:"typeName"`
+
+	// The output aggregation type
+	OutputAggregationType ParameterOutputAggregationTypeEnum `mandatory:"false" json:"outputAggregationType,omitempty"`
+}
+
+//GetKey returns Key
+func (m Parameter) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m Parameter) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m Parameter) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetConfigValues returns ConfigValues
+func (m Parameter) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m Parameter) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetName returns Name
+func (m Parameter) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m Parameter) GetDescription() *string {
+	return m.Description
+}
+
+func (m Parameter) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m Parameter) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeParameter Parameter
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeParameter
+	}{
+		"PARAMETER",
+		(MarshalTypeParameter)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *Parameter) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key                    *string                            `json:"key"`
+		ModelVersion           *string                            `json:"modelVersion"`
+		ParentRef              *ParentReference                   `json:"parentRef"`
+		ConfigValues           *ConfigValues                      `json:"configValues"`
+		ObjectStatus           *int                               `json:"objectStatus"`
+		Name                   *string                            `json:"name"`
+		Description            *string                            `json:"description"`
+		Type                   basetype                           `json:"type"`
+		DefaultValue           *interface{}                       `json:"defaultValue"`
+		RootObjectDefaultValue *interface{}                       `json:"rootObjectDefaultValue"`
+		IsInput                *bool                              `json:"isInput"`
+		IsOutput               *bool                              `json:"isOutput"`
+		OutputAggregationType  ParameterOutputAggregationTypeEnum `json:"outputAggregationType"`
+		TypeName               *string                            `json:"typeName"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.ConfigValues = model.ConfigValues
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.Name = model.Name
+
+	m.Description = model.Description
+
+	nn, e = model.Type.UnmarshalPolymorphicJSON(model.Type.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.Type = nn.(BaseType)
+	} else {
+		m.Type = nil
+	}
+
+	m.DefaultValue = model.DefaultValue
+
+	m.RootObjectDefaultValue = model.RootObjectDefaultValue
+
+	m.IsInput = model.IsInput
+
+	m.IsOutput = model.IsOutput
+
+	m.OutputAggregationType = model.OutputAggregationType
+
+	m.TypeName = model.TypeName
+	return
+}
+
+// ParameterOutputAggregationTypeEnum Enum with underlying type: string
+type ParameterOutputAggregationTypeEnum string
+
+// Set of constants representing the allowable values for ParameterOutputAggregationTypeEnum
+const (
+	ParameterOutputAggregationTypeMin   ParameterOutputAggregationTypeEnum = "MIN"
+	ParameterOutputAggregationTypeMax   ParameterOutputAggregationTypeEnum = "MAX"
+	ParameterOutputAggregationTypeCount ParameterOutputAggregationTypeEnum = "COUNT"
+	ParameterOutputAggregationTypeSum   ParameterOutputAggregationTypeEnum = "SUM"
+)
+
+var mappingParameterOutputAggregationType = map[string]ParameterOutputAggregationTypeEnum{
+	"MIN":   ParameterOutputAggregationTypeMin,
+	"MAX":   ParameterOutputAggregationTypeMax,
+	"COUNT": ParameterOutputAggregationTypeCount,
+	"SUM":   ParameterOutputAggregationTypeSum,
+}
+
+// GetParameterOutputAggregationTypeEnumValues Enumerates the set of values for ParameterOutputAggregationTypeEnum
+func GetParameterOutputAggregationTypeEnumValues() []ParameterOutputAggregationTypeEnum {
+	values := make([]ParameterOutputAggregationTypeEnum, 0)
+	for _, v := range mappingParameterOutputAggregationType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/parameter_value.go
+++ b/dataintegration/parameter_value.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ParameterValue A parameter value.
+type ParameterValue struct {
+
+	// A simple value for the parameter.
+	SimpleValue *interface{} `mandatory:"false" json:"simpleValue"`
+
+	// This can be any object such as a file entity, or a schema or a table.
+	RootObjectValue *interface{} `mandatory:"false" json:"rootObjectValue"`
+}
+
+func (m ParameterValue) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/parent_reference.go
+++ b/dataintegration/parent_reference.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ParentReference A reference to the object's parent
+type ParentReference struct {
+
+	// Key of the parent object
+	Parent *string `mandatory:"false" json:"parent"`
+}
+
+func (m ParentReference) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/partition_config.go
+++ b/dataintegration/partition_config.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// PartitionConfig The information about partition configuration.
+type PartitionConfig interface {
+}
+
+type partitionconfig struct {
+	JsonData  []byte
+	ModelType string `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *partitionconfig) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerpartitionconfig partitionconfig
+	s := struct {
+		Model Unmarshalerpartitionconfig
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *partitionconfig) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "KEYRANGEPARTITIONCONFIG":
+		mm := KeyRangePartitionConfig{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m partitionconfig) String() string {
+	return common.PointerString(m)
+}
+
+// PartitionConfigModelTypeEnum Enum with underlying type: string
+type PartitionConfigModelTypeEnum string
+
+// Set of constants representing the allowable values for PartitionConfigModelTypeEnum
+const (
+	PartitionConfigModelTypeKeyrangepartitionconfig PartitionConfigModelTypeEnum = "KEYRANGEPARTITIONCONFIG"
+)
+
+var mappingPartitionConfigModelType = map[string]PartitionConfigModelTypeEnum{
+	"KEYRANGEPARTITIONCONFIG": PartitionConfigModelTypeKeyrangepartitionconfig,
+}
+
+// GetPartitionConfigModelTypeEnumValues Enumerates the set of values for PartitionConfigModelTypeEnum
+func GetPartitionConfigModelTypeEnumValues() []PartitionConfigModelTypeEnum {
+	values := make([]PartitionConfigModelTypeEnum, 0)
+	for _, v := range mappingPartitionConfigModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/patch.go
+++ b/dataintegration/patch.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Patch The patch object contains the audit summary information and the definition of the patch.
+type Patch struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The date and time the patch was applied, in the timestamp format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	TimePatched *common.SDKTime `mandatory:"false" json:"timePatched"`
+
+	// The errors encountered while applying the patch, if any.
+	ErrorMessages map[string]string `mandatory:"false" json:"errorMessages"`
+
+	// The application version of the patch.
+	ApplicationVersion *int `mandatory:"false" json:"applicationVersion"`
+
+	// The type of the patch applied or being applied on the application.
+	PatchType PatchPatchTypeEnum `mandatory:"false" json:"patchType,omitempty"`
+
+	// Status of the patch applied or being applied on the application
+	PatchStatus PatchPatchStatusEnum `mandatory:"false" json:"patchStatus,omitempty"`
+
+	// List of dependent objects in this patch.
+	DependentObjectMetadata []PatchObjectMetadata `mandatory:"false" json:"dependentObjectMetadata"`
+
+	// List of objects that are published / unpublished in this patch.
+	PatchObjectMetadata []PatchObjectMetadata `mandatory:"false" json:"patchObjectMetadata"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+}
+
+func (m Patch) String() string {
+	return common.PointerString(m)
+}
+
+// PatchPatchTypeEnum Enum with underlying type: string
+type PatchPatchTypeEnum string
+
+// Set of constants representing the allowable values for PatchPatchTypeEnum
+const (
+	PatchPatchTypePublish   PatchPatchTypeEnum = "PUBLISH"
+	PatchPatchTypeUnpublish PatchPatchTypeEnum = "UNPUBLISH"
+)
+
+var mappingPatchPatchType = map[string]PatchPatchTypeEnum{
+	"PUBLISH":   PatchPatchTypePublish,
+	"UNPUBLISH": PatchPatchTypeUnpublish,
+}
+
+// GetPatchPatchTypeEnumValues Enumerates the set of values for PatchPatchTypeEnum
+func GetPatchPatchTypeEnumValues() []PatchPatchTypeEnum {
+	values := make([]PatchPatchTypeEnum, 0)
+	for _, v := range mappingPatchPatchType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// PatchPatchStatusEnum Enum with underlying type: string
+type PatchPatchStatusEnum string
+
+// Set of constants representing the allowable values for PatchPatchStatusEnum
+const (
+	PatchPatchStatusQueued     PatchPatchStatusEnum = "QUEUED"
+	PatchPatchStatusSuccessful PatchPatchStatusEnum = "SUCCESSFUL"
+	PatchPatchStatusFailed     PatchPatchStatusEnum = "FAILED"
+	PatchPatchStatusInProgress PatchPatchStatusEnum = "IN_PROGRESS"
+)
+
+var mappingPatchPatchStatus = map[string]PatchPatchStatusEnum{
+	"QUEUED":      PatchPatchStatusQueued,
+	"SUCCESSFUL":  PatchPatchStatusSuccessful,
+	"FAILED":      PatchPatchStatusFailed,
+	"IN_PROGRESS": PatchPatchStatusInProgress,
+}
+
+// GetPatchPatchStatusEnumValues Enumerates the set of values for PatchPatchStatusEnum
+func GetPatchPatchStatusEnumValues() []PatchPatchStatusEnum {
+	values := make([]PatchPatchStatusEnum, 0)
+	for _, v := range mappingPatchPatchStatus {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/patch_object_metadata.go
+++ b/dataintegration/patch_object_metadata.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// PatchObjectMetadata A summary type containing information about the object including its key, name and when/who created/updated it
+type PatchObjectMetadata struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// The fully qualified path of the published object which would include its project and folder.
+	NamePath *string `mandatory:"false" json:"namePath"`
+
+	// The type of the object in patch.
+	Type PatchObjectMetadataTypeEnum `mandatory:"false" json:"type,omitempty"`
+
+	// The object version.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The patch action, if object was created, updated or deleted.
+	Action PatchObjectMetadataActionEnum `mandatory:"false" json:"action,omitempty"`
+}
+
+func (m PatchObjectMetadata) String() string {
+	return common.PointerString(m)
+}
+
+// PatchObjectMetadataTypeEnum Enum with underlying type: string
+type PatchObjectMetadataTypeEnum string
+
+// Set of constants representing the allowable values for PatchObjectMetadataTypeEnum
+const (
+	PatchObjectMetadataTypeIntegrationTask PatchObjectMetadataTypeEnum = "INTEGRATION_TASK"
+	PatchObjectMetadataTypeDataLoaderTask  PatchObjectMetadataTypeEnum = "DATA_LOADER_TASK"
+)
+
+var mappingPatchObjectMetadataType = map[string]PatchObjectMetadataTypeEnum{
+	"INTEGRATION_TASK": PatchObjectMetadataTypeIntegrationTask,
+	"DATA_LOADER_TASK": PatchObjectMetadataTypeDataLoaderTask,
+}
+
+// GetPatchObjectMetadataTypeEnumValues Enumerates the set of values for PatchObjectMetadataTypeEnum
+func GetPatchObjectMetadataTypeEnumValues() []PatchObjectMetadataTypeEnum {
+	values := make([]PatchObjectMetadataTypeEnum, 0)
+	for _, v := range mappingPatchObjectMetadataType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// PatchObjectMetadataActionEnum Enum with underlying type: string
+type PatchObjectMetadataActionEnum string
+
+// Set of constants representing the allowable values for PatchObjectMetadataActionEnum
+const (
+	PatchObjectMetadataActionCreated PatchObjectMetadataActionEnum = "CREATED"
+	PatchObjectMetadataActionDeleted PatchObjectMetadataActionEnum = "DELETED"
+	PatchObjectMetadataActionUpdated PatchObjectMetadataActionEnum = "UPDATED"
+)
+
+var mappingPatchObjectMetadataAction = map[string]PatchObjectMetadataActionEnum{
+	"CREATED": PatchObjectMetadataActionCreated,
+	"DELETED": PatchObjectMetadataActionDeleted,
+	"UPDATED": PatchObjectMetadataActionUpdated,
+}
+
+// GetPatchObjectMetadataActionEnumValues Enumerates the set of values for PatchObjectMetadataActionEnum
+func GetPatchObjectMetadataActionEnumValues() []PatchObjectMetadataActionEnum {
+	values := make([]PatchObjectMetadataActionEnum, 0)
+	for _, v := range mappingPatchObjectMetadataAction {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/patch_summary.go
+++ b/dataintegration/patch_summary.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// PatchSummary The patch summary type contains the audit summary information and the definition of the patch.
+type PatchSummary struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The date and time the patch was applied, in the timestamp format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	TimePatched *common.SDKTime `mandatory:"false" json:"timePatched"`
+
+	// The errors encountered while applying the patch, if any.
+	ErrorMessages map[string]string `mandatory:"false" json:"errorMessages"`
+
+	// The application version of the patch.
+	ApplicationVersion *int `mandatory:"false" json:"applicationVersion"`
+
+	// The type of the patch applied or being applied on the application.
+	PatchType PatchSummaryPatchTypeEnum `mandatory:"false" json:"patchType,omitempty"`
+
+	// Status of the patch applied or being applied on the application
+	PatchStatus PatchSummaryPatchStatusEnum `mandatory:"false" json:"patchStatus,omitempty"`
+
+	// List of dependent objects in this patch.
+	DependentObjectMetadata []PatchObjectMetadata `mandatory:"false" json:"dependentObjectMetadata"`
+
+	// List of objects that are published / unpublished in this patch.
+	PatchObjectMetadata []PatchObjectMetadata `mandatory:"false" json:"patchObjectMetadata"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+}
+
+func (m PatchSummary) String() string {
+	return common.PointerString(m)
+}
+
+// PatchSummaryPatchTypeEnum Enum with underlying type: string
+type PatchSummaryPatchTypeEnum string
+
+// Set of constants representing the allowable values for PatchSummaryPatchTypeEnum
+const (
+	PatchSummaryPatchTypePublish   PatchSummaryPatchTypeEnum = "PUBLISH"
+	PatchSummaryPatchTypeUnpublish PatchSummaryPatchTypeEnum = "UNPUBLISH"
+)
+
+var mappingPatchSummaryPatchType = map[string]PatchSummaryPatchTypeEnum{
+	"PUBLISH":   PatchSummaryPatchTypePublish,
+	"UNPUBLISH": PatchSummaryPatchTypeUnpublish,
+}
+
+// GetPatchSummaryPatchTypeEnumValues Enumerates the set of values for PatchSummaryPatchTypeEnum
+func GetPatchSummaryPatchTypeEnumValues() []PatchSummaryPatchTypeEnum {
+	values := make([]PatchSummaryPatchTypeEnum, 0)
+	for _, v := range mappingPatchSummaryPatchType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// PatchSummaryPatchStatusEnum Enum with underlying type: string
+type PatchSummaryPatchStatusEnum string
+
+// Set of constants representing the allowable values for PatchSummaryPatchStatusEnum
+const (
+	PatchSummaryPatchStatusQueued     PatchSummaryPatchStatusEnum = "QUEUED"
+	PatchSummaryPatchStatusSuccessful PatchSummaryPatchStatusEnum = "SUCCESSFUL"
+	PatchSummaryPatchStatusFailed     PatchSummaryPatchStatusEnum = "FAILED"
+	PatchSummaryPatchStatusInProgress PatchSummaryPatchStatusEnum = "IN_PROGRESS"
+)
+
+var mappingPatchSummaryPatchStatus = map[string]PatchSummaryPatchStatusEnum{
+	"QUEUED":      PatchSummaryPatchStatusQueued,
+	"SUCCESSFUL":  PatchSummaryPatchStatusSuccessful,
+	"FAILED":      PatchSummaryPatchStatusFailed,
+	"IN_PROGRESS": PatchSummaryPatchStatusInProgress,
+}
+
+// GetPatchSummaryPatchStatusEnumValues Enumerates the set of values for PatchSummaryPatchStatusEnum
+func GetPatchSummaryPatchStatusEnumValues() []PatchSummaryPatchStatusEnum {
+	values := make([]PatchSummaryPatchStatusEnum, 0)
+	for _, v := range mappingPatchSummaryPatchStatus {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/patch_summary_collection.go
+++ b/dataintegration/patch_summary_collection.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// PatchSummaryCollection This is the collection of patch summaries, it may be a collection of lightweight details or full definitions.
+type PatchSummaryCollection struct {
+
+	// The array of patch summaries
+	Items []PatchSummary `mandatory:"true" json:"items"`
+}
+
+func (m PatchSummaryCollection) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/primary_key.go
+++ b/dataintegration/primary_key.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// PrimaryKey The primary key object.
+type PrimaryKey struct {
+
+	// The type of the key.
+	ModelType PrimaryKeyModelTypeEnum `mandatory:"true" json:"modelType"`
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// attributeRefs
+	AttributeRefs []KeyAttribute `mandatory:"false" json:"attributeRefs"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+}
+
+func (m PrimaryKey) String() string {
+	return common.PointerString(m)
+}
+
+// PrimaryKeyModelTypeEnum Enum with underlying type: string
+type PrimaryKeyModelTypeEnum string
+
+// Set of constants representing the allowable values for PrimaryKeyModelTypeEnum
+const (
+	PrimaryKeyModelTypeForeignKey PrimaryKeyModelTypeEnum = "FOREIGN_KEY"
+	PrimaryKeyModelTypePrimaryKey PrimaryKeyModelTypeEnum = "PRIMARY_KEY"
+	PrimaryKeyModelTypeUniqueKey  PrimaryKeyModelTypeEnum = "UNIQUE_KEY"
+)
+
+var mappingPrimaryKeyModelType = map[string]PrimaryKeyModelTypeEnum{
+	"FOREIGN_KEY": PrimaryKeyModelTypeForeignKey,
+	"PRIMARY_KEY": PrimaryKeyModelTypePrimaryKey,
+	"UNIQUE_KEY":  PrimaryKeyModelTypeUniqueKey,
+}
+
+// GetPrimaryKeyModelTypeEnumValues Enumerates the set of values for PrimaryKeyModelTypeEnum
+func GetPrimaryKeyModelTypeEnumValues() []PrimaryKeyModelTypeEnum {
+	values := make([]PrimaryKeyModelTypeEnum, 0)
+	for _, v := range mappingPrimaryKeyModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/project.go
+++ b/dataintegration/project.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Project The project type contains the audit summary information and the definition of the project.
+type Project struct {
+
+	// Generated key that can be used in API calls to identify project.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+}
+
+func (m Project) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/project_details.go
+++ b/dataintegration/project_details.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ProjectDetails The details including name, description for the project, which is a container of folders, tasks and dataflows.
+type ProjectDetails struct {
+
+	// Generated key that can be used in API calls to identify project.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"true" json:"modelType"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"true" json:"objectVersion"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+}
+
+func (m ProjectDetails) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/project_summary.go
+++ b/dataintegration/project_summary.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ProjectSummary The project summary type contains the audit summary information and the definition of the project.
+type ProjectSummary struct {
+
+	// Generated key that can be used in API calls to identify project.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+}
+
+func (m ProjectSummary) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/project_summary_collection.go
+++ b/dataintegration/project_summary_collection.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ProjectSummaryCollection A collection of project summaries. The collection can be lightweight details or full definitions.
+type ProjectSummaryCollection struct {
+
+	// The array of Project summaries
+	Items []ProjectSummary `mandatory:"true" json:"items"`
+}
+
+func (m ProjectSummaryCollection) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/projection.go
+++ b/dataintegration/projection.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Projection The information about the projection object.
+type Projection struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+}
+
+//GetKey returns Key
+func (m Projection) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m Projection) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m Projection) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m Projection) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m Projection) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m Projection) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetInputPorts returns InputPorts
+func (m Projection) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m Projection) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m Projection) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m Projection) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetParameters returns Parameters
+func (m Projection) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m Projection) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+func (m Projection) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m Projection) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeProjection Projection
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeProjection
+	}{
+		"PROJECTION_OPERATOR",
+		(MarshalTypeProjection)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/projection_rule.go
+++ b/dataintegration/projection_rule.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ProjectionRule Base type for how fields are projected, there are many different mechanisms for doing this such as by a name patter, datatype etc. See the modelType property for the types.
+type ProjectionRule interface {
+
+	// The key of the object.
+	GetKey() *string
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	GetParentRef() *ParentReference
+
+	// Specifies whether the rule uses a java regex syntax.
+	GetIsJavaRegexSyntax() *bool
+
+	GetConfigValues() *ConfigValues
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// Detailed description for the object.
+	GetDescription() *string
+}
+
+type projectionrule struct {
+	JsonData          []byte
+	Key               *string          `mandatory:"false" json:"key"`
+	ModelVersion      *string          `mandatory:"false" json:"modelVersion"`
+	ParentRef         *ParentReference `mandatory:"false" json:"parentRef"`
+	IsJavaRegexSyntax *bool            `mandatory:"false" json:"isJavaRegexSyntax"`
+	ConfigValues      *ConfigValues    `mandatory:"false" json:"configValues"`
+	ObjectStatus      *int             `mandatory:"false" json:"objectStatus"`
+	Description       *string          `mandatory:"false" json:"description"`
+	ModelType         string           `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *projectionrule) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerprojectionrule projectionrule
+	s := struct {
+		Model Unmarshalerprojectionrule
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Key = s.Model.Key
+	m.ModelVersion = s.Model.ModelVersion
+	m.ParentRef = s.Model.ParentRef
+	m.IsJavaRegexSyntax = s.Model.IsJavaRegexSyntax
+	m.ConfigValues = s.Model.ConfigValues
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.Description = s.Model.Description
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *projectionrule) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "RENAME_RULE":
+		mm := RenameRule{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "TYPE_LIST_RULE":
+		mm := TypeListRule{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "TYPED_NAME_PATTERN_RULE":
+		mm := TypedNamePatternRule{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "NAME_PATTERN_RULE":
+		mm := NamePatternRule{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "NAME_LIST_RULE":
+		mm := NameListRule{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetKey returns Key
+func (m projectionrule) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m projectionrule) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m projectionrule) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetIsJavaRegexSyntax returns IsJavaRegexSyntax
+func (m projectionrule) GetIsJavaRegexSyntax() *bool {
+	return m.IsJavaRegexSyntax
+}
+
+//GetConfigValues returns ConfigValues
+func (m projectionrule) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m projectionrule) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetDescription returns Description
+func (m projectionrule) GetDescription() *string {
+	return m.Description
+}
+
+func (m projectionrule) String() string {
+	return common.PointerString(m)
+}
+
+// ProjectionRuleModelTypeEnum Enum with underlying type: string
+type ProjectionRuleModelTypeEnum string
+
+// Set of constants representing the allowable values for ProjectionRuleModelTypeEnum
+const (
+	ProjectionRuleModelTypeNamePatternRule      ProjectionRuleModelTypeEnum = "NAME_PATTERN_RULE"
+	ProjectionRuleModelTypeTypeListRule         ProjectionRuleModelTypeEnum = "TYPE_LIST_RULE"
+	ProjectionRuleModelTypeNameListRule         ProjectionRuleModelTypeEnum = "NAME_LIST_RULE"
+	ProjectionRuleModelTypeTypedNamePatternRule ProjectionRuleModelTypeEnum = "TYPED_NAME_PATTERN_RULE"
+	ProjectionRuleModelTypeRenameRule           ProjectionRuleModelTypeEnum = "RENAME_RULE"
+)
+
+var mappingProjectionRuleModelType = map[string]ProjectionRuleModelTypeEnum{
+	"NAME_PATTERN_RULE":       ProjectionRuleModelTypeNamePatternRule,
+	"TYPE_LIST_RULE":          ProjectionRuleModelTypeTypeListRule,
+	"NAME_LIST_RULE":          ProjectionRuleModelTypeNameListRule,
+	"TYPED_NAME_PATTERN_RULE": ProjectionRuleModelTypeTypedNamePatternRule,
+	"RENAME_RULE":             ProjectionRuleModelTypeRenameRule,
+}
+
+// GetProjectionRuleModelTypeEnumValues Enumerates the set of values for ProjectionRuleModelTypeEnum
+func GetProjectionRuleModelTypeEnumValues() []ProjectionRuleModelTypeEnum {
+	values := make([]ProjectionRuleModelTypeEnum, 0)
+	for _, v := range mappingProjectionRuleModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/proxy_field.go
+++ b/dataintegration/proxy_field.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ProxyField A proxy field.
+type ProxyField struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a TypedObject or a full TypedObject definition.
+	Scope *interface{} `mandatory:"false" json:"scope"`
+
+	Type BaseType `mandatory:"false" json:"type"`
+
+	// Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+	Labels []string `mandatory:"false" json:"labels"`
+}
+
+//GetKey returns Key
+func (m ProxyField) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m ProxyField) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m ProxyField) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetConfigValues returns ConfigValues
+func (m ProxyField) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m ProxyField) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetName returns Name
+func (m ProxyField) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m ProxyField) GetDescription() *string {
+	return m.Description
+}
+
+func (m ProxyField) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ProxyField) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeProxyField ProxyField
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeProxyField
+	}{
+		"PROXY_FIELD",
+		(MarshalTypeProxyField)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *ProxyField) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key          *string          `json:"key"`
+		ModelVersion *string          `json:"modelVersion"`
+		ParentRef    *ParentReference `json:"parentRef"`
+		ConfigValues *ConfigValues    `json:"configValues"`
+		ObjectStatus *int             `json:"objectStatus"`
+		Name         *string          `json:"name"`
+		Description  *string          `json:"description"`
+		Scope        *interface{}     `json:"scope"`
+		Type         basetype         `json:"type"`
+		Labels       []string         `json:"labels"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.ConfigValues = model.ConfigValues
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.Name = model.Name
+
+	m.Description = model.Description
+
+	m.Scope = model.Scope
+
+	nn, e = model.Type.UnmarshalPolymorphicJSON(model.Type.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.Type = nn.(BaseType)
+	} else {
+		m.Type = nil
+	}
+
+	m.Labels = make([]string, len(model.Labels))
+	for i, n := range model.Labels {
+		m.Labels[i] = n
+	}
+	return
+}

--- a/dataintegration/published_object.go
+++ b/dataintegration/published_object.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// PublishedObject The information about the published object.
+type PublishedObject interface {
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	GetKey() *string
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	GetParentRef() *ParentReference
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	GetName() *string
+
+	// Detailed description for the object.
+	GetDescription() *string
+
+	// The version of the object that is used to track changes in the object instance.
+	GetObjectVersion() *int
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	GetIdentifier() *string
+}
+
+type publishedobject struct {
+	JsonData      []byte
+	Key           *string          `mandatory:"false" json:"key"`
+	ModelVersion  *string          `mandatory:"false" json:"modelVersion"`
+	ParentRef     *ParentReference `mandatory:"false" json:"parentRef"`
+	Name          *string          `mandatory:"false" json:"name"`
+	Description   *string          `mandatory:"false" json:"description"`
+	ObjectVersion *int             `mandatory:"false" json:"objectVersion"`
+	ObjectStatus  *int             `mandatory:"false" json:"objectStatus"`
+	Identifier    *string          `mandatory:"false" json:"identifier"`
+	ModelType     string           `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *publishedobject) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerpublishedobject publishedobject
+	s := struct {
+		Model Unmarshalerpublishedobject
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Key = s.Model.Key
+	m.ModelVersion = s.Model.ModelVersion
+	m.ParentRef = s.Model.ParentRef
+	m.Name = s.Model.Name
+	m.Description = s.Model.Description
+	m.ObjectVersion = s.Model.ObjectVersion
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.Identifier = s.Model.Identifier
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *publishedobject) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "DATA_LOADER_TASK":
+		mm := PublishedObjectFromDataLoaderTask{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "INTEGRATION_TASK":
+		mm := PublishedObjectFromIntegrationTask{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetKey returns Key
+func (m publishedobject) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m publishedobject) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m publishedobject) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m publishedobject) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m publishedobject) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m publishedobject) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m publishedobject) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m publishedobject) GetIdentifier() *string {
+	return m.Identifier
+}
+
+func (m publishedobject) String() string {
+	return common.PointerString(m)
+}
+
+// PublishedObjectModelTypeEnum Enum with underlying type: string
+type PublishedObjectModelTypeEnum string
+
+// Set of constants representing the allowable values for PublishedObjectModelTypeEnum
+const (
+	PublishedObjectModelTypeIntegrationTask PublishedObjectModelTypeEnum = "INTEGRATION_TASK"
+	PublishedObjectModelTypeDataLoaderTask  PublishedObjectModelTypeEnum = "DATA_LOADER_TASK"
+)
+
+var mappingPublishedObjectModelType = map[string]PublishedObjectModelTypeEnum{
+	"INTEGRATION_TASK": PublishedObjectModelTypeIntegrationTask,
+	"DATA_LOADER_TASK": PublishedObjectModelTypeDataLoaderTask,
+}
+
+// GetPublishedObjectModelTypeEnumValues Enumerates the set of values for PublishedObjectModelTypeEnum
+func GetPublishedObjectModelTypeEnumValues() []PublishedObjectModelTypeEnum {
+	values := make([]PublishedObjectModelTypeEnum, 0)
+	for _, v := range mappingPublishedObjectModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/published_object_from_data_loader_task.go
+++ b/dataintegration/published_object_from_data_loader_task.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// PublishedObjectFromDataLoaderTask The data loader task published object.
+type PublishedObjectFromDataLoaderTask struct {
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+
+	ConfigProviderDelegate *ConfigProvider `mandatory:"false" json:"configProviderDelegate"`
+
+	DataFlow *DataFlow `mandatory:"false" json:"dataFlow"`
+}
+
+//GetKey returns Key
+func (m PublishedObjectFromDataLoaderTask) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m PublishedObjectFromDataLoaderTask) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m PublishedObjectFromDataLoaderTask) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m PublishedObjectFromDataLoaderTask) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m PublishedObjectFromDataLoaderTask) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m PublishedObjectFromDataLoaderTask) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m PublishedObjectFromDataLoaderTask) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m PublishedObjectFromDataLoaderTask) GetIdentifier() *string {
+	return m.Identifier
+}
+
+func (m PublishedObjectFromDataLoaderTask) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m PublishedObjectFromDataLoaderTask) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypePublishedObjectFromDataLoaderTask PublishedObjectFromDataLoaderTask
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypePublishedObjectFromDataLoaderTask
+	}{
+		"DATA_LOADER_TASK",
+		(MarshalTypePublishedObjectFromDataLoaderTask)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/published_object_from_integration_task.go
+++ b/dataintegration/published_object_from_integration_task.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// PublishedObjectFromIntegrationTask The integration task published object.
+type PublishedObjectFromIntegrationTask struct {
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+
+	ConfigProviderDelegate *ConfigProvider `mandatory:"false" json:"configProviderDelegate"`
+
+	DataFlow *DataFlow `mandatory:"false" json:"dataFlow"`
+}
+
+//GetKey returns Key
+func (m PublishedObjectFromIntegrationTask) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m PublishedObjectFromIntegrationTask) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m PublishedObjectFromIntegrationTask) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m PublishedObjectFromIntegrationTask) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m PublishedObjectFromIntegrationTask) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m PublishedObjectFromIntegrationTask) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m PublishedObjectFromIntegrationTask) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m PublishedObjectFromIntegrationTask) GetIdentifier() *string {
+	return m.Identifier
+}
+
+func (m PublishedObjectFromIntegrationTask) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m PublishedObjectFromIntegrationTask) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypePublishedObjectFromIntegrationTask PublishedObjectFromIntegrationTask
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypePublishedObjectFromIntegrationTask
+	}{
+		"INTEGRATION_TASK",
+		(MarshalTypePublishedObjectFromIntegrationTask)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/published_object_summary.go
+++ b/dataintegration/published_object_summary.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// PublishedObjectSummary The published obect summary.
+type PublishedObjectSummary interface {
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	GetKey() *string
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	GetParentRef() *ParentReference
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	GetName() *string
+
+	// Detailed description for the object.
+	GetDescription() *string
+
+	// The version of the object that is used to track changes in the object instance.
+	GetObjectVersion() *int
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	GetIdentifier() *string
+
+	GetMetadata() *ObjectMetadata
+}
+
+type publishedobjectsummary struct {
+	JsonData      []byte
+	Key           *string          `mandatory:"false" json:"key"`
+	ModelVersion  *string          `mandatory:"false" json:"modelVersion"`
+	ParentRef     *ParentReference `mandatory:"false" json:"parentRef"`
+	Name          *string          `mandatory:"false" json:"name"`
+	Description   *string          `mandatory:"false" json:"description"`
+	ObjectVersion *int             `mandatory:"false" json:"objectVersion"`
+	ObjectStatus  *int             `mandatory:"false" json:"objectStatus"`
+	Identifier    *string          `mandatory:"false" json:"identifier"`
+	Metadata      *ObjectMetadata  `mandatory:"false" json:"metadata"`
+	ModelType     string           `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *publishedobjectsummary) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerpublishedobjectsummary publishedobjectsummary
+	s := struct {
+		Model Unmarshalerpublishedobjectsummary
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Key = s.Model.Key
+	m.ModelVersion = s.Model.ModelVersion
+	m.ParentRef = s.Model.ParentRef
+	m.Name = s.Model.Name
+	m.Description = s.Model.Description
+	m.ObjectVersion = s.Model.ObjectVersion
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.Identifier = s.Model.Identifier
+	m.Metadata = s.Model.Metadata
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *publishedobjectsummary) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "INTEGRATION_TASK":
+		mm := PublishedObjectSummaryFromIntegrationTask{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "DATA_LOADER_TASK":
+		mm := PublishedObjectSummaryFromDataLoaderTask{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetKey returns Key
+func (m publishedobjectsummary) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m publishedobjectsummary) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m publishedobjectsummary) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m publishedobjectsummary) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m publishedobjectsummary) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m publishedobjectsummary) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m publishedobjectsummary) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m publishedobjectsummary) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetMetadata returns Metadata
+func (m publishedobjectsummary) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m publishedobjectsummary) String() string {
+	return common.PointerString(m)
+}
+
+// PublishedObjectSummaryModelTypeEnum Enum with underlying type: string
+type PublishedObjectSummaryModelTypeEnum string
+
+// Set of constants representing the allowable values for PublishedObjectSummaryModelTypeEnum
+const (
+	PublishedObjectSummaryModelTypeIntegrationTask PublishedObjectSummaryModelTypeEnum = "INTEGRATION_TASK"
+	PublishedObjectSummaryModelTypeDataLoaderTask  PublishedObjectSummaryModelTypeEnum = "DATA_LOADER_TASK"
+)
+
+var mappingPublishedObjectSummaryModelType = map[string]PublishedObjectSummaryModelTypeEnum{
+	"INTEGRATION_TASK": PublishedObjectSummaryModelTypeIntegrationTask,
+	"DATA_LOADER_TASK": PublishedObjectSummaryModelTypeDataLoaderTask,
+}
+
+// GetPublishedObjectSummaryModelTypeEnumValues Enumerates the set of values for PublishedObjectSummaryModelTypeEnum
+func GetPublishedObjectSummaryModelTypeEnumValues() []PublishedObjectSummaryModelTypeEnum {
+	values := make([]PublishedObjectSummaryModelTypeEnum, 0)
+	for _, v := range mappingPublishedObjectSummaryModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/published_object_summary_collection.go
+++ b/dataintegration/published_object_summary_collection.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// PublishedObjectSummaryCollection This is the collection of published object summaries, it may be a collection of lightweight details or full definitions.
+type PublishedObjectSummaryCollection struct {
+
+	// The array of PublishedObject summaries
+	Items []PublishedObjectSummary `mandatory:"true" json:"items"`
+}
+
+func (m PublishedObjectSummaryCollection) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *PublishedObjectSummaryCollection) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Items []publishedobjectsummary `json:"items"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Items = make([]PublishedObjectSummary, len(model.Items))
+	for i, n := range model.Items {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.Items[i] = nn.(PublishedObjectSummary)
+		} else {
+			m.Items[i] = nil
+		}
+	}
+	return
+}

--- a/dataintegration/published_object_summary_from_data_loader_task.go
+++ b/dataintegration/published_object_summary_from_data_loader_task.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// PublishedObjectSummaryFromDataLoaderTask The data loader task published object summary.
+type PublishedObjectSummaryFromDataLoaderTask struct {
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+
+	ConfigProviderDelegate *ConfigProvider `mandatory:"false" json:"configProviderDelegate"`
+
+	DataFlow *DataFlow `mandatory:"false" json:"dataFlow"`
+}
+
+//GetKey returns Key
+func (m PublishedObjectSummaryFromDataLoaderTask) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m PublishedObjectSummaryFromDataLoaderTask) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m PublishedObjectSummaryFromDataLoaderTask) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m PublishedObjectSummaryFromDataLoaderTask) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m PublishedObjectSummaryFromDataLoaderTask) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m PublishedObjectSummaryFromDataLoaderTask) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m PublishedObjectSummaryFromDataLoaderTask) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m PublishedObjectSummaryFromDataLoaderTask) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetMetadata returns Metadata
+func (m PublishedObjectSummaryFromDataLoaderTask) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m PublishedObjectSummaryFromDataLoaderTask) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m PublishedObjectSummaryFromDataLoaderTask) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypePublishedObjectSummaryFromDataLoaderTask PublishedObjectSummaryFromDataLoaderTask
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypePublishedObjectSummaryFromDataLoaderTask
+	}{
+		"DATA_LOADER_TASK",
+		(MarshalTypePublishedObjectSummaryFromDataLoaderTask)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/published_object_summary_from_integration_task.go
+++ b/dataintegration/published_object_summary_from_integration_task.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// PublishedObjectSummaryFromIntegrationTask The integration task published object summary.
+type PublishedObjectSummaryFromIntegrationTask struct {
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+
+	ConfigProviderDelegate *ConfigProvider `mandatory:"false" json:"configProviderDelegate"`
+
+	DataFlow *DataFlow `mandatory:"false" json:"dataFlow"`
+}
+
+//GetKey returns Key
+func (m PublishedObjectSummaryFromIntegrationTask) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m PublishedObjectSummaryFromIntegrationTask) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m PublishedObjectSummaryFromIntegrationTask) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m PublishedObjectSummaryFromIntegrationTask) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m PublishedObjectSummaryFromIntegrationTask) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m PublishedObjectSummaryFromIntegrationTask) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m PublishedObjectSummaryFromIntegrationTask) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m PublishedObjectSummaryFromIntegrationTask) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetMetadata returns Metadata
+func (m PublishedObjectSummaryFromIntegrationTask) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+func (m PublishedObjectSummaryFromIntegrationTask) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m PublishedObjectSummaryFromIntegrationTask) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypePublishedObjectSummaryFromIntegrationTask PublishedObjectSummaryFromIntegrationTask
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypePublishedObjectSummaryFromIntegrationTask
+	}{
+		"INTEGRATION_TASK",
+		(MarshalTypePublishedObjectSummaryFromIntegrationTask)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/push_down_operation.go
+++ b/dataintegration/push_down_operation.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// PushDownOperation The information about a push down operation.
+type PushDownOperation interface {
+}
+
+type pushdownoperation struct {
+	JsonData  []byte
+	ModelType string `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *pushdownoperation) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerpushdownoperation pushdownoperation
+	s := struct {
+		Model Unmarshalerpushdownoperation
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *pushdownoperation) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "QUERY":
+		mm := Query{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "SELECT":
+		mm := ModelSelect{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "JOIN":
+		mm := Join{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "SORT":
+		mm := Sort{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "FILTER":
+		mm := FilterPush{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m pushdownoperation) String() string {
+	return common.PointerString(m)
+}
+
+// PushDownOperationModelTypeEnum Enum with underlying type: string
+type PushDownOperationModelTypeEnum string
+
+// Set of constants representing the allowable values for PushDownOperationModelTypeEnum
+const (
+	PushDownOperationModelTypeFilter PushDownOperationModelTypeEnum = "FILTER"
+	PushDownOperationModelTypeJoin   PushDownOperationModelTypeEnum = "JOIN"
+	PushDownOperationModelTypeSelect PushDownOperationModelTypeEnum = "SELECT"
+	PushDownOperationModelTypeSort   PushDownOperationModelTypeEnum = "SORT"
+	PushDownOperationModelTypeQuery  PushDownOperationModelTypeEnum = "QUERY"
+)
+
+var mappingPushDownOperationModelType = map[string]PushDownOperationModelTypeEnum{
+	"FILTER": PushDownOperationModelTypeFilter,
+	"JOIN":   PushDownOperationModelTypeJoin,
+	"SELECT": PushDownOperationModelTypeSelect,
+	"SORT":   PushDownOperationModelTypeSort,
+	"QUERY":  PushDownOperationModelTypeQuery,
+}
+
+// GetPushDownOperationModelTypeEnumValues Enumerates the set of values for PushDownOperationModelTypeEnum
+func GetPushDownOperationModelTypeEnumValues() []PushDownOperationModelTypeEnum {
+	values := make([]PushDownOperationModelTypeEnum, 0)
+	for _, v := range mappingPushDownOperationModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/query.go
+++ b/dataintegration/query.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Query A query object.
+type Query struct {
+
+	// A query string.
+	Query *string `mandatory:"false" json:"query"`
+}
+
+func (m Query) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m Query) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeQuery Query
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeQuery
+	}{
+		"QUERY",
+		(MarshalTypeQuery)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/read_operation_config.go
+++ b/dataintegration/read_operation_config.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ReadOperationConfig The information about the read operation.
+type ReadOperationConfig struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// An array of operations.
+	Operations []PushDownOperation `mandatory:"false" json:"operations"`
+
+	DataFormat *DataFormat `mandatory:"false" json:"dataFormat"`
+
+	PartitionConfig PartitionConfig `mandatory:"false" json:"partitionConfig"`
+
+	ReadAttribute AbstractReadAttribute `mandatory:"false" json:"readAttribute"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+}
+
+func (m ReadOperationConfig) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ReadOperationConfig) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeReadOperationConfig ReadOperationConfig
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeReadOperationConfig
+	}{
+		"READ_OPERATION_CONFIG",
+		(MarshalTypeReadOperationConfig)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *ReadOperationConfig) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key             *string               `json:"key"`
+		ModelVersion    *string               `json:"modelVersion"`
+		ParentRef       *ParentReference      `json:"parentRef"`
+		Operations      []pushdownoperation   `json:"operations"`
+		DataFormat      *DataFormat           `json:"dataFormat"`
+		PartitionConfig partitionconfig       `json:"partitionConfig"`
+		ReadAttribute   abstractreadattribute `json:"readAttribute"`
+		ObjectStatus    *int                  `json:"objectStatus"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.Operations = make([]PushDownOperation, len(model.Operations))
+	for i, n := range model.Operations {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.Operations[i] = nn.(PushDownOperation)
+		} else {
+			m.Operations[i] = nil
+		}
+	}
+
+	m.DataFormat = model.DataFormat
+
+	nn, e = model.PartitionConfig.UnmarshalPolymorphicJSON(model.PartitionConfig.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.PartitionConfig = nn.(PartitionConfig)
+	} else {
+		m.PartitionConfig = nil
+	}
+
+	nn, e = model.ReadAttribute.UnmarshalPolymorphicJSON(model.ReadAttribute.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.ReadAttribute = nn.(AbstractReadAttribute)
+	} else {
+		m.ReadAttribute = nil
+	}
+
+	m.ObjectStatus = model.ObjectStatus
+	return
+}

--- a/dataintegration/registry_metadata.go
+++ b/dataintegration/registry_metadata.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// RegistryMetadata Information about the object and its parent.
+type RegistryMetadata struct {
+
+	// The owning object's key for this object.
+	AggregatorKey *string `mandatory:"false" json:"aggregatorKey"`
+
+	// Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+	Labels []string `mandatory:"false" json:"labels"`
+
+	// Registry version.
+	RegistryVersion *int `mandatory:"false" json:"registryVersion"`
+
+	// The identifying key for the object.
+	Key *string `mandatory:"false" json:"key"`
+}
+
+func (m RegistryMetadata) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/rename_rule.go
+++ b/dataintegration/rename_rule.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// RenameRule The rename rule can rename fields from one to another.
+type RenameRule struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Specifies whether the rule uses a java regex syntax.
+	IsJavaRegexSyntax *bool `mandatory:"false" json:"isJavaRegexSyntax"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// skipRemainingRulesOnMatch
+	IsSkipRemainingRulesOnMatch *bool `mandatory:"false" json:"isSkipRemainingRulesOnMatch"`
+
+	// fromName
+	FromName *string `mandatory:"false" json:"fromName"`
+
+	// toName
+	ToName *string `mandatory:"false" json:"toName"`
+}
+
+//GetKey returns Key
+func (m RenameRule) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m RenameRule) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m RenameRule) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetIsJavaRegexSyntax returns IsJavaRegexSyntax
+func (m RenameRule) GetIsJavaRegexSyntax() *bool {
+	return m.IsJavaRegexSyntax
+}
+
+//GetConfigValues returns ConfigValues
+func (m RenameRule) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m RenameRule) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetDescription returns Description
+func (m RenameRule) GetDescription() *string {
+	return m.Description
+}
+
+func (m RenameRule) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m RenameRule) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeRenameRule RenameRule
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeRenameRule
+	}{
+		"RENAME_RULE",
+		(MarshalTypeRenameRule)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/root_object.go
+++ b/dataintegration/root_object.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// RootObject A base class for all model types, including First Class and its contained objects.
+type RootObject struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+}
+
+func (m RootObject) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/rule_based_field_map.go
+++ b/dataintegration/rule_based_field_map.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// RuleBasedFieldMap A map of rule patterns.
+type RuleBasedFieldMap struct {
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The pattern to map from.
+	FromPattern *string `mandatory:"false" json:"fromPattern"`
+
+	// The pattern to map to.
+	ToPattern *string `mandatory:"false" json:"toPattern"`
+
+	// Specifies whether the rule uses a java regex syntax.
+	IsJavaRegexSyntax *bool `mandatory:"false" json:"isJavaRegexSyntax"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	FromRuleConfig *RuleTypeConfig `mandatory:"false" json:"fromRuleConfig"`
+
+	ToRuleConfig *RuleTypeConfig `mandatory:"false" json:"toRuleConfig"`
+
+	// mapType
+	MapType RuleBasedFieldMapMapTypeEnum `mandatory:"false" json:"mapType,omitempty"`
+}
+
+//GetDescription returns Description
+func (m RuleBasedFieldMap) GetDescription() *string {
+	return m.Description
+}
+
+func (m RuleBasedFieldMap) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m RuleBasedFieldMap) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeRuleBasedFieldMap RuleBasedFieldMap
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeRuleBasedFieldMap
+	}{
+		"RULE_BASED_FIELD_MAP",
+		(MarshalTypeRuleBasedFieldMap)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// RuleBasedFieldMapMapTypeEnum Enum with underlying type: string
+type RuleBasedFieldMapMapTypeEnum string
+
+// Set of constants representing the allowable values for RuleBasedFieldMapMapTypeEnum
+const (
+	RuleBasedFieldMapMapTypeMapbyname     RuleBasedFieldMapMapTypeEnum = "MAPBYNAME"
+	RuleBasedFieldMapMapTypeMapbyposition RuleBasedFieldMapMapTypeEnum = "MAPBYPOSITION"
+	RuleBasedFieldMapMapTypeMapbypattern  RuleBasedFieldMapMapTypeEnum = "MAPBYPATTERN"
+)
+
+var mappingRuleBasedFieldMapMapType = map[string]RuleBasedFieldMapMapTypeEnum{
+	"MAPBYNAME":     RuleBasedFieldMapMapTypeMapbyname,
+	"MAPBYPOSITION": RuleBasedFieldMapMapTypeMapbyposition,
+	"MAPBYPATTERN":  RuleBasedFieldMapMapTypeMapbypattern,
+}
+
+// GetRuleBasedFieldMapMapTypeEnumValues Enumerates the set of values for RuleBasedFieldMapMapTypeEnum
+func GetRuleBasedFieldMapMapTypeEnumValues() []RuleBasedFieldMapMapTypeEnum {
+	values := make([]RuleBasedFieldMapMapTypeEnum, 0)
+	for _, v := range mappingRuleBasedFieldMapMapType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/rule_type_config.go
+++ b/dataintegration/rule_type_config.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// RuleTypeConfig The rule type config.
+type RuleTypeConfig struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a TypedObject or a full TypedObject definition.
+	Scope *interface{} `mandatory:"false" json:"scope"`
+
+	// orderByRule
+	IsOrderByRule *bool `mandatory:"false" json:"isOrderByRule"`
+
+	// projectionRules
+	ProjectionRules []ProjectionRule `mandatory:"false" json:"projectionRules"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+}
+
+func (m RuleTypeConfig) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m RuleTypeConfig) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeRuleTypeConfig RuleTypeConfig
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeRuleTypeConfig
+	}{
+		"RULE_TYPE_CONFIGS",
+		(MarshalTypeRuleTypeConfig)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *RuleTypeConfig) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key             *string          `json:"key"`
+		ModelVersion    *string          `json:"modelVersion"`
+		ParentRef       *ParentReference `json:"parentRef"`
+		Scope           *interface{}     `json:"scope"`
+		IsOrderByRule   *bool            `json:"isOrderByRule"`
+		ProjectionRules []projectionrule `json:"projectionRules"`
+		ConfigValues    *ConfigValues    `json:"configValues"`
+		ObjectStatus    *int             `json:"objectStatus"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.Scope = model.Scope
+
+	m.IsOrderByRule = model.IsOrderByRule
+
+	m.ProjectionRules = make([]ProjectionRule, len(model.ProjectionRules))
+	for i, n := range model.ProjectionRules {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.ProjectionRules[i] = nn.(ProjectionRule)
+		} else {
+			m.ProjectionRules[i] = nil
+		}
+	}
+
+	m.ConfigValues = model.ConfigValues
+
+	m.ObjectStatus = model.ObjectStatus
+	return
+}

--- a/dataintegration/schema.go
+++ b/dataintegration/schema.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Schema The schema object.
+type Schema struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The external key for the object.
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	// hasContainers
+	IsHasContainers *bool `mandatory:"false" json:"isHasContainers"`
+
+	// Connection key which is the default.
+	DefaultConnection *string `mandatory:"false" json:"defaultConnection"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+}
+
+func (m Schema) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/schema_summary.go
+++ b/dataintegration/schema_summary.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// SchemaSummary The schema summary object.
+type SchemaSummary struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The external key for the object.
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	// hasContainers
+	IsHasContainers *bool `mandatory:"false" json:"isHasContainers"`
+
+	// Connection key which is the default.
+	DefaultConnection *string `mandatory:"false" json:"defaultConnection"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+}
+
+func (m SchemaSummary) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/schema_summary_collection.go
+++ b/dataintegration/schema_summary_collection.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// SchemaSummaryCollection This is the collection of schema summaries, it may be a collection of lightweight details or full definitions.
+type SchemaSummaryCollection struct {
+
+	// The array of Schema summaries
+	Items []SchemaSummary `mandatory:"true" json:"items"`
+}
+
+func (m SchemaSummaryCollection) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/shape.go
+++ b/dataintegration/shape.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Shape The shape object.
+type Shape struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	Type BaseType `mandatory:"false" json:"type"`
+}
+
+//GetKey returns Key
+func (m Shape) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m Shape) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m Shape) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetConfigValues returns ConfigValues
+func (m Shape) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m Shape) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetName returns Name
+func (m Shape) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m Shape) GetDescription() *string {
+	return m.Description
+}
+
+func (m Shape) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m Shape) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeShape Shape
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeShape
+	}{
+		"SHAPE",
+		(MarshalTypeShape)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *Shape) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key          *string          `json:"key"`
+		ModelVersion *string          `json:"modelVersion"`
+		ParentRef    *ParentReference `json:"parentRef"`
+		ConfigValues *ConfigValues    `json:"configValues"`
+		ObjectStatus *int             `json:"objectStatus"`
+		Name         *string          `json:"name"`
+		Description  *string          `json:"description"`
+		Type         basetype         `json:"type"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.ConfigValues = model.ConfigValues
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.Name = model.Name
+
+	m.Description = model.Description
+
+	nn, e = model.Type.UnmarshalPolymorphicJSON(model.Type.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.Type = nn.(BaseType)
+	} else {
+		m.Type = nil
+	}
+	return
+}

--- a/dataintegration/shape_field.go
+++ b/dataintegration/shape_field.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ShapeField The shape field object.
+type ShapeField struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The reference to the type.
+	Type *string `mandatory:"false" json:"type"`
+
+	// Labels are keywords or labels that you can add to data assets, dataflows etc. You can define your own labels and use them to categorize content.
+	Labels []string `mandatory:"false" json:"labels"`
+
+	NativeShapeField *NativeShapeField `mandatory:"false" json:"nativeShapeField"`
+}
+
+//GetKey returns Key
+func (m ShapeField) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m ShapeField) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m ShapeField) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetConfigValues returns ConfigValues
+func (m ShapeField) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m ShapeField) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetName returns Name
+func (m ShapeField) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m ShapeField) GetDescription() *string {
+	return m.Description
+}
+
+func (m ShapeField) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ShapeField) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeShapeField ShapeField
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeShapeField
+	}{
+		"SHAPE_FIELD",
+		(MarshalTypeShapeField)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/sort.go
+++ b/dataintegration/sort.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Sort The information about the sort object.
+type Sort struct {
+
+	// The sort clause.
+	SortClauses []SortClause `mandatory:"false" json:"sortClauses"`
+}
+
+func (m Sort) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m Sort) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeSort Sort
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeSort
+	}{
+		"SORT",
+		(MarshalTypeSort)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/sort_clause.go
+++ b/dataintegration/sort_clause.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// SortClause The information about the sort object.
+type SortClause struct {
+	Field *ShapeField `mandatory:"false" json:"field"`
+
+	// The sort order.
+	Order SortClauseOrderEnum `mandatory:"false" json:"order,omitempty"`
+}
+
+func (m SortClause) String() string {
+	return common.PointerString(m)
+}
+
+// SortClauseOrderEnum Enum with underlying type: string
+type SortClauseOrderEnum string
+
+// Set of constants representing the allowable values for SortClauseOrderEnum
+const (
+	SortClauseOrderAsc  SortClauseOrderEnum = "ASC"
+	SortClauseOrderDesc SortClauseOrderEnum = "DESC"
+)
+
+var mappingSortClauseOrder = map[string]SortClauseOrderEnum{
+	"ASC":  SortClauseOrderAsc,
+	"DESC": SortClauseOrderDesc,
+}
+
+// GetSortClauseOrderEnumValues Enumerates the set of values for SortClauseOrderEnum
+func GetSortClauseOrderEnumValues() []SortClauseOrderEnum {
+	values := make([]SortClauseOrderEnum, 0)
+	for _, v := range mappingSortClauseOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/source.go
+++ b/dataintegration/source.go
@@ -1,0 +1,224 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Source The information about the source object.
+type Source struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+
+	Entity DataEntity `mandatory:"false" json:"entity"`
+
+	// Specifies the read access.
+	IsReadAccess *bool `mandatory:"false" json:"isReadAccess"`
+
+	// Specifies the copy fields.
+	IsCopyFields *bool `mandatory:"false" json:"isCopyFields"`
+
+	// Specifies if this uses a predefined shape.
+	IsPredefinedShape *bool `mandatory:"false" json:"isPredefinedShape"`
+
+	ReadOperationConfig *ReadOperationConfig `mandatory:"false" json:"readOperationConfig"`
+}
+
+//GetKey returns Key
+func (m Source) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m Source) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m Source) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m Source) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m Source) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m Source) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetInputPorts returns InputPorts
+func (m Source) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m Source) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m Source) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m Source) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetParameters returns Parameters
+func (m Source) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m Source) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+func (m Source) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m Source) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeSource Source
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeSource
+	}{
+		"SOURCE_OPERATOR",
+		(MarshalTypeSource)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *Source) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key                 *string              `json:"key"`
+		ModelVersion        *string              `json:"modelVersion"`
+		ParentRef           *ParentReference     `json:"parentRef"`
+		Name                *string              `json:"name"`
+		Description         *string              `json:"description"`
+		ObjectVersion       *int                 `json:"objectVersion"`
+		InputPorts          []InputPort          `json:"inputPorts"`
+		OutputPorts         []OutputPort         `json:"outputPorts"`
+		ObjectStatus        *int                 `json:"objectStatus"`
+		Identifier          *string              `json:"identifier"`
+		Parameters          []Parameter          `json:"parameters"`
+		OpConfigValues      *ConfigValues        `json:"opConfigValues"`
+		Entity              dataentity           `json:"entity"`
+		IsReadAccess        *bool                `json:"isReadAccess"`
+		IsCopyFields        *bool                `json:"isCopyFields"`
+		IsPredefinedShape   *bool                `json:"isPredefinedShape"`
+		ReadOperationConfig *ReadOperationConfig `json:"readOperationConfig"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.Name = model.Name
+
+	m.Description = model.Description
+
+	m.ObjectVersion = model.ObjectVersion
+
+	m.InputPorts = make([]InputPort, len(model.InputPorts))
+	for i, n := range model.InputPorts {
+		m.InputPorts[i] = n
+	}
+
+	m.OutputPorts = make([]OutputPort, len(model.OutputPorts))
+	for i, n := range model.OutputPorts {
+		m.OutputPorts[i] = n
+	}
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.Identifier = model.Identifier
+
+	m.Parameters = make([]Parameter, len(model.Parameters))
+	for i, n := range model.Parameters {
+		m.Parameters[i] = n
+	}
+
+	m.OpConfigValues = model.OpConfigValues
+
+	nn, e = model.Entity.UnmarshalPolymorphicJSON(model.Entity.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.Entity = nn.(DataEntity)
+	} else {
+		m.Entity = nil
+	}
+
+	m.IsReadAccess = model.IsReadAccess
+
+	m.IsCopyFields = model.IsCopyFields
+
+	m.IsPredefinedShape = model.IsPredefinedShape
+
+	m.ReadOperationConfig = model.ReadOperationConfig
+	return
+}

--- a/dataintegration/start_workspace_request_response.go
+++ b/dataintegration/start_workspace_request_response.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// StartWorkspaceRequest wrapper for the StartWorkspace operation
+type StartWorkspaceRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Caller may provide "retry tokens" allowing them to retry an operation
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request StartWorkspaceRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request StartWorkspaceRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request StartWorkspaceRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// StartWorkspaceResponse wrapper for the StartWorkspace operation
+type StartWorkspaceResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the work request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+	// with this ID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+}
+
+func (response StartWorkspaceResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response StartWorkspaceResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/stop_workspace_request_response.go
+++ b/dataintegration/stop_workspace_request_response.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// StopWorkspaceRequest wrapper for the StopWorkspace operation
+type StopWorkspaceRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// This parameter allows users to set the timeout for DIS to gracefully close down any running jobs before stopping the workspace.
+	QuiesceTimeout *int64 `mandatory:"false" contributesTo:"query" name:"quiesceTimeout"`
+
+	// This parameter allows users to force close down the workspace.
+	IsForceOperation *bool `mandatory:"false" contributesTo:"query" name:"isForceOperation"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Caller may provide "retry tokens" allowing them to retry an operation
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request StopWorkspaceRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request StopWorkspaceRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request StopWorkspaceRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// StopWorkspaceResponse wrapper for the StopWorkspace operation
+type StopWorkspaceResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the work request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+	// with this ID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+}
+
+func (response StopWorkspaceResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response StopWorkspaceResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/structured_type.go
+++ b/dataintegration/structured_type.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// StructuredType A StructuredType object represents a data type that exists in a physical data asset object such as a table column, but is more complex, for example an Oracle database OBJECT type.   It can be composed of multiple DataType objects.
+type StructuredType struct {
+
+	// The property which disciminates the subtypes.
+	ModelType StructuredTypeModelTypeEnum `mandatory:"true" json:"modelType"`
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// dtType
+	DtType StructuredTypeDtTypeEnum `mandatory:"false" json:"dtType,omitempty"`
+
+	// typeSystemName
+	TypeSystemName *string `mandatory:"false" json:"typeSystemName"`
+
+	ConfigDefinition *ConfigDefinition `mandatory:"false" json:"configDefinition"`
+
+	Schema BaseType `mandatory:"false" json:"schema"`
+}
+
+func (m StructuredType) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *StructuredType) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key              *string                     `json:"key"`
+		ModelVersion     *string                     `json:"modelVersion"`
+		ParentRef        *ParentReference            `json:"parentRef"`
+		Name             *string                     `json:"name"`
+		ObjectStatus     *int                        `json:"objectStatus"`
+		Description      *string                     `json:"description"`
+		DtType           StructuredTypeDtTypeEnum    `json:"dtType"`
+		TypeSystemName   *string                     `json:"typeSystemName"`
+		ConfigDefinition *ConfigDefinition           `json:"configDefinition"`
+		Schema           basetype                    `json:"schema"`
+		ModelType        StructuredTypeModelTypeEnum `json:"modelType"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.Name = model.Name
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.Description = model.Description
+
+	m.DtType = model.DtType
+
+	m.TypeSystemName = model.TypeSystemName
+
+	m.ConfigDefinition = model.ConfigDefinition
+
+	nn, e = model.Schema.UnmarshalPolymorphicJSON(model.Schema.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.Schema = nn.(BaseType)
+	} else {
+		m.Schema = nil
+	}
+
+	m.ModelType = model.ModelType
+	return
+}
+
+// StructuredTypeModelTypeEnum Enum with underlying type: string
+type StructuredTypeModelTypeEnum string
+
+// Set of constants representing the allowable values for StructuredTypeModelTypeEnum
+const (
+	StructuredTypeModelTypeDynamicType    StructuredTypeModelTypeEnum = "DYNAMIC_TYPE"
+	StructuredTypeModelTypeStructuredType StructuredTypeModelTypeEnum = "STRUCTURED_TYPE"
+	StructuredTypeModelTypeDataType       StructuredTypeModelTypeEnum = "DATA_TYPE"
+	StructuredTypeModelTypeJavaType       StructuredTypeModelTypeEnum = "JAVA_TYPE"
+	StructuredTypeModelTypeConfiguredType StructuredTypeModelTypeEnum = "CONFIGURED_TYPE"
+	StructuredTypeModelTypeCompositeType  StructuredTypeModelTypeEnum = "COMPOSITE_TYPE"
+)
+
+var mappingStructuredTypeModelType = map[string]StructuredTypeModelTypeEnum{
+	"DYNAMIC_TYPE":    StructuredTypeModelTypeDynamicType,
+	"STRUCTURED_TYPE": StructuredTypeModelTypeStructuredType,
+	"DATA_TYPE":       StructuredTypeModelTypeDataType,
+	"JAVA_TYPE":       StructuredTypeModelTypeJavaType,
+	"CONFIGURED_TYPE": StructuredTypeModelTypeConfiguredType,
+	"COMPOSITE_TYPE":  StructuredTypeModelTypeCompositeType,
+}
+
+// GetStructuredTypeModelTypeEnumValues Enumerates the set of values for StructuredTypeModelTypeEnum
+func GetStructuredTypeModelTypeEnumValues() []StructuredTypeModelTypeEnum {
+	values := make([]StructuredTypeModelTypeEnum, 0)
+	for _, v := range mappingStructuredTypeModelType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// StructuredTypeDtTypeEnum Enum with underlying type: string
+type StructuredTypeDtTypeEnum string
+
+// Set of constants representing the allowable values for StructuredTypeDtTypeEnum
+const (
+	StructuredTypeDtTypePrimitive  StructuredTypeDtTypeEnum = "PRIMITIVE"
+	StructuredTypeDtTypeStructured StructuredTypeDtTypeEnum = "STRUCTURED"
+)
+
+var mappingStructuredTypeDtType = map[string]StructuredTypeDtTypeEnum{
+	"PRIMITIVE":  StructuredTypeDtTypePrimitive,
+	"STRUCTURED": StructuredTypeDtTypeStructured,
+}
+
+// GetStructuredTypeDtTypeEnumValues Enumerates the set of values for StructuredTypeDtTypeEnum
+func GetStructuredTypeDtTypeEnumValues() []StructuredTypeDtTypeEnum {
+	values := make([]StructuredTypeDtTypeEnum, 0)
+	for _, v := range mappingStructuredTypeDtType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/target.go
+++ b/dataintegration/target.go
@@ -1,0 +1,261 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Target The information about the target operator. The target operator lets you specify the data entity to store the transformed data.
+type Target struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+
+	Entity DataEntity `mandatory:"false" json:"entity"`
+
+	// Specifies the read access.
+	IsReadAccess *bool `mandatory:"false" json:"isReadAccess"`
+
+	// Specifies the copy fields.
+	IsCopyFields *bool `mandatory:"false" json:"isCopyFields"`
+
+	// Specifies if this uses a predefined shape.
+	IsPredefinedShape *bool `mandatory:"false" json:"isPredefinedShape"`
+
+	WriteOperationConfig *WriteOperationConfig `mandatory:"false" json:"writeOperationConfig"`
+
+	// Specifies the data property.
+	DataProperty TargetDataPropertyEnum `mandatory:"false" json:"dataProperty,omitempty"`
+}
+
+//GetKey returns Key
+func (m Target) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m Target) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m Target) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m Target) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m Target) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m Target) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetInputPorts returns InputPorts
+func (m Target) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m Target) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m Target) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m Target) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetParameters returns Parameters
+func (m Target) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m Target) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+func (m Target) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m Target) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeTarget Target
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeTarget
+	}{
+		"TARGET_OPERATOR",
+		(MarshalTypeTarget)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *Target) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key                  *string                `json:"key"`
+		ModelVersion         *string                `json:"modelVersion"`
+		ParentRef            *ParentReference       `json:"parentRef"`
+		Name                 *string                `json:"name"`
+		Description          *string                `json:"description"`
+		ObjectVersion        *int                   `json:"objectVersion"`
+		InputPorts           []InputPort            `json:"inputPorts"`
+		OutputPorts          []OutputPort           `json:"outputPorts"`
+		ObjectStatus         *int                   `json:"objectStatus"`
+		Identifier           *string                `json:"identifier"`
+		Parameters           []Parameter            `json:"parameters"`
+		OpConfigValues       *ConfigValues          `json:"opConfigValues"`
+		Entity               dataentity             `json:"entity"`
+		IsReadAccess         *bool                  `json:"isReadAccess"`
+		IsCopyFields         *bool                  `json:"isCopyFields"`
+		IsPredefinedShape    *bool                  `json:"isPredefinedShape"`
+		DataProperty         TargetDataPropertyEnum `json:"dataProperty"`
+		WriteOperationConfig *WriteOperationConfig  `json:"writeOperationConfig"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.Name = model.Name
+
+	m.Description = model.Description
+
+	m.ObjectVersion = model.ObjectVersion
+
+	m.InputPorts = make([]InputPort, len(model.InputPorts))
+	for i, n := range model.InputPorts {
+		m.InputPorts[i] = n
+	}
+
+	m.OutputPorts = make([]OutputPort, len(model.OutputPorts))
+	for i, n := range model.OutputPorts {
+		m.OutputPorts[i] = n
+	}
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.Identifier = model.Identifier
+
+	m.Parameters = make([]Parameter, len(model.Parameters))
+	for i, n := range model.Parameters {
+		m.Parameters[i] = n
+	}
+
+	m.OpConfigValues = model.OpConfigValues
+
+	nn, e = model.Entity.UnmarshalPolymorphicJSON(model.Entity.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.Entity = nn.(DataEntity)
+	} else {
+		m.Entity = nil
+	}
+
+	m.IsReadAccess = model.IsReadAccess
+
+	m.IsCopyFields = model.IsCopyFields
+
+	m.IsPredefinedShape = model.IsPredefinedShape
+
+	m.DataProperty = model.DataProperty
+
+	m.WriteOperationConfig = model.WriteOperationConfig
+	return
+}
+
+// TargetDataPropertyEnum Enum with underlying type: string
+type TargetDataPropertyEnum string
+
+// Set of constants representing the allowable values for TargetDataPropertyEnum
+const (
+	TargetDataPropertyTruncate  TargetDataPropertyEnum = "TRUNCATE"
+	TargetDataPropertyMerge     TargetDataPropertyEnum = "MERGE"
+	TargetDataPropertyBackup    TargetDataPropertyEnum = "BACKUP"
+	TargetDataPropertyOverwrite TargetDataPropertyEnum = "OVERWRITE"
+	TargetDataPropertyAppend    TargetDataPropertyEnum = "APPEND"
+	TargetDataPropertyIgnore    TargetDataPropertyEnum = "IGNORE"
+)
+
+var mappingTargetDataProperty = map[string]TargetDataPropertyEnum{
+	"TRUNCATE":  TargetDataPropertyTruncate,
+	"MERGE":     TargetDataPropertyMerge,
+	"BACKUP":    TargetDataPropertyBackup,
+	"OVERWRITE": TargetDataPropertyOverwrite,
+	"APPEND":    TargetDataPropertyAppend,
+	"IGNORE":    TargetDataPropertyIgnore,
+}
+
+// GetTargetDataPropertyEnumValues Enumerates the set of values for TargetDataPropertyEnum
+func GetTargetDataPropertyEnumValues() []TargetDataPropertyEnum {
+	values := make([]TargetDataPropertyEnum, 0)
+	for _, v := range mappingTargetDataProperty {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/task.go
+++ b/dataintegration/task.go
@@ -1,0 +1,235 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Task The task type contains the audit summary information and the definition of the task.
+type Task interface {
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	GetKey() *string
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	GetParentRef() *ParentReference
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	GetName() *string
+
+	// Detailed description for the object.
+	GetDescription() *string
+
+	// The version of the object that is used to track changes in the object instance.
+	GetObjectVersion() *int
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	GetIdentifier() *string
+
+	// An array of input ports.
+	GetInputPorts() []InputPort
+
+	// An array of output ports.
+	GetOutputPorts() []OutputPort
+
+	// An array of parameters.
+	GetParameters() []Parameter
+
+	GetOpConfigValues() *ConfigValues
+
+	GetConfigProviderDelegate() *ConfigProvider
+
+	GetMetadata() *ObjectMetadata
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	GetKeyMap() map[string]string
+}
+
+type task struct {
+	JsonData               []byte
+	Key                    *string           `mandatory:"false" json:"key"`
+	ModelVersion           *string           `mandatory:"false" json:"modelVersion"`
+	ParentRef              *ParentReference  `mandatory:"false" json:"parentRef"`
+	Name                   *string           `mandatory:"false" json:"name"`
+	Description            *string           `mandatory:"false" json:"description"`
+	ObjectVersion          *int              `mandatory:"false" json:"objectVersion"`
+	ObjectStatus           *int              `mandatory:"false" json:"objectStatus"`
+	Identifier             *string           `mandatory:"false" json:"identifier"`
+	InputPorts             []InputPort       `mandatory:"false" json:"inputPorts"`
+	OutputPorts            []OutputPort      `mandatory:"false" json:"outputPorts"`
+	Parameters             []Parameter       `mandatory:"false" json:"parameters"`
+	OpConfigValues         *ConfigValues     `mandatory:"false" json:"opConfigValues"`
+	ConfigProviderDelegate *ConfigProvider   `mandatory:"false" json:"configProviderDelegate"`
+	Metadata               *ObjectMetadata   `mandatory:"false" json:"metadata"`
+	KeyMap                 map[string]string `mandatory:"false" json:"keyMap"`
+	ModelType              string            `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *task) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalertask task
+	s := struct {
+		Model Unmarshalertask
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Key = s.Model.Key
+	m.ModelVersion = s.Model.ModelVersion
+	m.ParentRef = s.Model.ParentRef
+	m.Name = s.Model.Name
+	m.Description = s.Model.Description
+	m.ObjectVersion = s.Model.ObjectVersion
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.Identifier = s.Model.Identifier
+	m.InputPorts = s.Model.InputPorts
+	m.OutputPorts = s.Model.OutputPorts
+	m.Parameters = s.Model.Parameters
+	m.OpConfigValues = s.Model.OpConfigValues
+	m.ConfigProviderDelegate = s.Model.ConfigProviderDelegate
+	m.Metadata = s.Model.Metadata
+	m.KeyMap = s.Model.KeyMap
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *task) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "INTEGRATION_TASK":
+		mm := TaskFromIntegrationTaskDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "DATA_LOADER_TASK":
+		mm := TaskFromDataLoaderTaskDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetKey returns Key
+func (m task) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m task) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m task) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m task) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m task) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m task) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m task) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m task) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetInputPorts returns InputPorts
+func (m task) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m task) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetParameters returns Parameters
+func (m task) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m task) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+//GetConfigProviderDelegate returns ConfigProviderDelegate
+func (m task) GetConfigProviderDelegate() *ConfigProvider {
+	return m.ConfigProviderDelegate
+}
+
+//GetMetadata returns Metadata
+func (m task) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m task) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m task) String() string {
+	return common.PointerString(m)
+}
+
+// TaskModelTypeEnum Enum with underlying type: string
+type TaskModelTypeEnum string
+
+// Set of constants representing the allowable values for TaskModelTypeEnum
+const (
+	TaskModelTypeIntegrationTask TaskModelTypeEnum = "INTEGRATION_TASK"
+	TaskModelTypeDataLoaderTask  TaskModelTypeEnum = "DATA_LOADER_TASK"
+)
+
+var mappingTaskModelType = map[string]TaskModelTypeEnum{
+	"INTEGRATION_TASK": TaskModelTypeIntegrationTask,
+	"DATA_LOADER_TASK": TaskModelTypeDataLoaderTask,
+}
+
+// GetTaskModelTypeEnumValues Enumerates the set of values for TaskModelTypeEnum
+func GetTaskModelTypeEnumValues() []TaskModelTypeEnum {
+	values := make([]TaskModelTypeEnum, 0)
+	for _, v := range mappingTaskModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/task_from_data_loader_task_details.go
+++ b/dataintegration/task_from_data_loader_task_details.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TaskFromDataLoaderTaskDetails The information about a data flow task.
+type TaskFromDataLoaderTaskDetails struct {
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+
+	ConfigProviderDelegate *ConfigProvider `mandatory:"false" json:"configProviderDelegate"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+
+	DataFlow *DataFlow `mandatory:"false" json:"dataFlow"`
+}
+
+//GetKey returns Key
+func (m TaskFromDataLoaderTaskDetails) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m TaskFromDataLoaderTaskDetails) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m TaskFromDataLoaderTaskDetails) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m TaskFromDataLoaderTaskDetails) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m TaskFromDataLoaderTaskDetails) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m TaskFromDataLoaderTaskDetails) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m TaskFromDataLoaderTaskDetails) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m TaskFromDataLoaderTaskDetails) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetInputPorts returns InputPorts
+func (m TaskFromDataLoaderTaskDetails) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m TaskFromDataLoaderTaskDetails) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetParameters returns Parameters
+func (m TaskFromDataLoaderTaskDetails) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m TaskFromDataLoaderTaskDetails) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+//GetConfigProviderDelegate returns ConfigProviderDelegate
+func (m TaskFromDataLoaderTaskDetails) GetConfigProviderDelegate() *ConfigProvider {
+	return m.ConfigProviderDelegate
+}
+
+//GetMetadata returns Metadata
+func (m TaskFromDataLoaderTaskDetails) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m TaskFromDataLoaderTaskDetails) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m TaskFromDataLoaderTaskDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m TaskFromDataLoaderTaskDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeTaskFromDataLoaderTaskDetails TaskFromDataLoaderTaskDetails
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeTaskFromDataLoaderTaskDetails
+	}{
+		"DATA_LOADER_TASK",
+		(MarshalTypeTaskFromDataLoaderTaskDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/task_from_integration_task_details.go
+++ b/dataintegration/task_from_integration_task_details.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TaskFromIntegrationTaskDetails The information about the integration task.
+type TaskFromIntegrationTaskDetails struct {
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+
+	ConfigProviderDelegate *ConfigProvider `mandatory:"false" json:"configProviderDelegate"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+
+	DataFlow *DataFlow `mandatory:"false" json:"dataFlow"`
+}
+
+//GetKey returns Key
+func (m TaskFromIntegrationTaskDetails) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m TaskFromIntegrationTaskDetails) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m TaskFromIntegrationTaskDetails) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m TaskFromIntegrationTaskDetails) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m TaskFromIntegrationTaskDetails) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m TaskFromIntegrationTaskDetails) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m TaskFromIntegrationTaskDetails) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m TaskFromIntegrationTaskDetails) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetInputPorts returns InputPorts
+func (m TaskFromIntegrationTaskDetails) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m TaskFromIntegrationTaskDetails) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetParameters returns Parameters
+func (m TaskFromIntegrationTaskDetails) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m TaskFromIntegrationTaskDetails) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+//GetConfigProviderDelegate returns ConfigProviderDelegate
+func (m TaskFromIntegrationTaskDetails) GetConfigProviderDelegate() *ConfigProvider {
+	return m.ConfigProviderDelegate
+}
+
+//GetMetadata returns Metadata
+func (m TaskFromIntegrationTaskDetails) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m TaskFromIntegrationTaskDetails) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m TaskFromIntegrationTaskDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m TaskFromIntegrationTaskDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeTaskFromIntegrationTaskDetails TaskFromIntegrationTaskDetails
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeTaskFromIntegrationTaskDetails
+	}{
+		"INTEGRATION_TASK",
+		(MarshalTypeTaskFromIntegrationTaskDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/task_run.go
+++ b/dataintegration/task_run.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TaskRun The information about TaskRun.
+type TaskRun struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	ConfigProvider *ConfigProvider `mandatory:"false" json:"configProvider"`
+
+	// status
+	Status TaskRunStatusEnum `mandatory:"false" json:"status,omitempty"`
+
+	// startTimeMillis
+	StartTimeMillis *int64 `mandatory:"false" json:"startTimeMillis"`
+
+	// endTimeMillis
+	EndTimeMillis *int64 `mandatory:"false" json:"endTimeMillis"`
+
+	// lastUpdated
+	LastUpdated *int64 `mandatory:"false" json:"lastUpdated"`
+
+	// Number of records processed in task run.
+	RecordsWritten *int64 `mandatory:"false" json:"recordsWritten"`
+
+	// Number of bytes processed in task run.
+	BytesProcessed *int64 `mandatory:"false" json:"bytesProcessed"`
+
+	// Error message if status is ERROR
+	ErrorMessage *string `mandatory:"false" json:"errorMessage"`
+
+	// Opc request id of execution of task run
+	OpcRequestId *string `mandatory:"false" json:"opcRequestId"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// The type of the task for the run.
+	TaskType TaskRunTaskTypeEnum `mandatory:"false" json:"taskType,omitempty"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+}
+
+func (m TaskRun) String() string {
+	return common.PointerString(m)
+}
+
+// TaskRunStatusEnum Enum with underlying type: string
+type TaskRunStatusEnum string
+
+// Set of constants representing the allowable values for TaskRunStatusEnum
+const (
+	TaskRunStatusNotStarted  TaskRunStatusEnum = "NOT_STARTED"
+	TaskRunStatusQueued      TaskRunStatusEnum = "QUEUED"
+	TaskRunStatusRunning     TaskRunStatusEnum = "RUNNING"
+	TaskRunStatusTerminating TaskRunStatusEnum = "TERMINATING"
+	TaskRunStatusTerminated  TaskRunStatusEnum = "TERMINATED"
+	TaskRunStatusSuccess     TaskRunStatusEnum = "SUCCESS"
+	TaskRunStatusError       TaskRunStatusEnum = "ERROR"
+)
+
+var mappingTaskRunStatus = map[string]TaskRunStatusEnum{
+	"NOT_STARTED": TaskRunStatusNotStarted,
+	"QUEUED":      TaskRunStatusQueued,
+	"RUNNING":     TaskRunStatusRunning,
+	"TERMINATING": TaskRunStatusTerminating,
+	"TERMINATED":  TaskRunStatusTerminated,
+	"SUCCESS":     TaskRunStatusSuccess,
+	"ERROR":       TaskRunStatusError,
+}
+
+// GetTaskRunStatusEnumValues Enumerates the set of values for TaskRunStatusEnum
+func GetTaskRunStatusEnumValues() []TaskRunStatusEnum {
+	values := make([]TaskRunStatusEnum, 0)
+	for _, v := range mappingTaskRunStatus {
+		values = append(values, v)
+	}
+	return values
+}
+
+// TaskRunTaskTypeEnum Enum with underlying type: string
+type TaskRunTaskTypeEnum string
+
+// Set of constants representing the allowable values for TaskRunTaskTypeEnum
+const (
+	TaskRunTaskTypeIntegrationTask TaskRunTaskTypeEnum = "INTEGRATION_TASK"
+	TaskRunTaskTypeDataLoaderTask  TaskRunTaskTypeEnum = "DATA_LOADER_TASK"
+)
+
+var mappingTaskRunTaskType = map[string]TaskRunTaskTypeEnum{
+	"INTEGRATION_TASK": TaskRunTaskTypeIntegrationTask,
+	"DATA_LOADER_TASK": TaskRunTaskTypeDataLoaderTask,
+}
+
+// GetTaskRunTaskTypeEnumValues Enumerates the set of values for TaskRunTaskTypeEnum
+func GetTaskRunTaskTypeEnumValues() []TaskRunTaskTypeEnum {
+	values := make([]TaskRunTaskTypeEnum, 0)
+	for _, v := range mappingTaskRunTaskType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/task_run_details.go
+++ b/dataintegration/task_run_details.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TaskRunDetails The task run object provides information on the execution of a task.
+type TaskRunDetails struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// status
+	Status TaskRunDetailsStatusEnum `mandatory:"false" json:"status,omitempty"`
+
+	// startTimeMillis
+	StartTimeMillis *int64 `mandatory:"false" json:"startTimeMillis"`
+
+	// endTimeMillis
+	EndTimeMillis *int64 `mandatory:"false" json:"endTimeMillis"`
+
+	// lastUpdated
+	LastUpdated *int64 `mandatory:"false" json:"lastUpdated"`
+
+	// Number of records processed in task run.
+	RecordsWritten *int64 `mandatory:"false" json:"recordsWritten"`
+
+	// Number of bytes processed in task run.
+	BytesProcessed *int64 `mandatory:"false" json:"bytesProcessed"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// The type of the task for the run.
+	TaskType TaskRunDetailsTaskTypeEnum `mandatory:"false" json:"taskType,omitempty"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+}
+
+func (m TaskRunDetails) String() string {
+	return common.PointerString(m)
+}
+
+// TaskRunDetailsStatusEnum Enum with underlying type: string
+type TaskRunDetailsStatusEnum string
+
+// Set of constants representing the allowable values for TaskRunDetailsStatusEnum
+const (
+	TaskRunDetailsStatusNotStarted  TaskRunDetailsStatusEnum = "NOT_STARTED"
+	TaskRunDetailsStatusQueued      TaskRunDetailsStatusEnum = "QUEUED"
+	TaskRunDetailsStatusRunning     TaskRunDetailsStatusEnum = "RUNNING"
+	TaskRunDetailsStatusTerminating TaskRunDetailsStatusEnum = "TERMINATING"
+	TaskRunDetailsStatusTerminated  TaskRunDetailsStatusEnum = "TERMINATED"
+	TaskRunDetailsStatusSuccess     TaskRunDetailsStatusEnum = "SUCCESS"
+	TaskRunDetailsStatusError       TaskRunDetailsStatusEnum = "ERROR"
+)
+
+var mappingTaskRunDetailsStatus = map[string]TaskRunDetailsStatusEnum{
+	"NOT_STARTED": TaskRunDetailsStatusNotStarted,
+	"QUEUED":      TaskRunDetailsStatusQueued,
+	"RUNNING":     TaskRunDetailsStatusRunning,
+	"TERMINATING": TaskRunDetailsStatusTerminating,
+	"TERMINATED":  TaskRunDetailsStatusTerminated,
+	"SUCCESS":     TaskRunDetailsStatusSuccess,
+	"ERROR":       TaskRunDetailsStatusError,
+}
+
+// GetTaskRunDetailsStatusEnumValues Enumerates the set of values for TaskRunDetailsStatusEnum
+func GetTaskRunDetailsStatusEnumValues() []TaskRunDetailsStatusEnum {
+	values := make([]TaskRunDetailsStatusEnum, 0)
+	for _, v := range mappingTaskRunDetailsStatus {
+		values = append(values, v)
+	}
+	return values
+}
+
+// TaskRunDetailsTaskTypeEnum Enum with underlying type: string
+type TaskRunDetailsTaskTypeEnum string
+
+// Set of constants representing the allowable values for TaskRunDetailsTaskTypeEnum
+const (
+	TaskRunDetailsTaskTypeIntegrationTask TaskRunDetailsTaskTypeEnum = "INTEGRATION_TASK"
+	TaskRunDetailsTaskTypeDataLoaderTask  TaskRunDetailsTaskTypeEnum = "DATA_LOADER_TASK"
+)
+
+var mappingTaskRunDetailsTaskType = map[string]TaskRunDetailsTaskTypeEnum{
+	"INTEGRATION_TASK": TaskRunDetailsTaskTypeIntegrationTask,
+	"DATA_LOADER_TASK": TaskRunDetailsTaskTypeDataLoaderTask,
+}
+
+// GetTaskRunDetailsTaskTypeEnumValues Enumerates the set of values for TaskRunDetailsTaskTypeEnum
+func GetTaskRunDetailsTaskTypeEnumValues() []TaskRunDetailsTaskTypeEnum {
+	values := make([]TaskRunDetailsTaskTypeEnum, 0)
+	for _, v := range mappingTaskRunDetailsTaskType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/task_run_log_summary.go
+++ b/dataintegration/task_run_log_summary.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TaskRunLogSummary A log message from the execution of a task.
+type TaskRunLogSummary struct {
+
+	// Human-readable log message.
+	Message *string `mandatory:"false" json:"message"`
+}
+
+func (m TaskRunLogSummary) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/task_run_summary.go
+++ b/dataintegration/task_run_summary.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TaskRunSummary The information about TaskRun.
+type TaskRunSummary struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// status
+	Status TaskRunSummaryStatusEnum `mandatory:"false" json:"status,omitempty"`
+
+	// startTimeMillis
+	StartTimeMillis *int64 `mandatory:"false" json:"startTimeMillis"`
+
+	// endTimeMillis
+	EndTimeMillis *int64 `mandatory:"false" json:"endTimeMillis"`
+
+	// lastUpdated
+	LastUpdated *int64 `mandatory:"false" json:"lastUpdated"`
+
+	// Number of records processed in task run.
+	RecordsWritten *int64 `mandatory:"false" json:"recordsWritten"`
+
+	// Number of bytes processed in task run.
+	BytesProcessed *int64 `mandatory:"false" json:"bytesProcessed"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// The type of the task for the run.
+	TaskType TaskRunSummaryTaskTypeEnum `mandatory:"false" json:"taskType,omitempty"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+}
+
+func (m TaskRunSummary) String() string {
+	return common.PointerString(m)
+}
+
+// TaskRunSummaryStatusEnum Enum with underlying type: string
+type TaskRunSummaryStatusEnum string
+
+// Set of constants representing the allowable values for TaskRunSummaryStatusEnum
+const (
+	TaskRunSummaryStatusNotStarted  TaskRunSummaryStatusEnum = "NOT_STARTED"
+	TaskRunSummaryStatusQueued      TaskRunSummaryStatusEnum = "QUEUED"
+	TaskRunSummaryStatusRunning     TaskRunSummaryStatusEnum = "RUNNING"
+	TaskRunSummaryStatusTerminating TaskRunSummaryStatusEnum = "TERMINATING"
+	TaskRunSummaryStatusTerminated  TaskRunSummaryStatusEnum = "TERMINATED"
+	TaskRunSummaryStatusSuccess     TaskRunSummaryStatusEnum = "SUCCESS"
+	TaskRunSummaryStatusError       TaskRunSummaryStatusEnum = "ERROR"
+)
+
+var mappingTaskRunSummaryStatus = map[string]TaskRunSummaryStatusEnum{
+	"NOT_STARTED": TaskRunSummaryStatusNotStarted,
+	"QUEUED":      TaskRunSummaryStatusQueued,
+	"RUNNING":     TaskRunSummaryStatusRunning,
+	"TERMINATING": TaskRunSummaryStatusTerminating,
+	"TERMINATED":  TaskRunSummaryStatusTerminated,
+	"SUCCESS":     TaskRunSummaryStatusSuccess,
+	"ERROR":       TaskRunSummaryStatusError,
+}
+
+// GetTaskRunSummaryStatusEnumValues Enumerates the set of values for TaskRunSummaryStatusEnum
+func GetTaskRunSummaryStatusEnumValues() []TaskRunSummaryStatusEnum {
+	values := make([]TaskRunSummaryStatusEnum, 0)
+	for _, v := range mappingTaskRunSummaryStatus {
+		values = append(values, v)
+	}
+	return values
+}
+
+// TaskRunSummaryTaskTypeEnum Enum with underlying type: string
+type TaskRunSummaryTaskTypeEnum string
+
+// Set of constants representing the allowable values for TaskRunSummaryTaskTypeEnum
+const (
+	TaskRunSummaryTaskTypeIntegrationTask TaskRunSummaryTaskTypeEnum = "INTEGRATION_TASK"
+	TaskRunSummaryTaskTypeDataLoaderTask  TaskRunSummaryTaskTypeEnum = "DATA_LOADER_TASK"
+)
+
+var mappingTaskRunSummaryTaskType = map[string]TaskRunSummaryTaskTypeEnum{
+	"INTEGRATION_TASK": TaskRunSummaryTaskTypeIntegrationTask,
+	"DATA_LOADER_TASK": TaskRunSummaryTaskTypeDataLoaderTask,
+}
+
+// GetTaskRunSummaryTaskTypeEnumValues Enumerates the set of values for TaskRunSummaryTaskTypeEnum
+func GetTaskRunSummaryTaskTypeEnumValues() []TaskRunSummaryTaskTypeEnum {
+	values := make([]TaskRunSummaryTaskTypeEnum, 0)
+	for _, v := range mappingTaskRunSummaryTaskType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/task_run_summary_collection.go
+++ b/dataintegration/task_run_summary_collection.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TaskRunSummaryCollection List of taskRun summaries
+type TaskRunSummaryCollection struct {
+
+	// The array of taskRun summaries
+	Items []TaskRunSummary `mandatory:"true" json:"items"`
+}
+
+func (m TaskRunSummaryCollection) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/task_summary.go
+++ b/dataintegration/task_summary.go
@@ -1,0 +1,235 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TaskSummary The task summary object type contains the audit summary information and the definition of the task summary object.
+type TaskSummary interface {
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	GetKey() *string
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	GetParentRef() *ParentReference
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	GetName() *string
+
+	// Detailed description for the object.
+	GetDescription() *string
+
+	// The version of the object that is used to track changes in the object instance.
+	GetObjectVersion() *int
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	GetIdentifier() *string
+
+	// An array of input ports.
+	GetInputPorts() []InputPort
+
+	// An array of output ports.
+	GetOutputPorts() []OutputPort
+
+	// An array of parameters.
+	GetParameters() []Parameter
+
+	GetOpConfigValues() *ConfigValues
+
+	GetConfigProviderDelegate() *ConfigProvider
+
+	GetMetadata() *ObjectMetadata
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	GetKeyMap() map[string]string
+}
+
+type tasksummary struct {
+	JsonData               []byte
+	Key                    *string           `mandatory:"false" json:"key"`
+	ModelVersion           *string           `mandatory:"false" json:"modelVersion"`
+	ParentRef              *ParentReference  `mandatory:"false" json:"parentRef"`
+	Name                   *string           `mandatory:"false" json:"name"`
+	Description            *string           `mandatory:"false" json:"description"`
+	ObjectVersion          *int              `mandatory:"false" json:"objectVersion"`
+	ObjectStatus           *int              `mandatory:"false" json:"objectStatus"`
+	Identifier             *string           `mandatory:"false" json:"identifier"`
+	InputPorts             []InputPort       `mandatory:"false" json:"inputPorts"`
+	OutputPorts            []OutputPort      `mandatory:"false" json:"outputPorts"`
+	Parameters             []Parameter       `mandatory:"false" json:"parameters"`
+	OpConfigValues         *ConfigValues     `mandatory:"false" json:"opConfigValues"`
+	ConfigProviderDelegate *ConfigProvider   `mandatory:"false" json:"configProviderDelegate"`
+	Metadata               *ObjectMetadata   `mandatory:"false" json:"metadata"`
+	KeyMap                 map[string]string `mandatory:"false" json:"keyMap"`
+	ModelType              string            `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *tasksummary) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalertasksummary tasksummary
+	s := struct {
+		Model Unmarshalertasksummary
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Key = s.Model.Key
+	m.ModelVersion = s.Model.ModelVersion
+	m.ParentRef = s.Model.ParentRef
+	m.Name = s.Model.Name
+	m.Description = s.Model.Description
+	m.ObjectVersion = s.Model.ObjectVersion
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.Identifier = s.Model.Identifier
+	m.InputPorts = s.Model.InputPorts
+	m.OutputPorts = s.Model.OutputPorts
+	m.Parameters = s.Model.Parameters
+	m.OpConfigValues = s.Model.OpConfigValues
+	m.ConfigProviderDelegate = s.Model.ConfigProviderDelegate
+	m.Metadata = s.Model.Metadata
+	m.KeyMap = s.Model.KeyMap
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *tasksummary) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "INTEGRATION_TASK":
+		mm := TaskSummaryFromIntegrationTask{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "DATA_LOADER_TASK":
+		mm := TaskSummaryFromDataLoaderTask{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetKey returns Key
+func (m tasksummary) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m tasksummary) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m tasksummary) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m tasksummary) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m tasksummary) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m tasksummary) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m tasksummary) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m tasksummary) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetInputPorts returns InputPorts
+func (m tasksummary) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m tasksummary) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetParameters returns Parameters
+func (m tasksummary) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m tasksummary) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+//GetConfigProviderDelegate returns ConfigProviderDelegate
+func (m tasksummary) GetConfigProviderDelegate() *ConfigProvider {
+	return m.ConfigProviderDelegate
+}
+
+//GetMetadata returns Metadata
+func (m tasksummary) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m tasksummary) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m tasksummary) String() string {
+	return common.PointerString(m)
+}
+
+// TaskSummaryModelTypeEnum Enum with underlying type: string
+type TaskSummaryModelTypeEnum string
+
+// Set of constants representing the allowable values for TaskSummaryModelTypeEnum
+const (
+	TaskSummaryModelTypeIntegrationTask TaskSummaryModelTypeEnum = "INTEGRATION_TASK"
+	TaskSummaryModelTypeDataLoaderTask  TaskSummaryModelTypeEnum = "DATA_LOADER_TASK"
+)
+
+var mappingTaskSummaryModelType = map[string]TaskSummaryModelTypeEnum{
+	"INTEGRATION_TASK": TaskSummaryModelTypeIntegrationTask,
+	"DATA_LOADER_TASK": TaskSummaryModelTypeDataLoaderTask,
+}
+
+// GetTaskSummaryModelTypeEnumValues Enumerates the set of values for TaskSummaryModelTypeEnum
+func GetTaskSummaryModelTypeEnumValues() []TaskSummaryModelTypeEnum {
+	values := make([]TaskSummaryModelTypeEnum, 0)
+	for _, v := range mappingTaskSummaryModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/task_summary_collection.go
+++ b/dataintegration/task_summary_collection.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TaskSummaryCollection This is the collection of task summaries, it may be a collection of lightweight details or full definitions.
+type TaskSummaryCollection struct {
+
+	// The array of Task summaries.
+	Items []TaskSummary `mandatory:"true" json:"items"`
+}
+
+func (m TaskSummaryCollection) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *TaskSummaryCollection) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Items []tasksummary `json:"items"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Items = make([]TaskSummary, len(model.Items))
+	for i, n := range model.Items {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.Items[i] = nn.(TaskSummary)
+		} else {
+			m.Items[i] = nil
+		}
+	}
+	return
+}

--- a/dataintegration/task_summary_from_data_loader_task.go
+++ b/dataintegration/task_summary_from_data_loader_task.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TaskSummaryFromDataLoaderTask The information about a data flow task.
+type TaskSummaryFromDataLoaderTask struct {
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+
+	ConfigProviderDelegate *ConfigProvider `mandatory:"false" json:"configProviderDelegate"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+
+	DataFlow *DataFlow `mandatory:"false" json:"dataFlow"`
+}
+
+//GetKey returns Key
+func (m TaskSummaryFromDataLoaderTask) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m TaskSummaryFromDataLoaderTask) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m TaskSummaryFromDataLoaderTask) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m TaskSummaryFromDataLoaderTask) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m TaskSummaryFromDataLoaderTask) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m TaskSummaryFromDataLoaderTask) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m TaskSummaryFromDataLoaderTask) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m TaskSummaryFromDataLoaderTask) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetInputPorts returns InputPorts
+func (m TaskSummaryFromDataLoaderTask) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m TaskSummaryFromDataLoaderTask) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetParameters returns Parameters
+func (m TaskSummaryFromDataLoaderTask) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m TaskSummaryFromDataLoaderTask) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+//GetConfigProviderDelegate returns ConfigProviderDelegate
+func (m TaskSummaryFromDataLoaderTask) GetConfigProviderDelegate() *ConfigProvider {
+	return m.ConfigProviderDelegate
+}
+
+//GetMetadata returns Metadata
+func (m TaskSummaryFromDataLoaderTask) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m TaskSummaryFromDataLoaderTask) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m TaskSummaryFromDataLoaderTask) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m TaskSummaryFromDataLoaderTask) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeTaskSummaryFromDataLoaderTask TaskSummaryFromDataLoaderTask
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeTaskSummaryFromDataLoaderTask
+	}{
+		"DATA_LOADER_TASK",
+		(MarshalTypeTaskSummaryFromDataLoaderTask)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/task_summary_from_integration_task.go
+++ b/dataintegration/task_summary_from_integration_task.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TaskSummaryFromIntegrationTask The information about the integration task.
+type TaskSummaryFromIntegrationTask struct {
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+
+	ConfigProviderDelegate *ConfigProvider `mandatory:"false" json:"configProviderDelegate"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+
+	// A map, if provided key is replaced with generated key, this structure provides mapping between user provided key and generated key
+	KeyMap map[string]string `mandatory:"false" json:"keyMap"`
+
+	DataFlow *DataFlow `mandatory:"false" json:"dataFlow"`
+}
+
+//GetKey returns Key
+func (m TaskSummaryFromIntegrationTask) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m TaskSummaryFromIntegrationTask) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m TaskSummaryFromIntegrationTask) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m TaskSummaryFromIntegrationTask) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m TaskSummaryFromIntegrationTask) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m TaskSummaryFromIntegrationTask) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m TaskSummaryFromIntegrationTask) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m TaskSummaryFromIntegrationTask) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetInputPorts returns InputPorts
+func (m TaskSummaryFromIntegrationTask) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m TaskSummaryFromIntegrationTask) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetParameters returns Parameters
+func (m TaskSummaryFromIntegrationTask) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m TaskSummaryFromIntegrationTask) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+//GetConfigProviderDelegate returns ConfigProviderDelegate
+func (m TaskSummaryFromIntegrationTask) GetConfigProviderDelegate() *ConfigProvider {
+	return m.ConfigProviderDelegate
+}
+
+//GetMetadata returns Metadata
+func (m TaskSummaryFromIntegrationTask) GetMetadata() *ObjectMetadata {
+	return m.Metadata
+}
+
+//GetKeyMap returns KeyMap
+func (m TaskSummaryFromIntegrationTask) GetKeyMap() map[string]string {
+	return m.KeyMap
+}
+
+func (m TaskSummaryFromIntegrationTask) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m TaskSummaryFromIntegrationTask) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeTaskSummaryFromIntegrationTask TaskSummaryFromIntegrationTask
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeTaskSummaryFromIntegrationTask
+	}{
+		"INTEGRATION_TASK",
+		(MarshalTypeTaskSummaryFromIntegrationTask)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/task_validation.go
+++ b/dataintegration/task_validation.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TaskValidation The information about task validation
+type TaskValidation struct {
+
+	// Total number of validation messages
+	TotalMessageCount *int `mandatory:"false" json:"totalMessageCount"`
+
+	// Total number of validation error messages
+	ErrorMessageCount *int `mandatory:"false" json:"errorMessageCount"`
+
+	// Total number of validation warning messages
+	WarnMessageCount *int `mandatory:"false" json:"warnMessageCount"`
+
+	// Total number of validation information messages
+	InfoMessageCount *int `mandatory:"false" json:"infoMessageCount"`
+
+	// Detailed information of the DataFlow object validation.
+	ValidationMessages map[string][]ValidationMessage `mandatory:"false" json:"validationMessages"`
+
+	// Objects will use a 36 character key as unique ID. It is system generated and cannot be edited by user
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+}
+
+func (m TaskValidation) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/task_validation_summary.go
+++ b/dataintegration/task_validation_summary.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TaskValidationSummary The information about task validation
+type TaskValidationSummary struct {
+
+	// Total number of validation messages
+	TotalMessageCount *int `mandatory:"false" json:"totalMessageCount"`
+
+	// Total number of validation error messages
+	ErrorMessageCount *int `mandatory:"false" json:"errorMessageCount"`
+
+	// Total number of validation warning messages
+	WarnMessageCount *int `mandatory:"false" json:"warnMessageCount"`
+
+	// Total number of validation information messages
+	InfoMessageCount *int `mandatory:"false" json:"infoMessageCount"`
+
+	// Detailed information of the DataFlow object validation.
+	ValidationMessages map[string][]ValidationMessage `mandatory:"false" json:"validationMessages"`
+
+	// Objects will use a 36 character key as unique ID. It is system generated and cannot be edited by user
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+}
+
+func (m TaskValidationSummary) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/task_validation_summary_collection.go
+++ b/dataintegration/task_validation_summary_collection.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TaskValidationSummaryCollection List of task validation summaries
+type TaskValidationSummaryCollection struct {
+
+	// The array of validation summaries
+	Items []TaskValidationSummary `mandatory:"true" json:"items"`
+}
+
+func (m TaskValidationSummaryCollection) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/type_library.go
+++ b/dataintegration/type_library.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TypeLibrary The DIS type library container type.
+type TypeLibrary struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// types
+	Types map[string]DerivedType `mandatory:"false" json:"types"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+}
+
+func (m TypeLibrary) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/type_list_rule.go
+++ b/dataintegration/type_list_rule.go
@@ -1,0 +1,225 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TypeListRule The type list rule which defines how fields are projected.
+type TypeListRule struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Specifies whether the rule uses a java regex syntax.
+	IsJavaRegexSyntax *bool `mandatory:"false" json:"isJavaRegexSyntax"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// skipRemainingRulesOnMatch
+	IsSkipRemainingRulesOnMatch *bool `mandatory:"false" json:"isSkipRemainingRulesOnMatch"`
+
+	// Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a TypedObject or a full TypedObject definition.
+	Scope *interface{} `mandatory:"false" json:"scope"`
+
+	// cascade
+	IsCascade *bool `mandatory:"false" json:"isCascade"`
+
+	// caseSensitive
+	IsCaseSensitive *bool `mandatory:"false" json:"isCaseSensitive"`
+
+	// types
+	Types []BaseType `mandatory:"false" json:"types"`
+
+	// matchingStrategy
+	MatchingStrategy TypeListRuleMatchingStrategyEnum `mandatory:"false" json:"matchingStrategy,omitempty"`
+
+	// ruleType
+	RuleType TypeListRuleRuleTypeEnum `mandatory:"false" json:"ruleType,omitempty"`
+}
+
+//GetKey returns Key
+func (m TypeListRule) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m TypeListRule) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m TypeListRule) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetIsJavaRegexSyntax returns IsJavaRegexSyntax
+func (m TypeListRule) GetIsJavaRegexSyntax() *bool {
+	return m.IsJavaRegexSyntax
+}
+
+//GetConfigValues returns ConfigValues
+func (m TypeListRule) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m TypeListRule) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetDescription returns Description
+func (m TypeListRule) GetDescription() *string {
+	return m.Description
+}
+
+func (m TypeListRule) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m TypeListRule) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeTypeListRule TypeListRule
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeTypeListRule
+	}{
+		"TYPE_LIST_RULE",
+		(MarshalTypeTypeListRule)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *TypeListRule) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key                         *string                          `json:"key"`
+		ModelVersion                *string                          `json:"modelVersion"`
+		ParentRef                   *ParentReference                 `json:"parentRef"`
+		IsJavaRegexSyntax           *bool                            `json:"isJavaRegexSyntax"`
+		ConfigValues                *ConfigValues                    `json:"configValues"`
+		ObjectStatus                *int                             `json:"objectStatus"`
+		Description                 *string                          `json:"description"`
+		IsSkipRemainingRulesOnMatch *bool                            `json:"isSkipRemainingRulesOnMatch"`
+		Scope                       *interface{}                     `json:"scope"`
+		IsCascade                   *bool                            `json:"isCascade"`
+		MatchingStrategy            TypeListRuleMatchingStrategyEnum `json:"matchingStrategy"`
+		IsCaseSensitive             *bool                            `json:"isCaseSensitive"`
+		RuleType                    TypeListRuleRuleTypeEnum         `json:"ruleType"`
+		Types                       []basetype                       `json:"types"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.IsJavaRegexSyntax = model.IsJavaRegexSyntax
+
+	m.ConfigValues = model.ConfigValues
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.Description = model.Description
+
+	m.IsSkipRemainingRulesOnMatch = model.IsSkipRemainingRulesOnMatch
+
+	m.Scope = model.Scope
+
+	m.IsCascade = model.IsCascade
+
+	m.MatchingStrategy = model.MatchingStrategy
+
+	m.IsCaseSensitive = model.IsCaseSensitive
+
+	m.RuleType = model.RuleType
+
+	m.Types = make([]BaseType, len(model.Types))
+	for i, n := range model.Types {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.Types[i] = nn.(BaseType)
+		} else {
+			m.Types[i] = nil
+		}
+	}
+	return
+}
+
+// TypeListRuleMatchingStrategyEnum Enum with underlying type: string
+type TypeListRuleMatchingStrategyEnum string
+
+// Set of constants representing the allowable values for TypeListRuleMatchingStrategyEnum
+const (
+	TypeListRuleMatchingStrategyNameOrTags TypeListRuleMatchingStrategyEnum = "NAME_OR_TAGS"
+	TypeListRuleMatchingStrategyTagsOnly   TypeListRuleMatchingStrategyEnum = "TAGS_ONLY"
+	TypeListRuleMatchingStrategyNameOnly   TypeListRuleMatchingStrategyEnum = "NAME_ONLY"
+)
+
+var mappingTypeListRuleMatchingStrategy = map[string]TypeListRuleMatchingStrategyEnum{
+	"NAME_OR_TAGS": TypeListRuleMatchingStrategyNameOrTags,
+	"TAGS_ONLY":    TypeListRuleMatchingStrategyTagsOnly,
+	"NAME_ONLY":    TypeListRuleMatchingStrategyNameOnly,
+}
+
+// GetTypeListRuleMatchingStrategyEnumValues Enumerates the set of values for TypeListRuleMatchingStrategyEnum
+func GetTypeListRuleMatchingStrategyEnumValues() []TypeListRuleMatchingStrategyEnum {
+	values := make([]TypeListRuleMatchingStrategyEnum, 0)
+	for _, v := range mappingTypeListRuleMatchingStrategy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// TypeListRuleRuleTypeEnum Enum with underlying type: string
+type TypeListRuleRuleTypeEnum string
+
+// Set of constants representing the allowable values for TypeListRuleRuleTypeEnum
+const (
+	TypeListRuleRuleTypeInclude TypeListRuleRuleTypeEnum = "INCLUDE"
+	TypeListRuleRuleTypeExclude TypeListRuleRuleTypeEnum = "EXCLUDE"
+)
+
+var mappingTypeListRuleRuleType = map[string]TypeListRuleRuleTypeEnum{
+	"INCLUDE": TypeListRuleRuleTypeInclude,
+	"EXCLUDE": TypeListRuleRuleTypeExclude,
+}
+
+// GetTypeListRuleRuleTypeEnumValues Enumerates the set of values for TypeListRuleRuleTypeEnum
+func GetTypeListRuleRuleTypeEnumValues() []TypeListRuleRuleTypeEnum {
+	values := make([]TypeListRuleRuleTypeEnum, 0)
+	for _, v := range mappingTypeListRuleRuleType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/type_system.go
+++ b/dataintegration/type_system.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TypeSystem The type system maps from and to a type.
+type TypeSystem struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	// typeMappingTo
+	TypeMappingTo map[string]string `mandatory:"false" json:"typeMappingTo"`
+
+	// typeMappingFrom
+	TypeMappingFrom map[string]string `mandatory:"false" json:"typeMappingFrom"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// types
+	Types []DataType `mandatory:"false" json:"types"`
+}
+
+func (m TypeSystem) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/typed_name_pattern_rule.go
+++ b/dataintegration/typed_name_pattern_rule.go
@@ -1,0 +1,234 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TypedNamePatternRule The typed name rule for field projection.
+type TypedNamePatternRule struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Specifies whether the rule uses a java regex syntax.
+	IsJavaRegexSyntax *bool `mandatory:"false" json:"isJavaRegexSyntax"`
+
+	ConfigValues *ConfigValues `mandatory:"false" json:"configValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// types
+	Types []BaseType `mandatory:"false" json:"types"`
+
+	// skipRemainingRulesOnMatch
+	IsSkipRemainingRulesOnMatch *bool `mandatory:"false" json:"isSkipRemainingRulesOnMatch"`
+
+	// Reference to a typed object, this can be either a key value to an object within the document, a shall referenced to a TypedObject or a full TypedObject definition.
+	Scope *interface{} `mandatory:"false" json:"scope"`
+
+	// cascade
+	IsCascade *bool `mandatory:"false" json:"isCascade"`
+
+	// caseSensitive
+	IsCaseSensitive *bool `mandatory:"false" json:"isCaseSensitive"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Names []string `mandatory:"false" json:"names"`
+
+	// matchingStrategy
+	MatchingStrategy TypedNamePatternRuleMatchingStrategyEnum `mandatory:"false" json:"matchingStrategy,omitempty"`
+
+	// ruleType
+	RuleType TypedNamePatternRuleRuleTypeEnum `mandatory:"false" json:"ruleType,omitempty"`
+}
+
+//GetKey returns Key
+func (m TypedNamePatternRule) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m TypedNamePatternRule) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m TypedNamePatternRule) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetIsJavaRegexSyntax returns IsJavaRegexSyntax
+func (m TypedNamePatternRule) GetIsJavaRegexSyntax() *bool {
+	return m.IsJavaRegexSyntax
+}
+
+//GetConfigValues returns ConfigValues
+func (m TypedNamePatternRule) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m TypedNamePatternRule) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetDescription returns Description
+func (m TypedNamePatternRule) GetDescription() *string {
+	return m.Description
+}
+
+func (m TypedNamePatternRule) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m TypedNamePatternRule) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeTypedNamePatternRule TypedNamePatternRule
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeTypedNamePatternRule
+	}{
+		"TYPED_NAME_PATTERN_RULE",
+		(MarshalTypeTypedNamePatternRule)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *TypedNamePatternRule) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key                         *string                                  `json:"key"`
+		ModelVersion                *string                                  `json:"modelVersion"`
+		ParentRef                   *ParentReference                         `json:"parentRef"`
+		IsJavaRegexSyntax           *bool                                    `json:"isJavaRegexSyntax"`
+		ConfigValues                *ConfigValues                            `json:"configValues"`
+		ObjectStatus                *int                                     `json:"objectStatus"`
+		Description                 *string                                  `json:"description"`
+		Types                       []basetype                               `json:"types"`
+		IsSkipRemainingRulesOnMatch *bool                                    `json:"isSkipRemainingRulesOnMatch"`
+		Scope                       *interface{}                             `json:"scope"`
+		IsCascade                   *bool                                    `json:"isCascade"`
+		MatchingStrategy            TypedNamePatternRuleMatchingStrategyEnum `json:"matchingStrategy"`
+		IsCaseSensitive             *bool                                    `json:"isCaseSensitive"`
+		RuleType                    TypedNamePatternRuleRuleTypeEnum         `json:"ruleType"`
+		Names                       []string                                 `json:"names"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.IsJavaRegexSyntax = model.IsJavaRegexSyntax
+
+	m.ConfigValues = model.ConfigValues
+
+	m.ObjectStatus = model.ObjectStatus
+
+	m.Description = model.Description
+
+	m.Types = make([]BaseType, len(model.Types))
+	for i, n := range model.Types {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.Types[i] = nn.(BaseType)
+		} else {
+			m.Types[i] = nil
+		}
+	}
+
+	m.IsSkipRemainingRulesOnMatch = model.IsSkipRemainingRulesOnMatch
+
+	m.Scope = model.Scope
+
+	m.IsCascade = model.IsCascade
+
+	m.MatchingStrategy = model.MatchingStrategy
+
+	m.IsCaseSensitive = model.IsCaseSensitive
+
+	m.RuleType = model.RuleType
+
+	m.Names = make([]string, len(model.Names))
+	for i, n := range model.Names {
+		m.Names[i] = n
+	}
+	return
+}
+
+// TypedNamePatternRuleMatchingStrategyEnum Enum with underlying type: string
+type TypedNamePatternRuleMatchingStrategyEnum string
+
+// Set of constants representing the allowable values for TypedNamePatternRuleMatchingStrategyEnum
+const (
+	TypedNamePatternRuleMatchingStrategyNameOrTags TypedNamePatternRuleMatchingStrategyEnum = "NAME_OR_TAGS"
+	TypedNamePatternRuleMatchingStrategyTagsOnly   TypedNamePatternRuleMatchingStrategyEnum = "TAGS_ONLY"
+	TypedNamePatternRuleMatchingStrategyNameOnly   TypedNamePatternRuleMatchingStrategyEnum = "NAME_ONLY"
+)
+
+var mappingTypedNamePatternRuleMatchingStrategy = map[string]TypedNamePatternRuleMatchingStrategyEnum{
+	"NAME_OR_TAGS": TypedNamePatternRuleMatchingStrategyNameOrTags,
+	"TAGS_ONLY":    TypedNamePatternRuleMatchingStrategyTagsOnly,
+	"NAME_ONLY":    TypedNamePatternRuleMatchingStrategyNameOnly,
+}
+
+// GetTypedNamePatternRuleMatchingStrategyEnumValues Enumerates the set of values for TypedNamePatternRuleMatchingStrategyEnum
+func GetTypedNamePatternRuleMatchingStrategyEnumValues() []TypedNamePatternRuleMatchingStrategyEnum {
+	values := make([]TypedNamePatternRuleMatchingStrategyEnum, 0)
+	for _, v := range mappingTypedNamePatternRuleMatchingStrategy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// TypedNamePatternRuleRuleTypeEnum Enum with underlying type: string
+type TypedNamePatternRuleRuleTypeEnum string
+
+// Set of constants representing the allowable values for TypedNamePatternRuleRuleTypeEnum
+const (
+	TypedNamePatternRuleRuleTypeInclude TypedNamePatternRuleRuleTypeEnum = "INCLUDE"
+	TypedNamePatternRuleRuleTypeExclude TypedNamePatternRuleRuleTypeEnum = "EXCLUDE"
+)
+
+var mappingTypedNamePatternRuleRuleType = map[string]TypedNamePatternRuleRuleTypeEnum{
+	"INCLUDE": TypedNamePatternRuleRuleTypeInclude,
+	"EXCLUDE": TypedNamePatternRuleRuleTypeExclude,
+}
+
+// GetTypedNamePatternRuleRuleTypeEnumValues Enumerates the set of values for TypedNamePatternRuleRuleTypeEnum
+func GetTypedNamePatternRuleRuleTypeEnumValues() []TypedNamePatternRuleRuleTypeEnum {
+	values := make([]TypedNamePatternRuleRuleTypeEnum, 0)
+	for _, v := range mappingTypedNamePatternRuleRuleType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/typed_object.go
+++ b/dataintegration/typed_object.go
@@ -1,0 +1,219 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// TypedObject The TypedObject class is a base class for any model object that has a type.
+type TypedObject interface {
+
+	// The key of the object.
+	GetKey() *string
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	GetParentRef() *ParentReference
+
+	GetConfigValues() *ConfigValues
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	GetName() *string
+
+	// Detailed description for the object.
+	GetDescription() *string
+}
+
+type typedobject struct {
+	JsonData     []byte
+	Key          *string          `mandatory:"false" json:"key"`
+	ModelVersion *string          `mandatory:"false" json:"modelVersion"`
+	ParentRef    *ParentReference `mandatory:"false" json:"parentRef"`
+	ConfigValues *ConfigValues    `mandatory:"false" json:"configValues"`
+	ObjectStatus *int             `mandatory:"false" json:"objectStatus"`
+	Name         *string          `mandatory:"false" json:"name"`
+	Description  *string          `mandatory:"false" json:"description"`
+	ModelType    string           `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *typedobject) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalertypedobject typedobject
+	s := struct {
+		Model Unmarshalertypedobject
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Key = s.Model.Key
+	m.ModelVersion = s.Model.ModelVersion
+	m.ParentRef = s.Model.ParentRef
+	m.ConfigValues = s.Model.ConfigValues
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.Name = s.Model.Name
+	m.Description = s.Model.Description
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *typedobject) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "OUTPUT_PORT":
+		mm := OutputPort{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "DYNAMIC_INPUT_FIELD":
+		mm := DynamicInputField{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "FIELD":
+		mm := AbstractField{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "INPUT_FIELD":
+		mm := InputField{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "SHAPE":
+		mm := Shape{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "INPUT_PORT":
+		mm := InputPort{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "PROXY_FIELD":
+		mm := ProxyField{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "DYNAMIC_PROXY_FIELD":
+		mm := DynamicProxyField{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "SHAPE_FIELD":
+		mm := ShapeField{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "PARAMETER":
+		mm := Parameter{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "OUTPUT_FIELD":
+		mm := OutputField{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "DERIVED_FIELD":
+		mm := DerivedField{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "FLOW_PORT":
+		mm := FlowPort{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetKey returns Key
+func (m typedobject) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m typedobject) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m typedobject) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetConfigValues returns ConfigValues
+func (m typedobject) GetConfigValues() *ConfigValues {
+	return m.ConfigValues
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m typedobject) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetName returns Name
+func (m typedobject) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m typedobject) GetDescription() *string {
+	return m.Description
+}
+
+func (m typedobject) String() string {
+	return common.PointerString(m)
+}
+
+// TypedObjectModelTypeEnum Enum with underlying type: string
+type TypedObjectModelTypeEnum string
+
+// Set of constants representing the allowable values for TypedObjectModelTypeEnum
+const (
+	TypedObjectModelTypeShape             TypedObjectModelTypeEnum = "SHAPE"
+	TypedObjectModelTypeInputPort         TypedObjectModelTypeEnum = "INPUT_PORT"
+	TypedObjectModelTypeShapeField        TypedObjectModelTypeEnum = "SHAPE_FIELD"
+	TypedObjectModelTypeInputField        TypedObjectModelTypeEnum = "INPUT_FIELD"
+	TypedObjectModelTypeDerivedField      TypedObjectModelTypeEnum = "DERIVED_FIELD"
+	TypedObjectModelTypeOutputField       TypedObjectModelTypeEnum = "OUTPUT_FIELD"
+	TypedObjectModelTypeDynamicProxyField TypedObjectModelTypeEnum = "DYNAMIC_PROXY_FIELD"
+	TypedObjectModelTypeOutputPort        TypedObjectModelTypeEnum = "OUTPUT_PORT"
+	TypedObjectModelTypeDynamicInputField TypedObjectModelTypeEnum = "DYNAMIC_INPUT_FIELD"
+	TypedObjectModelTypeProxyField        TypedObjectModelTypeEnum = "PROXY_FIELD"
+	TypedObjectModelTypeParameter         TypedObjectModelTypeEnum = "PARAMETER"
+)
+
+var mappingTypedObjectModelType = map[string]TypedObjectModelTypeEnum{
+	"SHAPE":               TypedObjectModelTypeShape,
+	"INPUT_PORT":          TypedObjectModelTypeInputPort,
+	"SHAPE_FIELD":         TypedObjectModelTypeShapeField,
+	"INPUT_FIELD":         TypedObjectModelTypeInputField,
+	"DERIVED_FIELD":       TypedObjectModelTypeDerivedField,
+	"OUTPUT_FIELD":        TypedObjectModelTypeOutputField,
+	"DYNAMIC_PROXY_FIELD": TypedObjectModelTypeDynamicProxyField,
+	"OUTPUT_PORT":         TypedObjectModelTypeOutputPort,
+	"DYNAMIC_INPUT_FIELD": TypedObjectModelTypeDynamicInputField,
+	"PROXY_FIELD":         TypedObjectModelTypeProxyField,
+	"PARAMETER":           TypedObjectModelTypeParameter,
+}
+
+// GetTypedObjectModelTypeEnumValues Enumerates the set of values for TypedObjectModelTypeEnum
+func GetTypedObjectModelTypeEnumValues() []TypedObjectModelTypeEnum {
+	values := make([]TypedObjectModelTypeEnum, 0)
+	for _, v := range mappingTypedObjectModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/ui_properties.go
+++ b/dataintegration/ui_properties.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UiProperties The UI properties of the object.
+type UiProperties struct {
+
+	// coordinateX
+	CoordinateX *float32 `mandatory:"false" json:"coordinateX"`
+
+	// coordinateY
+	CoordinateY *float32 `mandatory:"false" json:"coordinateY"`
+}
+
+func (m UiProperties) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/unique_key.go
+++ b/dataintegration/unique_key.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UniqueKey The unqique key object.
+type UniqueKey struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// attributeRefs
+	AttributeRefs []KeyAttribute `mandatory:"false" json:"attributeRefs"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+}
+
+func (m UniqueKey) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m UniqueKey) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeUniqueKey UniqueKey
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeUniqueKey
+	}{
+		"UNIQUE_KEY",
+		(MarshalTypeUniqueKey)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/update_application_details.go
+++ b/dataintegration/update_application_details.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateApplicationDetails Properties used in application create operations.
+type UpdateApplicationDetails struct {
+
+	// Generated key that can be used in API calls to identify application.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"true" json:"modelType"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"true" json:"objectVersion"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// version
+	ApplicationVersion *int `mandatory:"false" json:"applicationVersion"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	Metadata *ObjectMetadata `mandatory:"false" json:"metadata"`
+}
+
+func (m UpdateApplicationDetails) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/update_application_request_response.go
+++ b/dataintegration/update_application_request_response.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateApplicationRequest wrapper for the UpdateApplication operation
+type UpdateApplicationRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS application key
+	ApplicationKey *string `mandatory:"true" contributesTo:"path" name:"applicationKey"`
+
+	// The details needed to update an application.
+	UpdateApplicationDetails `contributesTo:"body"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateApplicationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateApplicationRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateApplicationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateApplicationResponse wrapper for the UpdateApplication operation
+type UpdateApplicationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Application instance
+	Application `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateApplicationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateApplicationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/update_connection_details.go
+++ b/dataintegration/update_connection_details.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateConnectionDetails Properties used in connection update operations.
+type UpdateConnectionDetails interface {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	GetKey() *string
+
+	// The version of the object that is used to track changes in the object instance.
+	GetObjectVersion() *int
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	GetParentRef() *ParentReference
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	GetName() *string
+
+	// Detailed description for the object.
+	GetDescription() *string
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	GetIdentifier() *string
+
+	// The properties for the connection.
+	GetConnectionProperties() []ConnectionProperty
+
+	GetRegistryMetadata() *RegistryMetadata
+}
+
+type updateconnectiondetails struct {
+	JsonData             []byte
+	Key                  *string              `mandatory:"true" json:"key"`
+	ObjectVersion        *int                 `mandatory:"true" json:"objectVersion"`
+	ModelVersion         *string              `mandatory:"false" json:"modelVersion"`
+	ParentRef            *ParentReference     `mandatory:"false" json:"parentRef"`
+	Name                 *string              `mandatory:"false" json:"name"`
+	Description          *string              `mandatory:"false" json:"description"`
+	ObjectStatus         *int                 `mandatory:"false" json:"objectStatus"`
+	Identifier           *string              `mandatory:"false" json:"identifier"`
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+	RegistryMetadata     *RegistryMetadata    `mandatory:"false" json:"registryMetadata"`
+	ModelType            string               `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *updateconnectiondetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerupdateconnectiondetails updateconnectiondetails
+	s := struct {
+		Model Unmarshalerupdateconnectiondetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Key = s.Model.Key
+	m.ObjectVersion = s.Model.ObjectVersion
+	m.ModelVersion = s.Model.ModelVersion
+	m.ParentRef = s.Model.ParentRef
+	m.Name = s.Model.Name
+	m.Description = s.Model.Description
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.Identifier = s.Model.Identifier
+	m.ConnectionProperties = s.Model.ConnectionProperties
+	m.RegistryMetadata = s.Model.RegistryMetadata
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *updateconnectiondetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "ORACLE_OBJECT_STORAGE_CONNECTION":
+		mm := UpdateConnectionFromObjectStorage{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_ATP_CONNECTION":
+		mm := UpdateConnectionFromAtp{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLEDB_CONNECTION":
+		mm := UpdateConnectionFromOracle{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_ADWC_CONNECTION":
+		mm := UpdateConnectionFromAdwc{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetKey returns Key
+func (m updateconnectiondetails) GetKey() *string {
+	return m.Key
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m updateconnectiondetails) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetModelVersion returns ModelVersion
+func (m updateconnectiondetails) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m updateconnectiondetails) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m updateconnectiondetails) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m updateconnectiondetails) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m updateconnectiondetails) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m updateconnectiondetails) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m updateconnectiondetails) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m updateconnectiondetails) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m updateconnectiondetails) String() string {
+	return common.PointerString(m)
+}
+
+// UpdateConnectionDetailsModelTypeEnum Enum with underlying type: string
+type UpdateConnectionDetailsModelTypeEnum string
+
+// Set of constants representing the allowable values for UpdateConnectionDetailsModelTypeEnum
+const (
+	UpdateConnectionDetailsModelTypeOracleAdwcConnection          UpdateConnectionDetailsModelTypeEnum = "ORACLE_ADWC_CONNECTION"
+	UpdateConnectionDetailsModelTypeOracleAtpConnection           UpdateConnectionDetailsModelTypeEnum = "ORACLE_ATP_CONNECTION"
+	UpdateConnectionDetailsModelTypeOracleObjectStorageConnection UpdateConnectionDetailsModelTypeEnum = "ORACLE_OBJECT_STORAGE_CONNECTION"
+	UpdateConnectionDetailsModelTypeOracledbConnection            UpdateConnectionDetailsModelTypeEnum = "ORACLEDB_CONNECTION"
+)
+
+var mappingUpdateConnectionDetailsModelType = map[string]UpdateConnectionDetailsModelTypeEnum{
+	"ORACLE_ADWC_CONNECTION":           UpdateConnectionDetailsModelTypeOracleAdwcConnection,
+	"ORACLE_ATP_CONNECTION":            UpdateConnectionDetailsModelTypeOracleAtpConnection,
+	"ORACLE_OBJECT_STORAGE_CONNECTION": UpdateConnectionDetailsModelTypeOracleObjectStorageConnection,
+	"ORACLEDB_CONNECTION":              UpdateConnectionDetailsModelTypeOracledbConnection,
+}
+
+// GetUpdateConnectionDetailsModelTypeEnumValues Enumerates the set of values for UpdateConnectionDetailsModelTypeEnum
+func GetUpdateConnectionDetailsModelTypeEnumValues() []UpdateConnectionDetailsModelTypeEnum {
+	values := make([]UpdateConnectionDetailsModelTypeEnum, 0)
+	for _, v := range mappingUpdateConnectionDetailsModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/update_connection_from_adwc.go
+++ b/dataintegration/update_connection_from_adwc.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateConnectionFromAdwc The ADWC connection details object.
+type UpdateConnectionFromAdwc struct {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"true" json:"objectVersion"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+
+	// The user name for the connection.
+	Username *string `mandatory:"false" json:"username"`
+
+	// The password for the connection.
+	Password *string `mandatory:"false" json:"password"`
+}
+
+//GetKey returns Key
+func (m UpdateConnectionFromAdwc) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m UpdateConnectionFromAdwc) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m UpdateConnectionFromAdwc) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m UpdateConnectionFromAdwc) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m UpdateConnectionFromAdwc) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m UpdateConnectionFromAdwc) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m UpdateConnectionFromAdwc) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetIdentifier returns Identifier
+func (m UpdateConnectionFromAdwc) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m UpdateConnectionFromAdwc) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m UpdateConnectionFromAdwc) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m UpdateConnectionFromAdwc) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m UpdateConnectionFromAdwc) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeUpdateConnectionFromAdwc UpdateConnectionFromAdwc
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeUpdateConnectionFromAdwc
+	}{
+		"ORACLE_ADWC_CONNECTION",
+		(MarshalTypeUpdateConnectionFromAdwc)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/update_connection_from_atp.go
+++ b/dataintegration/update_connection_from_atp.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateConnectionFromAtp The ATP connection details.
+type UpdateConnectionFromAtp struct {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"true" json:"objectVersion"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+
+	// The user name for the connection.
+	Username *string `mandatory:"false" json:"username"`
+
+	// The password for the connection.
+	Password *string `mandatory:"false" json:"password"`
+}
+
+//GetKey returns Key
+func (m UpdateConnectionFromAtp) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m UpdateConnectionFromAtp) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m UpdateConnectionFromAtp) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m UpdateConnectionFromAtp) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m UpdateConnectionFromAtp) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m UpdateConnectionFromAtp) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m UpdateConnectionFromAtp) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetIdentifier returns Identifier
+func (m UpdateConnectionFromAtp) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m UpdateConnectionFromAtp) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m UpdateConnectionFromAtp) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m UpdateConnectionFromAtp) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m UpdateConnectionFromAtp) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeUpdateConnectionFromAtp UpdateConnectionFromAtp
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeUpdateConnectionFromAtp
+	}{
+		"ORACLE_ATP_CONNECTION",
+		(MarshalTypeUpdateConnectionFromAtp)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/update_connection_from_object_storage.go
+++ b/dataintegration/update_connection_from_object_storage.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateConnectionFromObjectStorage The Object Storage connection details.
+type UpdateConnectionFromObjectStorage struct {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"true" json:"objectVersion"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+
+	// The credential file content from a wallet for the data asset.
+	CredentialFileContent *string `mandatory:"false" json:"credentialFileContent"`
+
+	// The OCI user OCID for the user to connect to.
+	UserId *string `mandatory:"false" json:"userId"`
+
+	// The fingeprint for the user.
+	FingerPrint *string `mandatory:"false" json:"fingerPrint"`
+
+	// The pass phrase for the connection.
+	PassPhrase *string `mandatory:"false" json:"passPhrase"`
+}
+
+//GetKey returns Key
+func (m UpdateConnectionFromObjectStorage) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m UpdateConnectionFromObjectStorage) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m UpdateConnectionFromObjectStorage) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m UpdateConnectionFromObjectStorage) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m UpdateConnectionFromObjectStorage) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m UpdateConnectionFromObjectStorage) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m UpdateConnectionFromObjectStorage) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetIdentifier returns Identifier
+func (m UpdateConnectionFromObjectStorage) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m UpdateConnectionFromObjectStorage) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m UpdateConnectionFromObjectStorage) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m UpdateConnectionFromObjectStorage) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m UpdateConnectionFromObjectStorage) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeUpdateConnectionFromObjectStorage UpdateConnectionFromObjectStorage
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeUpdateConnectionFromObjectStorage
+	}{
+		"ORACLE_OBJECT_STORAGE_CONNECTION",
+		(MarshalTypeUpdateConnectionFromObjectStorage)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/update_connection_from_oracle.go
+++ b/dataintegration/update_connection_from_oracle.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateConnectionFromOracle The Oracle connection details object.
+type UpdateConnectionFromOracle struct {
+
+	// Generated key that can be used in API calls to identify connection. On scenarios where reference to the connection is needed, a value can be passed in create.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"true" json:"objectVersion"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The properties for the connection.
+	ConnectionProperties []ConnectionProperty `mandatory:"false" json:"connectionProperties"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+
+	// The user name for the connection.
+	Username *string `mandatory:"false" json:"username"`
+
+	// The password for the connection.
+	Password *string `mandatory:"false" json:"password"`
+}
+
+//GetKey returns Key
+func (m UpdateConnectionFromOracle) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m UpdateConnectionFromOracle) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m UpdateConnectionFromOracle) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m UpdateConnectionFromOracle) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m UpdateConnectionFromOracle) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m UpdateConnectionFromOracle) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m UpdateConnectionFromOracle) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetIdentifier returns Identifier
+func (m UpdateConnectionFromOracle) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetConnectionProperties returns ConnectionProperties
+func (m UpdateConnectionFromOracle) GetConnectionProperties() []ConnectionProperty {
+	return m.ConnectionProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m UpdateConnectionFromOracle) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m UpdateConnectionFromOracle) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m UpdateConnectionFromOracle) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeUpdateConnectionFromOracle UpdateConnectionFromOracle
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeUpdateConnectionFromOracle
+	}{
+		"ORACLEDB_CONNECTION",
+		(MarshalTypeUpdateConnectionFromOracle)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/update_connection_request_response.go
+++ b/dataintegration/update_connection_request_response.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateConnectionRequest wrapper for the UpdateConnection operation
+type UpdateConnectionRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// The connection key
+	ConnectionKey *string `mandatory:"true" contributesTo:"path" name:"connectionKey"`
+
+	// Request body parameter for connection details
+	UpdateConnectionDetails `contributesTo:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateConnectionRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateConnectionRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateConnectionRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateConnectionResponse wrapper for the UpdateConnection operation
+type UpdateConnectionResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Connection instance
+	Connection `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateConnectionResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateConnectionResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/update_data_asset_details.go
+++ b/dataintegration/update_data_asset_details.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateDataAssetDetails Properties used in data asset update operations.
+type UpdateDataAssetDetails interface {
+
+	// Generated key that can be used in API calls to identify data asset.
+	GetKey() *string
+
+	// The version of the object that is used to track changes in the object instance.
+	GetObjectVersion() *int
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	GetName() *string
+
+	// Detailed description for the object.
+	GetDescription() *string
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	GetIdentifier() *string
+
+	// The external key for the object
+	GetExternalKey() *string
+
+	// assetProperties
+	GetAssetProperties() map[string]string
+
+	GetRegistryMetadata() *RegistryMetadata
+}
+
+type updatedataassetdetails struct {
+	JsonData         []byte
+	Key              *string           `mandatory:"true" json:"key"`
+	ObjectVersion    *int              `mandatory:"true" json:"objectVersion"`
+	ModelVersion     *string           `mandatory:"false" json:"modelVersion"`
+	Name             *string           `mandatory:"false" json:"name"`
+	Description      *string           `mandatory:"false" json:"description"`
+	ObjectStatus     *int              `mandatory:"false" json:"objectStatus"`
+	Identifier       *string           `mandatory:"false" json:"identifier"`
+	ExternalKey      *string           `mandatory:"false" json:"externalKey"`
+	AssetProperties  map[string]string `mandatory:"false" json:"assetProperties"`
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+	ModelType        string            `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *updatedataassetdetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerupdatedataassetdetails updatedataassetdetails
+	s := struct {
+		Model Unmarshalerupdatedataassetdetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Key = s.Model.Key
+	m.ObjectVersion = s.Model.ObjectVersion
+	m.ModelVersion = s.Model.ModelVersion
+	m.Name = s.Model.Name
+	m.Description = s.Model.Description
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.Identifier = s.Model.Identifier
+	m.ExternalKey = s.Model.ExternalKey
+	m.AssetProperties = s.Model.AssetProperties
+	m.RegistryMetadata = s.Model.RegistryMetadata
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *updatedataassetdetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "ORACLE_ATP_DATA_ASSET":
+		mm := UpdateDataAssetFromAtp{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_ADWC_DATA_ASSET":
+		mm := UpdateDataAssetFromAdwc{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_OBJECT_STORAGE_DATA_ASSET":
+		mm := UpdateDataAssetFromObjectStorage{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "ORACLE_DATA_ASSET":
+		mm := UpdateDataAssetFromOracle{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetKey returns Key
+func (m updatedataassetdetails) GetKey() *string {
+	return m.Key
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m updatedataassetdetails) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetModelVersion returns ModelVersion
+func (m updatedataassetdetails) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetName returns Name
+func (m updatedataassetdetails) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m updatedataassetdetails) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m updatedataassetdetails) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m updatedataassetdetails) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetExternalKey returns ExternalKey
+func (m updatedataassetdetails) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m updatedataassetdetails) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m updatedataassetdetails) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m updatedataassetdetails) String() string {
+	return common.PointerString(m)
+}
+
+// UpdateDataAssetDetailsModelTypeEnum Enum with underlying type: string
+type UpdateDataAssetDetailsModelTypeEnum string
+
+// Set of constants representing the allowable values for UpdateDataAssetDetailsModelTypeEnum
+const (
+	UpdateDataAssetDetailsModelTypeDataAsset              UpdateDataAssetDetailsModelTypeEnum = "ORACLE_DATA_ASSET"
+	UpdateDataAssetDetailsModelTypeObjectStorageDataAsset UpdateDataAssetDetailsModelTypeEnum = "ORACLE_OBJECT_STORAGE_DATA_ASSET"
+	UpdateDataAssetDetailsModelTypeAtpDataAsset           UpdateDataAssetDetailsModelTypeEnum = "ORACLE_ATP_DATA_ASSET"
+	UpdateDataAssetDetailsModelTypeAdwcDataAsset          UpdateDataAssetDetailsModelTypeEnum = "ORACLE_ADWC_DATA_ASSET"
+)
+
+var mappingUpdateDataAssetDetailsModelType = map[string]UpdateDataAssetDetailsModelTypeEnum{
+	"ORACLE_DATA_ASSET":                UpdateDataAssetDetailsModelTypeDataAsset,
+	"ORACLE_OBJECT_STORAGE_DATA_ASSET": UpdateDataAssetDetailsModelTypeObjectStorageDataAsset,
+	"ORACLE_ATP_DATA_ASSET":            UpdateDataAssetDetailsModelTypeAtpDataAsset,
+	"ORACLE_ADWC_DATA_ASSET":           UpdateDataAssetDetailsModelTypeAdwcDataAsset,
+}
+
+// GetUpdateDataAssetDetailsModelTypeEnumValues Enumerates the set of values for UpdateDataAssetDetailsModelTypeEnum
+func GetUpdateDataAssetDetailsModelTypeEnumValues() []UpdateDataAssetDetailsModelTypeEnum {
+	values := make([]UpdateDataAssetDetailsModelTypeEnum, 0)
+	for _, v := range mappingUpdateDataAssetDetailsModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/update_data_asset_from_adwc.go
+++ b/dataintegration/update_data_asset_from_adwc.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateDataAssetFromAdwc The Oracle data asset details.
+type UpdateDataAssetFromAdwc struct {
+
+	// Generated key that can be used in API calls to identify data asset.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"true" json:"objectVersion"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The external key for the object
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	// assetProperties
+	AssetProperties map[string]string `mandatory:"false" json:"assetProperties"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+
+	// The service name for the data asset.
+	ServiceName *string `mandatory:"false" json:"serviceName"`
+
+	// The driver class for the data asset.
+	DriverClass *string `mandatory:"false" json:"driverClass"`
+
+	// The credential file content from a wallet for the data asset.
+	CredentialFileContent *string `mandatory:"false" json:"credentialFileContent"`
+
+	DefaultConnection *UpdateConnectionFromAdwc `mandatory:"false" json:"defaultConnection"`
+}
+
+//GetKey returns Key
+func (m UpdateDataAssetFromAdwc) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m UpdateDataAssetFromAdwc) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetName returns Name
+func (m UpdateDataAssetFromAdwc) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m UpdateDataAssetFromAdwc) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m UpdateDataAssetFromAdwc) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m UpdateDataAssetFromAdwc) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetIdentifier returns Identifier
+func (m UpdateDataAssetFromAdwc) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetExternalKey returns ExternalKey
+func (m UpdateDataAssetFromAdwc) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m UpdateDataAssetFromAdwc) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m UpdateDataAssetFromAdwc) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m UpdateDataAssetFromAdwc) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m UpdateDataAssetFromAdwc) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeUpdateDataAssetFromAdwc UpdateDataAssetFromAdwc
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeUpdateDataAssetFromAdwc
+	}{
+		"ORACLE_ADWC_DATA_ASSET",
+		(MarshalTypeUpdateDataAssetFromAdwc)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/update_data_asset_from_atp.go
+++ b/dataintegration/update_data_asset_from_atp.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateDataAssetFromAtp The Oracle data asset details.
+type UpdateDataAssetFromAtp struct {
+
+	// Generated key that can be used in API calls to identify data asset.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"true" json:"objectVersion"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The external key for the object
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	// assetProperties
+	AssetProperties map[string]string `mandatory:"false" json:"assetProperties"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+
+	// The service name for the data asset.
+	ServiceName *string `mandatory:"false" json:"serviceName"`
+
+	// The driver class for the data asset.
+	DriverClass *string `mandatory:"false" json:"driverClass"`
+
+	// The credential file content from a wallet for the data asset.
+	CredentialFileContent *string `mandatory:"false" json:"credentialFileContent"`
+
+	DefaultConnection *UpdateConnectionFromAtp `mandatory:"false" json:"defaultConnection"`
+}
+
+//GetKey returns Key
+func (m UpdateDataAssetFromAtp) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m UpdateDataAssetFromAtp) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetName returns Name
+func (m UpdateDataAssetFromAtp) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m UpdateDataAssetFromAtp) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m UpdateDataAssetFromAtp) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m UpdateDataAssetFromAtp) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetIdentifier returns Identifier
+func (m UpdateDataAssetFromAtp) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetExternalKey returns ExternalKey
+func (m UpdateDataAssetFromAtp) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m UpdateDataAssetFromAtp) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m UpdateDataAssetFromAtp) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m UpdateDataAssetFromAtp) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m UpdateDataAssetFromAtp) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeUpdateDataAssetFromAtp UpdateDataAssetFromAtp
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeUpdateDataAssetFromAtp
+	}{
+		"ORACLE_ATP_DATA_ASSET",
+		(MarshalTypeUpdateDataAssetFromAtp)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/update_data_asset_from_object_storage.go
+++ b/dataintegration/update_data_asset_from_object_storage.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateDataAssetFromObjectStorage The Oracle data asset details.
+type UpdateDataAssetFromObjectStorage struct {
+
+	// Generated key that can be used in API calls to identify data asset.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"true" json:"objectVersion"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The external key for the object
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	// assetProperties
+	AssetProperties map[string]string `mandatory:"false" json:"assetProperties"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+
+	// url
+	Url *string `mandatory:"false" json:"url"`
+
+	// The OCI tenancy OCID.
+	TenancyId *string `mandatory:"false" json:"tenancyId"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Namespace *string `mandatory:"false" json:"namespace"`
+
+	DefaultConnection *UpdateConnectionFromObjectStorage `mandatory:"false" json:"defaultConnection"`
+}
+
+//GetKey returns Key
+func (m UpdateDataAssetFromObjectStorage) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m UpdateDataAssetFromObjectStorage) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetName returns Name
+func (m UpdateDataAssetFromObjectStorage) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m UpdateDataAssetFromObjectStorage) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m UpdateDataAssetFromObjectStorage) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m UpdateDataAssetFromObjectStorage) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetIdentifier returns Identifier
+func (m UpdateDataAssetFromObjectStorage) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetExternalKey returns ExternalKey
+func (m UpdateDataAssetFromObjectStorage) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m UpdateDataAssetFromObjectStorage) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m UpdateDataAssetFromObjectStorage) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m UpdateDataAssetFromObjectStorage) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m UpdateDataAssetFromObjectStorage) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeUpdateDataAssetFromObjectStorage UpdateDataAssetFromObjectStorage
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeUpdateDataAssetFromObjectStorage
+	}{
+		"ORACLE_OBJECT_STORAGE_DATA_ASSET",
+		(MarshalTypeUpdateDataAssetFromObjectStorage)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/update_data_asset_from_oracle.go
+++ b/dataintegration/update_data_asset_from_oracle.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateDataAssetFromOracle The Oracle data asset details.
+type UpdateDataAssetFromOracle struct {
+
+	// Generated key that can be used in API calls to identify data asset.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"true" json:"objectVersion"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The external key for the object
+	ExternalKey *string `mandatory:"false" json:"externalKey"`
+
+	// assetProperties
+	AssetProperties map[string]string `mandatory:"false" json:"assetProperties"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+
+	// The host details for the data asset.
+	Host *string `mandatory:"false" json:"host"`
+
+	// The port details for the data asset.
+	Port *string `mandatory:"false" json:"port"`
+
+	// The service name for the data asset.
+	ServiceName *string `mandatory:"false" json:"serviceName"`
+
+	// The driver class for the data asset.
+	DriverClass *string `mandatory:"false" json:"driverClass"`
+
+	// sid
+	Sid *string `mandatory:"false" json:"sid"`
+
+	// The credential file content from a wallet for the data asset.
+	CredentialFileContent *string `mandatory:"false" json:"credentialFileContent"`
+
+	DefaultConnection *UpdateConnectionFromOracle `mandatory:"false" json:"defaultConnection"`
+}
+
+//GetKey returns Key
+func (m UpdateDataAssetFromOracle) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m UpdateDataAssetFromOracle) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetName returns Name
+func (m UpdateDataAssetFromOracle) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m UpdateDataAssetFromOracle) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m UpdateDataAssetFromOracle) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m UpdateDataAssetFromOracle) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetIdentifier returns Identifier
+func (m UpdateDataAssetFromOracle) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetExternalKey returns ExternalKey
+func (m UpdateDataAssetFromOracle) GetExternalKey() *string {
+	return m.ExternalKey
+}
+
+//GetAssetProperties returns AssetProperties
+func (m UpdateDataAssetFromOracle) GetAssetProperties() map[string]string {
+	return m.AssetProperties
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m UpdateDataAssetFromOracle) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m UpdateDataAssetFromOracle) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m UpdateDataAssetFromOracle) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeUpdateDataAssetFromOracle UpdateDataAssetFromOracle
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeUpdateDataAssetFromOracle
+	}{
+		"ORACLE_DATA_ASSET",
+		(MarshalTypeUpdateDataAssetFromOracle)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/update_data_asset_request_response.go
+++ b/dataintegration/update_data_asset_request_response.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateDataAssetRequest wrapper for the UpdateDataAsset operation
+type UpdateDataAssetRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// Data asset key.
+	DataAssetKey *string `mandatory:"true" contributesTo:"path" name:"dataAssetKey"`
+
+	// Request body parameter for data asset details
+	UpdateDataAssetDetails `contributesTo:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateDataAssetRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateDataAssetRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateDataAssetRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateDataAssetResponse wrapper for the UpdateDataAsset operation
+type UpdateDataAssetResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The DataAsset instance
+	DataAsset `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateDataAssetResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateDataAssetResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/update_data_flow_details.go
+++ b/dataintegration/update_data_flow_details.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateDataFlowDetails Properties used in data flow update operations.
+type UpdateDataFlowDetails struct {
+
+	// Generated key that can be used in API calls to identify data flow. On scenarios where reference to the data flow is needed, a value can be passed in create.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"true" json:"modelType"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"true" json:"objectVersion"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// An array of nodes.
+	Nodes []FlowNode `mandatory:"false" json:"nodes"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	FlowConfigValues *ConfigValues `mandatory:"false" json:"flowConfigValues"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+}
+
+func (m UpdateDataFlowDetails) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/update_data_flow_request_response.go
+++ b/dataintegration/update_data_flow_request_response.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateDataFlowRequest wrapper for the UpdateDataFlow operation
+type UpdateDataFlowRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS DataFlow key
+	DataFlowKey *string `mandatory:"true" contributesTo:"path" name:"dataFlowKey"`
+
+	// The details needed to updated a data flow.
+	UpdateDataFlowDetails `contributesTo:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateDataFlowRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateDataFlowRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateDataFlowRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateDataFlowResponse wrapper for the UpdateDataFlow operation
+type UpdateDataFlowResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The DataFlow instance
+	DataFlow `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateDataFlowResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateDataFlowResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/update_folder_details.go
+++ b/dataintegration/update_folder_details.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateFolderDetails The properties used in folder update operations.
+type UpdateFolderDetails struct {
+
+	// Generated key that can be used in API calls to identify folder.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"true" json:"modelType"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"true" json:"objectVersion"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// categoryName
+	CategoryName *string `mandatory:"false" json:"categoryName"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+}
+
+func (m UpdateFolderDetails) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/update_folder_request_response.go
+++ b/dataintegration/update_folder_request_response.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateFolderRequest wrapper for the UpdateFolder operation
+type UpdateFolderRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS Folder key
+	FolderKey *string `mandatory:"true" contributesTo:"path" name:"folderKey"`
+
+	// The details needed to update a folder.
+	UpdateFolderDetails `contributesTo:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateFolderRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateFolderRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateFolderRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateFolderResponse wrapper for the UpdateFolder operation
+type UpdateFolderResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Folder instance
+	Folder `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateFolderResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateFolderResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/update_project_details.go
+++ b/dataintegration/update_project_details.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateProjectDetails The properties used in project update operations.
+type UpdateProjectDetails struct {
+
+	// Generated key that can be used in API calls to identify project.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"true" json:"modelType"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"true" json:"objectVersion"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+}
+
+func (m UpdateProjectDetails) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/update_project_request_response.go
+++ b/dataintegration/update_project_request_response.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateProjectRequest wrapper for the UpdateProject operation
+type UpdateProjectRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS Project key
+	ProjectKey *string `mandatory:"true" contributesTo:"path" name:"projectKey"`
+
+	// The details needed to update a project.
+	UpdateProjectDetails `contributesTo:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateProjectRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateProjectRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateProjectRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateProjectResponse wrapper for the UpdateProject operation
+type UpdateProjectResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Project instance
+	Project `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateProjectResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateProjectResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/update_task_details.go
+++ b/dataintegration/update_task_details.go
@@ -1,0 +1,225 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateTaskDetails Properties used in task create operations.
+type UpdateTaskDetails interface {
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	GetKey() *string
+
+	// The version of the object that is used to track changes in the object instance.
+	GetObjectVersion() *int
+
+	// The model version of an object.
+	GetModelVersion() *string
+
+	GetParentRef() *ParentReference
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	GetName() *string
+
+	// Detailed description for the object.
+	GetDescription() *string
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	GetObjectStatus() *int
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	GetIdentifier() *string
+
+	// An array of input ports.
+	GetInputPorts() []InputPort
+
+	// An array of output ports.
+	GetOutputPorts() []OutputPort
+
+	// An array of parameters.
+	GetParameters() []Parameter
+
+	GetOpConfigValues() *ConfigValues
+
+	GetConfigProviderDelegate() *ConfigProvider
+
+	GetRegistryMetadata() *RegistryMetadata
+}
+
+type updatetaskdetails struct {
+	JsonData               []byte
+	Key                    *string           `mandatory:"true" json:"key"`
+	ObjectVersion          *int              `mandatory:"true" json:"objectVersion"`
+	ModelVersion           *string           `mandatory:"false" json:"modelVersion"`
+	ParentRef              *ParentReference  `mandatory:"false" json:"parentRef"`
+	Name                   *string           `mandatory:"false" json:"name"`
+	Description            *string           `mandatory:"false" json:"description"`
+	ObjectStatus           *int              `mandatory:"false" json:"objectStatus"`
+	Identifier             *string           `mandatory:"false" json:"identifier"`
+	InputPorts             []InputPort       `mandatory:"false" json:"inputPorts"`
+	OutputPorts            []OutputPort      `mandatory:"false" json:"outputPorts"`
+	Parameters             []Parameter       `mandatory:"false" json:"parameters"`
+	OpConfigValues         *ConfigValues     `mandatory:"false" json:"opConfigValues"`
+	ConfigProviderDelegate *ConfigProvider   `mandatory:"false" json:"configProviderDelegate"`
+	RegistryMetadata       *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+	ModelType              string            `json:"modelType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *updatetaskdetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerupdatetaskdetails updatetaskdetails
+	s := struct {
+		Model Unmarshalerupdatetaskdetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Key = s.Model.Key
+	m.ObjectVersion = s.Model.ObjectVersion
+	m.ModelVersion = s.Model.ModelVersion
+	m.ParentRef = s.Model.ParentRef
+	m.Name = s.Model.Name
+	m.Description = s.Model.Description
+	m.ObjectStatus = s.Model.ObjectStatus
+	m.Identifier = s.Model.Identifier
+	m.InputPorts = s.Model.InputPorts
+	m.OutputPorts = s.Model.OutputPorts
+	m.Parameters = s.Model.Parameters
+	m.OpConfigValues = s.Model.OpConfigValues
+	m.ConfigProviderDelegate = s.Model.ConfigProviderDelegate
+	m.RegistryMetadata = s.Model.RegistryMetadata
+	m.ModelType = s.Model.ModelType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *updatetaskdetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ModelType {
+	case "DATA_LOADER_TASK":
+		mm := UpdateTaskFromDataLoaderTask{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "INTEGRATION_TASK":
+		mm := UpdateTaskFromIntegrationTask{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetKey returns Key
+func (m updatetaskdetails) GetKey() *string {
+	return m.Key
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m updatetaskdetails) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetModelVersion returns ModelVersion
+func (m updatetaskdetails) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m updatetaskdetails) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m updatetaskdetails) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m updatetaskdetails) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m updatetaskdetails) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetIdentifier returns Identifier
+func (m updatetaskdetails) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetInputPorts returns InputPorts
+func (m updatetaskdetails) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m updatetaskdetails) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetParameters returns Parameters
+func (m updatetaskdetails) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m updatetaskdetails) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+//GetConfigProviderDelegate returns ConfigProviderDelegate
+func (m updatetaskdetails) GetConfigProviderDelegate() *ConfigProvider {
+	return m.ConfigProviderDelegate
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m updatetaskdetails) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m updatetaskdetails) String() string {
+	return common.PointerString(m)
+}
+
+// UpdateTaskDetailsModelTypeEnum Enum with underlying type: string
+type UpdateTaskDetailsModelTypeEnum string
+
+// Set of constants representing the allowable values for UpdateTaskDetailsModelTypeEnum
+const (
+	UpdateTaskDetailsModelTypeIntegrationTask UpdateTaskDetailsModelTypeEnum = "INTEGRATION_TASK"
+	UpdateTaskDetailsModelTypeDataLoaderTask  UpdateTaskDetailsModelTypeEnum = "DATA_LOADER_TASK"
+)
+
+var mappingUpdateTaskDetailsModelType = map[string]UpdateTaskDetailsModelTypeEnum{
+	"INTEGRATION_TASK": UpdateTaskDetailsModelTypeIntegrationTask,
+	"DATA_LOADER_TASK": UpdateTaskDetailsModelTypeDataLoaderTask,
+}
+
+// GetUpdateTaskDetailsModelTypeEnumValues Enumerates the set of values for UpdateTaskDetailsModelTypeEnum
+func GetUpdateTaskDetailsModelTypeEnumValues() []UpdateTaskDetailsModelTypeEnum {
+	values := make([]UpdateTaskDetailsModelTypeEnum, 0)
+	for _, v := range mappingUpdateTaskDetailsModelType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/update_task_from_data_loader_task.go
+++ b/dataintegration/update_task_from_data_loader_task.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateTaskFromDataLoaderTask The information about the data loader task.
+type UpdateTaskFromDataLoaderTask struct {
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"true" json:"objectVersion"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+
+	ConfigProviderDelegate *ConfigProvider `mandatory:"false" json:"configProviderDelegate"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+
+	DataFlow *DataFlow `mandatory:"false" json:"dataFlow"`
+}
+
+//GetKey returns Key
+func (m UpdateTaskFromDataLoaderTask) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m UpdateTaskFromDataLoaderTask) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m UpdateTaskFromDataLoaderTask) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m UpdateTaskFromDataLoaderTask) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m UpdateTaskFromDataLoaderTask) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m UpdateTaskFromDataLoaderTask) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m UpdateTaskFromDataLoaderTask) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetIdentifier returns Identifier
+func (m UpdateTaskFromDataLoaderTask) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetInputPorts returns InputPorts
+func (m UpdateTaskFromDataLoaderTask) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m UpdateTaskFromDataLoaderTask) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetParameters returns Parameters
+func (m UpdateTaskFromDataLoaderTask) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m UpdateTaskFromDataLoaderTask) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+//GetConfigProviderDelegate returns ConfigProviderDelegate
+func (m UpdateTaskFromDataLoaderTask) GetConfigProviderDelegate() *ConfigProvider {
+	return m.ConfigProviderDelegate
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m UpdateTaskFromDataLoaderTask) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m UpdateTaskFromDataLoaderTask) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m UpdateTaskFromDataLoaderTask) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeUpdateTaskFromDataLoaderTask UpdateTaskFromDataLoaderTask
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeUpdateTaskFromDataLoaderTask
+	}{
+		"DATA_LOADER_TASK",
+		(MarshalTypeUpdateTaskFromDataLoaderTask)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/update_task_from_integration_task.go
+++ b/dataintegration/update_task_from_integration_task.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateTaskFromIntegrationTask The information about the integration task.
+type UpdateTaskFromIntegrationTask struct {
+
+	// Generated key that can be used in API calls to identify task. On scenarios where reference to the task is needed, a value can be passed in create.
+	Key *string `mandatory:"true" json:"key"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"true" json:"objectVersion"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// Value can only contain upper case letters, underscore and numbers. It should begin with upper case letter or underscore. The value can be edited by the user.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// An array of input ports.
+	InputPorts []InputPort `mandatory:"false" json:"inputPorts"`
+
+	// An array of output ports.
+	OutputPorts []OutputPort `mandatory:"false" json:"outputPorts"`
+
+	// An array of parameters.
+	Parameters []Parameter `mandatory:"false" json:"parameters"`
+
+	OpConfigValues *ConfigValues `mandatory:"false" json:"opConfigValues"`
+
+	ConfigProviderDelegate *ConfigProvider `mandatory:"false" json:"configProviderDelegate"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+
+	DataFlow *DataFlow `mandatory:"false" json:"dataFlow"`
+}
+
+//GetKey returns Key
+func (m UpdateTaskFromIntegrationTask) GetKey() *string {
+	return m.Key
+}
+
+//GetModelVersion returns ModelVersion
+func (m UpdateTaskFromIntegrationTask) GetModelVersion() *string {
+	return m.ModelVersion
+}
+
+//GetParentRef returns ParentRef
+func (m UpdateTaskFromIntegrationTask) GetParentRef() *ParentReference {
+	return m.ParentRef
+}
+
+//GetName returns Name
+func (m UpdateTaskFromIntegrationTask) GetName() *string {
+	return m.Name
+}
+
+//GetDescription returns Description
+func (m UpdateTaskFromIntegrationTask) GetDescription() *string {
+	return m.Description
+}
+
+//GetObjectStatus returns ObjectStatus
+func (m UpdateTaskFromIntegrationTask) GetObjectStatus() *int {
+	return m.ObjectStatus
+}
+
+//GetObjectVersion returns ObjectVersion
+func (m UpdateTaskFromIntegrationTask) GetObjectVersion() *int {
+	return m.ObjectVersion
+}
+
+//GetIdentifier returns Identifier
+func (m UpdateTaskFromIntegrationTask) GetIdentifier() *string {
+	return m.Identifier
+}
+
+//GetInputPorts returns InputPorts
+func (m UpdateTaskFromIntegrationTask) GetInputPorts() []InputPort {
+	return m.InputPorts
+}
+
+//GetOutputPorts returns OutputPorts
+func (m UpdateTaskFromIntegrationTask) GetOutputPorts() []OutputPort {
+	return m.OutputPorts
+}
+
+//GetParameters returns Parameters
+func (m UpdateTaskFromIntegrationTask) GetParameters() []Parameter {
+	return m.Parameters
+}
+
+//GetOpConfigValues returns OpConfigValues
+func (m UpdateTaskFromIntegrationTask) GetOpConfigValues() *ConfigValues {
+	return m.OpConfigValues
+}
+
+//GetConfigProviderDelegate returns ConfigProviderDelegate
+func (m UpdateTaskFromIntegrationTask) GetConfigProviderDelegate() *ConfigProvider {
+	return m.ConfigProviderDelegate
+}
+
+//GetRegistryMetadata returns RegistryMetadata
+func (m UpdateTaskFromIntegrationTask) GetRegistryMetadata() *RegistryMetadata {
+	return m.RegistryMetadata
+}
+
+func (m UpdateTaskFromIntegrationTask) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m UpdateTaskFromIntegrationTask) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeUpdateTaskFromIntegrationTask UpdateTaskFromIntegrationTask
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeUpdateTaskFromIntegrationTask
+	}{
+		"INTEGRATION_TASK",
+		(MarshalTypeUpdateTaskFromIntegrationTask)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/dataintegration/update_task_request_response.go
+++ b/dataintegration/update_task_request_response.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateTaskRequest wrapper for the UpdateTask operation
+type UpdateTaskRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS Task key
+	TaskKey *string `mandatory:"true" contributesTo:"path" name:"taskKey"`
+
+	// The details needed to update a task.
+	UpdateTaskDetails `contributesTo:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateTaskRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateTaskRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateTaskRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateTaskResponse wrapper for the UpdateTask operation
+type UpdateTaskResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Task instance
+	Task `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateTaskResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateTaskResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/update_task_run_details.go
+++ b/dataintegration/update_task_run_details.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateTaskRunDetails Properties used in task run update operations.
+type UpdateTaskRunDetails struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// status
+	Status UpdateTaskRunDetailsStatusEnum `mandatory:"false" json:"status,omitempty"`
+
+	// The type of the object.
+	ModelType *string `mandatory:"false" json:"modelType"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	// Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value can be edited by the user and it is restricted to 1000 characters
+	Name *string `mandatory:"false" json:"name"`
+
+	// Detailed description for the object.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The version of the object that is used to track changes in the object instance.
+	ObjectVersion *int `mandatory:"false" json:"objectVersion"`
+
+	RegistryMetadata *RegistryMetadata `mandatory:"false" json:"registryMetadata"`
+}
+
+func (m UpdateTaskRunDetails) String() string {
+	return common.PointerString(m)
+}
+
+// UpdateTaskRunDetailsStatusEnum Enum with underlying type: string
+type UpdateTaskRunDetailsStatusEnum string
+
+// Set of constants representing the allowable values for UpdateTaskRunDetailsStatusEnum
+const (
+	UpdateTaskRunDetailsStatusTerminating UpdateTaskRunDetailsStatusEnum = "TERMINATING"
+)
+
+var mappingUpdateTaskRunDetailsStatus = map[string]UpdateTaskRunDetailsStatusEnum{
+	"TERMINATING": UpdateTaskRunDetailsStatusTerminating,
+}
+
+// GetUpdateTaskRunDetailsStatusEnumValues Enumerates the set of values for UpdateTaskRunDetailsStatusEnum
+func GetUpdateTaskRunDetailsStatusEnumValues() []UpdateTaskRunDetailsStatusEnum {
+	values := make([]UpdateTaskRunDetailsStatusEnum, 0)
+	for _, v := range mappingUpdateTaskRunDetailsStatus {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/update_task_run_request_response.go
+++ b/dataintegration/update_task_run_request_response.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateTaskRunRequest wrapper for the UpdateTaskRun operation
+type UpdateTaskRunRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// DIS application key
+	ApplicationKey *string `mandatory:"true" contributesTo:"path" name:"applicationKey"`
+
+	// DIS taskRun key
+	TaskRunKey *string `mandatory:"true" contributesTo:"path" name:"taskRunKey"`
+
+	// The details needed to update the status of a task run.
+	UpdateTaskRunDetails `contributesTo:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateTaskRunRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateTaskRunRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateTaskRunRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateTaskRunResponse wrapper for the UpdateTaskRun operation
+type UpdateTaskRunResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The TaskRunDetails instance
+	TaskRunDetails `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateTaskRunResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateTaskRunResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/update_workspace_details.go
+++ b/dataintegration/update_workspace_details.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateWorkspaceDetails The information to be updated, the private network can be enabled and VCN and subnet set only when initially it is has been created with it off.
+type UpdateWorkspaceDetails struct {
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. See Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace. See Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// A detailed description for the workspace.
+	Description *string `mandatory:"false" json:"description"`
+
+	// A user-friendly display name for the workspace. Does not have to be unique, and can be modified. Avoid entering confidential information.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+}
+
+func (m UpdateWorkspaceDetails) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/update_workspace_request_response.go
+++ b/dataintegration/update_workspace_request_response.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateWorkspaceRequest wrapper for the UpdateWorkspace operation
+type UpdateWorkspaceRequest struct {
+
+	// DIS workspace id
+	WorkspaceId *string `mandatory:"true" contributesTo:"path" name:"workspaceId"`
+
+	// The information to be updated.
+	UpdateWorkspaceDetails `contributesTo:"body"`
+
+	// Update and Delete operations should accept an optional If-Match header,
+	// in which clients can send a previously-received ETag. When If-Match is
+	// provided and its value does not exactly match the ETag of the resource
+	// on the server, the request should fail with HTTP response status code 412
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If
+	// you need to contact Oracle about a particular request,
+	// please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateWorkspaceRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateWorkspaceRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateWorkspaceRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateWorkspaceResponse wrapper for the UpdateWorkspace operation
+type UpdateWorkspaceResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Workspace instance
+	Workspace `presentIn:"body"`
+
+	// For optimistic concurrency control. See ETags for Optimistic Concurrency Control (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the work request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+	// with this ID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+}
+
+func (response UpdateWorkspaceResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateWorkspaceResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/dataintegration/validation_message.go
+++ b/dataintegration/validation_message.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ValidationMessage The level, message key and validation message.
+type ValidationMessage struct {
+
+	// Total number of validation messages
+	Level *string `mandatory:"false" json:"level"`
+
+	// The key.
+	MessageKey *string `mandatory:"false" json:"messageKey"`
+
+	// The message itself.
+	ValidationMessage *string `mandatory:"false" json:"validationMessage"`
+}
+
+func (m ValidationMessage) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/work_request.go
+++ b/dataintegration/work_request.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// WorkRequest The API operations used to create and configure Data Integration resources do not take effect immediately. In these cases, the operation spawns an asynchronous workflow to fulfill the request. Work requests provide visibility into the status of these in-progress, long-running asynchronous workflows.
+type WorkRequest struct {
+
+	// The asynchronous operation tracked by this work request.
+	OperationType WorkRequestOperationTypeEnum `mandatory:"true" json:"operationType"`
+
+	// The status of this work request.
+	Status WorkRequestStatusEnum `mandatory:"true" json:"status"`
+
+	// The id of the work request.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The ocid of the compartment that contains this work request. Work requests should be scoped to
+	// the same compartment as the resource the work request affects. If the work request affects multiple resources that are not in the same compartment, then the system picks a primary
+	// resource whose compartment should be used.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The resources affected by this work request.
+	Resources []WorkRequestResource `mandatory:"true" json:"resources"`
+
+	// The completed percentage of the operation tracked by this work request.
+	PercentComplete *float32 `mandatory:"true" json:"percentComplete"`
+
+	// The date and time this work request was accepted, in the timestamp format defined by
+	// RFC 3339 (https://tools.ietf.org/rfc/rfc3339).
+	TimeAccepted *common.SDKTime `mandatory:"true" json:"timeAccepted"`
+
+	// The date and time the work request transitioned from `ACCEPTED` to `IN_PROGRESS`, in the timestamp format defined by RFC 3339 (https://tools.ietf.org/rfc/rfc3339).
+	TimeStarted *common.SDKTime `mandatory:"false" json:"timeStarted"`
+
+	// The date and time the work request reached a terminal state, either `FAILED` or `SUCCEEDED`, in the timestamp format defined by RFC 3339 (https://tools.ietf.org/rfc/rfc3339).
+	TimeFinished *common.SDKTime `mandatory:"false" json:"timeFinished"`
+}
+
+func (m WorkRequest) String() string {
+	return common.PointerString(m)
+}
+
+// WorkRequestOperationTypeEnum Enum with underlying type: string
+type WorkRequestOperationTypeEnum string
+
+// Set of constants representing the allowable values for WorkRequestOperationTypeEnum
+const (
+	WorkRequestOperationTypeCreateWorkspace WorkRequestOperationTypeEnum = "CREATE_WORKSPACE"
+	WorkRequestOperationTypeUpdateWorkspace WorkRequestOperationTypeEnum = "UPDATE_WORKSPACE"
+	WorkRequestOperationTypeDeleteWorkspace WorkRequestOperationTypeEnum = "DELETE_WORKSPACE"
+	WorkRequestOperationTypeMoveWorkspace   WorkRequestOperationTypeEnum = "MOVE_WORKSPACE"
+)
+
+var mappingWorkRequestOperationType = map[string]WorkRequestOperationTypeEnum{
+	"CREATE_WORKSPACE": WorkRequestOperationTypeCreateWorkspace,
+	"UPDATE_WORKSPACE": WorkRequestOperationTypeUpdateWorkspace,
+	"DELETE_WORKSPACE": WorkRequestOperationTypeDeleteWorkspace,
+	"MOVE_WORKSPACE":   WorkRequestOperationTypeMoveWorkspace,
+}
+
+// GetWorkRequestOperationTypeEnumValues Enumerates the set of values for WorkRequestOperationTypeEnum
+func GetWorkRequestOperationTypeEnumValues() []WorkRequestOperationTypeEnum {
+	values := make([]WorkRequestOperationTypeEnum, 0)
+	for _, v := range mappingWorkRequestOperationType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// WorkRequestStatusEnum Enum with underlying type: string
+type WorkRequestStatusEnum string
+
+// Set of constants representing the allowable values for WorkRequestStatusEnum
+const (
+	WorkRequestStatusAccepted   WorkRequestStatusEnum = "ACCEPTED"
+	WorkRequestStatusInProgress WorkRequestStatusEnum = "IN_PROGRESS"
+	WorkRequestStatusFailed     WorkRequestStatusEnum = "FAILED"
+	WorkRequestStatusSucceeded  WorkRequestStatusEnum = "SUCCEEDED"
+	WorkRequestStatusCanceling  WorkRequestStatusEnum = "CANCELING"
+	WorkRequestStatusCanceled   WorkRequestStatusEnum = "CANCELED"
+)
+
+var mappingWorkRequestStatus = map[string]WorkRequestStatusEnum{
+	"ACCEPTED":    WorkRequestStatusAccepted,
+	"IN_PROGRESS": WorkRequestStatusInProgress,
+	"FAILED":      WorkRequestStatusFailed,
+	"SUCCEEDED":   WorkRequestStatusSucceeded,
+	"CANCELING":   WorkRequestStatusCanceling,
+	"CANCELED":    WorkRequestStatusCanceled,
+}
+
+// GetWorkRequestStatusEnumValues Enumerates the set of values for WorkRequestStatusEnum
+func GetWorkRequestStatusEnumValues() []WorkRequestStatusEnum {
+	values := make([]WorkRequestStatusEnum, 0)
+	for _, v := range mappingWorkRequestStatus {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/work_request_error.go
+++ b/dataintegration/work_request_error.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// WorkRequestError The error that occured while executing an operation that is tracked by a work request.
+type WorkRequestError struct {
+
+	// A machine-usable code for the error that occured, as listed in API Errors (https://docs.cloud.oracle.com/Content/API/References/apierrors.htm).
+	Code *string `mandatory:"true" json:"code"`
+
+	// A user friendly description of the error that occured.
+	Message *string `mandatory:"true" json:"message"`
+
+	// The date and time the error occured, in the timestamp format defined by RFC 3339 (https://tools.ietf.org/rfc/rfc3339).
+	Timestamp *common.SDKTime `mandatory:"true" json:"timestamp"`
+}
+
+func (m WorkRequestError) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/work_request_log_entry.go
+++ b/dataintegration/work_request_log_entry.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// WorkRequestLogEntry The log message from executing an operation that is tracked by a work request.
+type WorkRequestLogEntry struct {
+
+	// A user friendly log message.
+	Message *string `mandatory:"true" json:"message"`
+
+	// The date and time the log message was written, in the timestamp format defined by RFC 3339 (https://tools.ietf.org/rfc/rfc3339).
+	Timestamp *common.SDKTime `mandatory:"true" json:"timestamp"`
+}
+
+func (m WorkRequestLogEntry) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/work_request_resource.go
+++ b/dataintegration/work_request_resource.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// WorkRequestResource The resource that is created or operated on by a work request.
+type WorkRequestResource struct {
+
+	// The resource type the work request affects.
+	EntityType *string `mandatory:"true" json:"entityType"`
+
+	// The way in which this resource is affected by the work tracked in the work request.
+	// A resource being created, updated, or deleted will remain in the IN_PROGRESS state until
+	// work is complete for that resource at which point it will transition to CREATED, UPDATED,
+	// or DELETED, respectively.
+	ActionType WorkRequestResourceActionTypeEnum `mandatory:"true" json:"actionType"`
+
+	// The OCID or other unique identifier of the resource the work request affects.
+	Identifier *string `mandatory:"true" json:"identifier"`
+
+	// The URI path that is used in a GET request to access the resource metadata.
+	EntityUri *string `mandatory:"false" json:"entityUri"`
+}
+
+func (m WorkRequestResource) String() string {
+	return common.PointerString(m)
+}
+
+// WorkRequestResourceActionTypeEnum Enum with underlying type: string
+type WorkRequestResourceActionTypeEnum string
+
+// Set of constants representing the allowable values for WorkRequestResourceActionTypeEnum
+const (
+	WorkRequestResourceActionTypeCreated    WorkRequestResourceActionTypeEnum = "CREATED"
+	WorkRequestResourceActionTypeUpdated    WorkRequestResourceActionTypeEnum = "UPDATED"
+	WorkRequestResourceActionTypeDeleted    WorkRequestResourceActionTypeEnum = "DELETED"
+	WorkRequestResourceActionTypeMoved      WorkRequestResourceActionTypeEnum = "MOVED"
+	WorkRequestResourceActionTypeInProgress WorkRequestResourceActionTypeEnum = "IN_PROGRESS"
+	WorkRequestResourceActionTypeFailed     WorkRequestResourceActionTypeEnum = "FAILED"
+	WorkRequestResourceActionTypeStopped    WorkRequestResourceActionTypeEnum = "STOPPED"
+	WorkRequestResourceActionTypeStarted    WorkRequestResourceActionTypeEnum = "STARTED"
+)
+
+var mappingWorkRequestResourceActionType = map[string]WorkRequestResourceActionTypeEnum{
+	"CREATED":     WorkRequestResourceActionTypeCreated,
+	"UPDATED":     WorkRequestResourceActionTypeUpdated,
+	"DELETED":     WorkRequestResourceActionTypeDeleted,
+	"MOVED":       WorkRequestResourceActionTypeMoved,
+	"IN_PROGRESS": WorkRequestResourceActionTypeInProgress,
+	"FAILED":      WorkRequestResourceActionTypeFailed,
+	"STOPPED":     WorkRequestResourceActionTypeStopped,
+	"STARTED":     WorkRequestResourceActionTypeStarted,
+}
+
+// GetWorkRequestResourceActionTypeEnumValues Enumerates the set of values for WorkRequestResourceActionTypeEnum
+func GetWorkRequestResourceActionTypeEnumValues() []WorkRequestResourceActionTypeEnum {
+	values := make([]WorkRequestResourceActionTypeEnum, 0)
+	for _, v := range mappingWorkRequestResourceActionType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/work_request_summary.go
+++ b/dataintegration/work_request_summary.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// WorkRequestSummary A work request summary object.
+type WorkRequestSummary struct {
+
+	// The asynchronous operation tracked by this work request.
+	OperationType WorkRequestSummaryOperationTypeEnum `mandatory:"true" json:"operationType"`
+
+	// The status of this work request.
+	Status WorkRequestSummaryStatusEnum `mandatory:"true" json:"status"`
+
+	// The id of the work request.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The ocid of the compartment that contains this work request. Work requests should be scoped to
+	// the same compartment as the resource the work request affects. If the work request affects multiple resources that are not in the same compartment, then the system picks a primary
+	// resource whose compartment should be used.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The resources affected by this work request.
+	Resources []WorkRequestResource `mandatory:"true" json:"resources"`
+
+	// The completed percentage of the operation tracked by this work request.
+	PercentComplete *float32 `mandatory:"true" json:"percentComplete"`
+
+	// The date and time this work request was accepted, in the timestamp format defined by
+	// RFC 3339 (https://tools.ietf.org/rfc/rfc3339).
+	TimeAccepted *common.SDKTime `mandatory:"true" json:"timeAccepted"`
+
+	// The date and time the work request transitioned from `ACCEPTED` to `IN_PROGRESS`, in the timestamp format defined by RFC 3339 (https://tools.ietf.org/rfc/rfc3339).
+	TimeStarted *common.SDKTime `mandatory:"false" json:"timeStarted"`
+
+	// The date and time the work request reached a terminal state, either `FAILED` or `SUCCEEDED`, in the timestamp format defined by RFC 3339 (https://tools.ietf.org/rfc/rfc3339).
+	TimeFinished *common.SDKTime `mandatory:"false" json:"timeFinished"`
+}
+
+func (m WorkRequestSummary) String() string {
+	return common.PointerString(m)
+}
+
+// WorkRequestSummaryOperationTypeEnum Enum with underlying type: string
+type WorkRequestSummaryOperationTypeEnum string
+
+// Set of constants representing the allowable values for WorkRequestSummaryOperationTypeEnum
+const (
+	WorkRequestSummaryOperationTypeCreateWorkspace WorkRequestSummaryOperationTypeEnum = "CREATE_WORKSPACE"
+	WorkRequestSummaryOperationTypeUpdateWorkspace WorkRequestSummaryOperationTypeEnum = "UPDATE_WORKSPACE"
+	WorkRequestSummaryOperationTypeDeleteWorkspace WorkRequestSummaryOperationTypeEnum = "DELETE_WORKSPACE"
+	WorkRequestSummaryOperationTypeMoveWorkspace   WorkRequestSummaryOperationTypeEnum = "MOVE_WORKSPACE"
+)
+
+var mappingWorkRequestSummaryOperationType = map[string]WorkRequestSummaryOperationTypeEnum{
+	"CREATE_WORKSPACE": WorkRequestSummaryOperationTypeCreateWorkspace,
+	"UPDATE_WORKSPACE": WorkRequestSummaryOperationTypeUpdateWorkspace,
+	"DELETE_WORKSPACE": WorkRequestSummaryOperationTypeDeleteWorkspace,
+	"MOVE_WORKSPACE":   WorkRequestSummaryOperationTypeMoveWorkspace,
+}
+
+// GetWorkRequestSummaryOperationTypeEnumValues Enumerates the set of values for WorkRequestSummaryOperationTypeEnum
+func GetWorkRequestSummaryOperationTypeEnumValues() []WorkRequestSummaryOperationTypeEnum {
+	values := make([]WorkRequestSummaryOperationTypeEnum, 0)
+	for _, v := range mappingWorkRequestSummaryOperationType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// WorkRequestSummaryStatusEnum Enum with underlying type: string
+type WorkRequestSummaryStatusEnum string
+
+// Set of constants representing the allowable values for WorkRequestSummaryStatusEnum
+const (
+	WorkRequestSummaryStatusAccepted   WorkRequestSummaryStatusEnum = "ACCEPTED"
+	WorkRequestSummaryStatusInProgress WorkRequestSummaryStatusEnum = "IN_PROGRESS"
+	WorkRequestSummaryStatusFailed     WorkRequestSummaryStatusEnum = "FAILED"
+	WorkRequestSummaryStatusSucceeded  WorkRequestSummaryStatusEnum = "SUCCEEDED"
+	WorkRequestSummaryStatusCanceling  WorkRequestSummaryStatusEnum = "CANCELING"
+	WorkRequestSummaryStatusCanceled   WorkRequestSummaryStatusEnum = "CANCELED"
+)
+
+var mappingWorkRequestSummaryStatus = map[string]WorkRequestSummaryStatusEnum{
+	"ACCEPTED":    WorkRequestSummaryStatusAccepted,
+	"IN_PROGRESS": WorkRequestSummaryStatusInProgress,
+	"FAILED":      WorkRequestSummaryStatusFailed,
+	"SUCCEEDED":   WorkRequestSummaryStatusSucceeded,
+	"CANCELING":   WorkRequestSummaryStatusCanceling,
+	"CANCELED":    WorkRequestSummaryStatusCanceled,
+}
+
+// GetWorkRequestSummaryStatusEnumValues Enumerates the set of values for WorkRequestSummaryStatusEnum
+func GetWorkRequestSummaryStatusEnumValues() []WorkRequestSummaryStatusEnum {
+	values := make([]WorkRequestSummaryStatusEnum, 0)
+	for _, v := range mappingWorkRequestSummaryStatus {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/workspace.go
+++ b/dataintegration/workspace.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Workspace A workspace is an organizational construct to keep multiple data integration solutions and their resources (data assets, data flows, tasks, and so on) separate from each other, helping you to stay organized. For example, you could have separate workspaces for development, testing, and production.
+type Workspace struct {
+
+	// A user-friendly display name for the workspace. Does not have to be unique, and can be modified. Avoid entering confidential information.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// Unique identifier that is immutable on creation
+	Id *string `mandatory:"true" json:"id"`
+
+	// The OCID of the VCN the subnet is in.
+	VcnId *string `mandatory:"false" json:"vcnId"`
+
+	// The OCID of the subnet for customer connected databases.
+	SubnetId *string `mandatory:"false" json:"subnetId"`
+
+	// The IP of the custom DNS.
+	DnsServerIp *string `mandatory:"false" json:"dnsServerIp"`
+
+	// The DNS zone of the custom DNS to use to resolve names.
+	DnsServerZone *string `mandatory:"false" json:"dnsServerZone"`
+
+	// Whether the private network connection is enabled or disabled.
+	IsPrivateNetworkEnabled *bool `mandatory:"false" json:"isPrivateNetworkEnabled"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. See Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace. See Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// A detailed description for the workspace.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The OCID of the compartment containing the workspace.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The date and time the workspace was created, in the timestamp format defined by RFC3339.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The date and time the workspace was updated, in the timestamp format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// Lifecycle states for workspaces in Data Integration Service
+	// CREATING - The resource is being created and may not be usable until the entire metadata is defined
+	// UPDATING - The resource is being updated and may not be usable until all changes are commited
+	// DELETING - The resource is being deleted and might require deep cleanup of children.
+	// ACTIVE   - The resource is valid and available for access
+	// INACTIVE - The resource might be incomplete in its definition or might have been made unavailable for
+	//          administrative reasons
+	// DELETED  - The resource has been deleted and isn't available
+	// FAILED   - The resource is in a failed state due to validation or other errors
+	// STARTING - The resource is being started and may not be usable until becomes ACTIVE again
+	// STOPPING - The resource is in the process of Stopping and may not be usable until it Stops or fails
+	// STOPPED  - The resource is in Stopped state due to stop operation.
+	LifecycleState WorkspaceLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// A message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+	StateMessage *string `mandatory:"false" json:"stateMessage"`
+}
+
+func (m Workspace) String() string {
+	return common.PointerString(m)
+}
+
+// WorkspaceLifecycleStateEnum Enum with underlying type: string
+type WorkspaceLifecycleStateEnum string
+
+// Set of constants representing the allowable values for WorkspaceLifecycleStateEnum
+const (
+	WorkspaceLifecycleStateCreating WorkspaceLifecycleStateEnum = "CREATING"
+	WorkspaceLifecycleStateActive   WorkspaceLifecycleStateEnum = "ACTIVE"
+	WorkspaceLifecycleStateInactive WorkspaceLifecycleStateEnum = "INACTIVE"
+	WorkspaceLifecycleStateUpdating WorkspaceLifecycleStateEnum = "UPDATING"
+	WorkspaceLifecycleStateDeleting WorkspaceLifecycleStateEnum = "DELETING"
+	WorkspaceLifecycleStateDeleted  WorkspaceLifecycleStateEnum = "DELETED"
+	WorkspaceLifecycleStateFailed   WorkspaceLifecycleStateEnum = "FAILED"
+	WorkspaceLifecycleStateStarting WorkspaceLifecycleStateEnum = "STARTING"
+	WorkspaceLifecycleStateStopping WorkspaceLifecycleStateEnum = "STOPPING"
+	WorkspaceLifecycleStateStopped  WorkspaceLifecycleStateEnum = "STOPPED"
+)
+
+var mappingWorkspaceLifecycleState = map[string]WorkspaceLifecycleStateEnum{
+	"CREATING": WorkspaceLifecycleStateCreating,
+	"ACTIVE":   WorkspaceLifecycleStateActive,
+	"INACTIVE": WorkspaceLifecycleStateInactive,
+	"UPDATING": WorkspaceLifecycleStateUpdating,
+	"DELETING": WorkspaceLifecycleStateDeleting,
+	"DELETED":  WorkspaceLifecycleStateDeleted,
+	"FAILED":   WorkspaceLifecycleStateFailed,
+	"STARTING": WorkspaceLifecycleStateStarting,
+	"STOPPING": WorkspaceLifecycleStateStopping,
+	"STOPPED":  WorkspaceLifecycleStateStopped,
+}
+
+// GetWorkspaceLifecycleStateEnumValues Enumerates the set of values for WorkspaceLifecycleStateEnum
+func GetWorkspaceLifecycleStateEnumValues() []WorkspaceLifecycleStateEnum {
+	values := make([]WorkspaceLifecycleStateEnum, 0)
+	for _, v := range mappingWorkspaceLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}

--- a/dataintegration/workspace_summary.go
+++ b/dataintegration/workspace_summary.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// WorkspaceSummary Summary of a Workspace.
+type WorkspaceSummary struct {
+
+	// Unique identifier that is immutable.
+	Id *string `mandatory:"false" json:"id"`
+
+	// A detailed description of the workspace.
+	Description *string `mandatory:"false" json:"description"`
+
+	// A user-friendly display name that is changeable. Avoid entering confidential information.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// The OCID of the compartment that contains the workspace.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The date and time the workspace was created, in the timestamp format defined by RFC3339.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The date and time the workspace was updated, in the timestamp format defined by RFC3339.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// The current state of the workspace.
+	LifecycleState WorkspaceLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// A detailed description about the current state of the workspace. Used to provide actionable information if the workspace is in a failed state.
+	StateMessage *string `mandatory:"false" json:"stateMessage"`
+}
+
+func (m WorkspaceSummary) String() string {
+	return common.PointerString(m)
+}

--- a/dataintegration/write_operation_config.go
+++ b/dataintegration/write_operation_config.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Integration API
+//
+// Use the Data Integration Service APIs to perform common extract, load, and transform (ETL) tasks.
+//
+
+package dataintegration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// WriteOperationConfig The information about the write operation.
+type WriteOperationConfig struct {
+
+	// The key of the object.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The model version of an object.
+	ModelVersion *string `mandatory:"false" json:"modelVersion"`
+
+	ParentRef *ParentReference `mandatory:"false" json:"parentRef"`
+
+	// An array of operations.
+	Operations []PushDownOperation `mandatory:"false" json:"operations"`
+
+	DataFormat *DataFormat `mandatory:"false" json:"dataFormat"`
+
+	PartitionConfig PartitionConfig `mandatory:"false" json:"partitionConfig"`
+
+	WriteAttribute AbstractWriteAttribute `mandatory:"false" json:"writeAttribute"`
+
+	// The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+	ObjectStatus *int `mandatory:"false" json:"objectStatus"`
+
+	// The mode for the write operation.
+	WriteMode WriteOperationConfigWriteModeEnum `mandatory:"false" json:"writeMode,omitempty"`
+}
+
+func (m WriteOperationConfig) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m WriteOperationConfig) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeWriteOperationConfig WriteOperationConfig
+	s := struct {
+		DiscriminatorParam string `json:"modelType"`
+		MarshalTypeWriteOperationConfig
+	}{
+		"WRITE_OPERATION_CONFIG",
+		(MarshalTypeWriteOperationConfig)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *WriteOperationConfig) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Key             *string                           `json:"key"`
+		ModelVersion    *string                           `json:"modelVersion"`
+		ParentRef       *ParentReference                  `json:"parentRef"`
+		Operations      []pushdownoperation               `json:"operations"`
+		DataFormat      *DataFormat                       `json:"dataFormat"`
+		PartitionConfig partitionconfig                   `json:"partitionConfig"`
+		WriteAttribute  abstractwriteattribute            `json:"writeAttribute"`
+		WriteMode       WriteOperationConfigWriteModeEnum `json:"writeMode"`
+		ObjectStatus    *int                              `json:"objectStatus"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Key = model.Key
+
+	m.ModelVersion = model.ModelVersion
+
+	m.ParentRef = model.ParentRef
+
+	m.Operations = make([]PushDownOperation, len(model.Operations))
+	for i, n := range model.Operations {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.Operations[i] = nn.(PushDownOperation)
+		} else {
+			m.Operations[i] = nil
+		}
+	}
+
+	m.DataFormat = model.DataFormat
+
+	nn, e = model.PartitionConfig.UnmarshalPolymorphicJSON(model.PartitionConfig.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.PartitionConfig = nn.(PartitionConfig)
+	} else {
+		m.PartitionConfig = nil
+	}
+
+	nn, e = model.WriteAttribute.UnmarshalPolymorphicJSON(model.WriteAttribute.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.WriteAttribute = nn.(AbstractWriteAttribute)
+	} else {
+		m.WriteAttribute = nil
+	}
+
+	m.WriteMode = model.WriteMode
+
+	m.ObjectStatus = model.ObjectStatus
+	return
+}
+
+// WriteOperationConfigWriteModeEnum Enum with underlying type: string
+type WriteOperationConfigWriteModeEnum string
+
+// Set of constants representing the allowable values for WriteOperationConfigWriteModeEnum
+const (
+	WriteOperationConfigWriteModeOverwrite WriteOperationConfigWriteModeEnum = "OVERWRITE"
+	WriteOperationConfigWriteModeAppend    WriteOperationConfigWriteModeEnum = "APPEND"
+	WriteOperationConfigWriteModeMerge     WriteOperationConfigWriteModeEnum = "MERGE"
+	WriteOperationConfigWriteModeIgnore    WriteOperationConfigWriteModeEnum = "IGNORE"
+)
+
+var mappingWriteOperationConfigWriteMode = map[string]WriteOperationConfigWriteModeEnum{
+	"OVERWRITE": WriteOperationConfigWriteModeOverwrite,
+	"APPEND":    WriteOperationConfigWriteModeAppend,
+	"MERGE":     WriteOperationConfigWriteModeMerge,
+	"IGNORE":    WriteOperationConfigWriteModeIgnore,
+}
+
+// GetWriteOperationConfigWriteModeEnumValues Enumerates the set of values for WriteOperationConfigWriteModeEnum
+func GetWriteOperationConfigWriteModeEnumValues() []WriteOperationConfigWriteModeEnum {
+	values := make([]WriteOperationConfigWriteModeEnum, 0)
+	for _, v := range mappingWriteOperationConfigWriteMode {
+		values = append(values, v)
+	}
+	return values
+}


### PR DESCRIPTION
### Added

- Support for the Data Integration service

- Support for updating database home IDs on databases in the Database service

- Support for backing up autonomous databases on Cloud at Customer in the Database service

- Support for managing autonomous VM clusters on Cloud at Customer in the Database service

- Support for accessing data assets via private endpoints in the Data Catalog service

- Support for dependency archive zip files to be specified for use by applications in the Data Flow service



### Breaking changes

- Property `LifecycleState` type changed from `JobLifecycleStateEnum` to `ListJobsLifecycleStateEnum` in the Data Catalog service

- Property `JobType` type changed from `JobTypeEnum` to `ListJobsJobTypeEnum` in the Data Catalog service

- Property `HarvestStatus` type changed from `HarvestStatusEnum` to `ListEntitiesHarvestStatusEnum` in the Data Catalog service


