### PR TITLE
Fix splitStreamToParts() if number of bytes read is less than part size

### DIFF
--- a/objectstorage/transfer/multipart_manifest.go
+++ b/objectstorage/transfer/multipart_manifest.go
@@ -166,15 +166,20 @@ func (manifest *multipartManifest) splitStreamToParts(done <-chan struct{}, part
 		partNum := 1
 		for {
 			buffer := make([]byte, partSize)
-			_, err := reader.Read(buffer)
+			numberOfBytesRead, err := reader.Read(buffer)
 
 			if err == io.EOF {
 				break
 			}
 
+			// If the number of bytes read is less than the initial buffer size, reduce the buffer size to match the actual content size.
+			if int64(numberOfBytesRead) < partSize {
+				buffer = buffer[:numberOfBytesRead]
+			}
+
 			part := uploadPart{
 				partNum:  partNum,
-				size:     partSize,
+				size:     int64(numberOfBytesRead),
 				err:      err,
 				partBody: buffer,
 			}


### PR DESCRIPTION
### Current Implementation
The current splitStreamToParts() reads a stream and break down to parts and each part will be defined in uploadPart's size field.

If you call uploadManager.UploadStream() likes example/example_objectstorage_test.go to upload a file with content "_Hello World_" (12 bytes), since the defaultStreamPartSize is 10MB, the uploadManager will upload a 10MB file instead.
If you want to upload a 24MB file, the uploaded file size will be 30MB.
The uploaded file size is always a multiply of 10MB.

### Fix In this PR
In objectstorage/transfer/multipart_manifest.go, this MR only fix the splitStreamToParts(). Your team can consider to apply the similar fix to splitFileToParts() if needed.

The following two examples use helpers.WriteTempFileOfSize() to generate the uploaded file. Similar to ExampleObjectStorage_UploadManager_Stream() in example/example_objectstorage_test.go.

**Example 1** 12 bytes
```
$ ls -l /var/folders/fw/30gm94pd10x2f7rl7ckmyyvc0000gn/T/OCIGOSDKSampleFile360238909 _var_folders_fw_30gm94pd10x2f7rl7ckmyyvc0000gn_T_OCIGOSDKSampleFile360238909 
-rw-------  1 aatam  staff  12 Jul 17 23:43 /var/folders/fw/30gm94pd10x2f7rl7ckmyyvc0000gn/T/OCIGOSDKSampleFile360238909
-rw-r--r--@ 1 aatam  staff  12 Jul 17 23:44 _var_folders_fw_30gm94pd10x2f7rl7ckmyyvc0000gn_T_OCIGOSDKSampleFile360238909
```

**Example 2** 25MB
```
$ ls -l /var/folders/fw/30gm94pd10x2f7rl7ckmyyvc0000gn/T/OCIGOSDKSampleFile593671721 _var_folders_fw_30gm94pd10x2f7rl7ckmyyvc0000gn_T_OCIGOSDKSampleFile593671721 
-rw-------  1 aatam  staff  25600000 Jul 17 21:07 /var/folders/fw/30gm94pd10x2f7rl7ckmyyvc0000gn/T/OCIGOSDKSampleFile593671721
-rw-r--r--@ 1 aatam  staff  25600000 Jul 17 21:14 _var_folders_fw_30gm94pd10x2f7rl7ckmyyvc0000gn_T_OCIGOSDKSampleFile593671721
```