### PR TITLE
Releasing version 22.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## 22.0.0 - 2020-07-28
+### Added
+- Support for calling Oracle Cloud Infrastructure services in the us-sanjose-1 region
+- Support for PKCS#8 format API Keys
+- Support for updating the fault domain and launch options of VM instances in the Compute service
+- Support for image capability schemas and schema versions in the Compute service
+- Support for 'Patch Now' maintenance runs for autonomous Exadata infrastructure and autonomous container database resources in the Database service
+- Support for automatic performance and cost tuning on volumes in the Block Storage service
+
+### Breaking changes
+- Removed the accessToken field from the GitlabAccessTokenConfigurationSourceProvider model in the Resource Manager service
+
 ## 21.4.0 - 2020-07-21
 ### Added
 - Support for license types on instances in the Content and Experience service

--- a/common/common.go
+++ b/common/common.go
@@ -31,6 +31,8 @@ const (
 	RegionPHX Region = "us-phoenix-1"
 	//RegionIAD region IAD
 	RegionIAD Region = "us-ashburn-1"
+	//RegionSJC1 region SJC
+	RegionSJC1 Region = "us-sanjose-1"
 	//RegionFRA region FRA
 	RegionFRA Region = "eu-frankfurt-1"
 	//RegionLHR region LHR
@@ -99,15 +101,16 @@ var shortNameRegion = map[string]Region{
 	"mel": RegionAPMelbourne1,
 	"bom": RegionAPMumbai1,
 	"hyd": RegionAPHyderabad1,
-	"gru": RegionSASaopaulo1,
 	"icn": RegionAPSeoul1,
 	"yny": RegionAPChuncheon1,
 	"nrt": RegionAPTokyo1,
 	"kix": RegionAPOsaka1,
+	"syd": RegionAPSydney1,
 	"yul": RegionCAMontreal1,
 	"yyz": RegionCAToronto1,
+	"sjc": RegionSJC1,
+	"gru": RegionSASaopaulo1,
 	"jed": RegionMEJeddah1,
-	"syd": RegionAPSydney1,
 	"ltn": RegionUKGovLondon1,
 }
 
@@ -125,6 +128,7 @@ var regionRealm = map[Region]string{
 	RegionLHR:          "oc1",
 	RegionCAToronto1:   "oc1",
 	RegionCAMontreal1:  "oc1",
+	RegionSJC1:         "oc1",
 	RegionAPTokyo1:     "oc1",
 	RegionAPOsaka1:     "oc1",
 	RegionAPSeoul1:     "oc1",

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -31,6 +31,10 @@ func TestEndpoint(t *testing.T) {
 	endpoint = region.Endpoint("bar")
 	assert.Equal(t, "bar.ap-chuncheon-1.oraclecloud.com", endpoint)
 
+	region = StringToRegion("us-sanjose-1")
+	endpoint = region.Endpoint("bar")
+	assert.Equal(t, "bar.us-sanjose-1.oraclecloud.com", endpoint)
+
 	// OC2
 	region = StringToRegion("us-langley-1")
 	endpoint = region.Endpoint("bar")
@@ -105,6 +109,13 @@ func TestEndpointForTemplate(t *testing.T) {
 			expected:         "https://foo.region.oraclecloud.com",
 		},
 		{
+			// template with second level domain
+			region:           StringToRegion("us-sanjose-1"),
+			service:          "test",
+			endpointTemplate: "https://foo.region.{secondLevelDomain}",
+			expected:         "https://foo.region.oraclecloud.com",
+		},
+		{
 			// template with everything for OC2
 			region:           StringToRegion("us-langley-1"),
 			service:          "test",
@@ -172,6 +183,9 @@ func TestStringToRegion(t *testing.T) {
 
 	region = StringToRegion("yny")
 	assert.Equal(t, RegionAPChuncheon1, region)
+
+	region = StringToRegion("sjc")
+	assert.Equal(t, RegionSJC1, region)
 
 	regionMetadataEnvVar := `{"realmKey":"OC0","realmDomainComponent":"testRealm.com","regionKey":"RTK","regionIdentifier":"us-testregion-1"}`
 	os.Unsetenv("OCI_REGION_METADATA")

--- a/common/version.go
+++ b/common/version.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	major = "21"
-	minor = "4"
+	major = "22"
+	minor = "0"
 	patch = "0"
 	tag   = ""
 )

--- a/core/boolean_image_capability_schema_descriptor.go
+++ b/core/boolean_image_capability_schema_descriptor.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// BooleanImageCapabilitySchemaDescriptor Boolean type ImageCapabilitySchemaDescriptor
+type BooleanImageCapabilitySchemaDescriptor struct {
+
+	// the default value
+	DefaultValue *bool `mandatory:"false" json:"defaultValue"`
+
+	Source ImageCapabilitySchemaDescriptorSourceEnum `mandatory:"true" json:"source"`
+}
+
+//GetSource returns Source
+func (m BooleanImageCapabilitySchemaDescriptor) GetSource() ImageCapabilitySchemaDescriptorSourceEnum {
+	return m.Source
+}
+
+func (m BooleanImageCapabilitySchemaDescriptor) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m BooleanImageCapabilitySchemaDescriptor) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeBooleanImageCapabilitySchemaDescriptor BooleanImageCapabilitySchemaDescriptor
+	s := struct {
+		DiscriminatorParam string `json:"descriptorType"`
+		MarshalTypeBooleanImageCapabilitySchemaDescriptor
+	}{
+		"boolean",
+		(MarshalTypeBooleanImageCapabilitySchemaDescriptor)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/core/boot_volume.go
+++ b/core/boot_volume.go
@@ -92,6 +92,12 @@ type BootVolume struct {
 
 	// The OCID of the Key Management master encryption key assigned to the boot volume.
 	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// Specifies whether the auto-tune performance is enabled for this boot volume.
+	IsAutoTuneEnabled *bool `mandatory:"false" json:"isAutoTuneEnabled"`
+
+	// The number of Volume Performance Units per GB that this boot volume is effectively tuned to when it's idle.
+	AutoTunedVpusPerGB *int64 `mandatory:"false" json:"autoTunedVpusPerGB"`
 }
 
 func (m BootVolume) String() string {
@@ -112,6 +118,8 @@ func (m *BootVolume) UnmarshalJSON(data []byte) (e error) {
 		SourceDetails      bootvolumesourcedetails           `json:"sourceDetails"`
 		VolumeGroupId      *string                           `json:"volumeGroupId"`
 		KmsKeyId           *string                           `json:"kmsKeyId"`
+		IsAutoTuneEnabled  *bool                             `json:"isAutoTuneEnabled"`
+		AutoTunedVpusPerGB *int64                            `json:"autoTunedVpusPerGB"`
 		AvailabilityDomain *string                           `json:"availabilityDomain"`
 		CompartmentId      *string                           `json:"compartmentId"`
 		Id                 *string                           `json:"id"`
@@ -154,6 +162,10 @@ func (m *BootVolume) UnmarshalJSON(data []byte) (e error) {
 	m.VolumeGroupId = model.VolumeGroupId
 
 	m.KmsKeyId = model.KmsKeyId
+
+	m.IsAutoTuneEnabled = model.IsAutoTuneEnabled
+
+	m.AutoTunedVpusPerGB = model.AutoTunedVpusPerGB
 
 	m.AvailabilityDomain = model.AvailabilityDomain
 

--- a/core/change_compute_image_capability_schema_compartment_details.go
+++ b/core/change_compute_image_capability_schema_compartment_details.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ChangeComputeImageCapabilitySchemaCompartmentDetails The configuration details for the move operation.
+type ChangeComputeImageCapabilitySchemaCompartmentDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to
+	// move the instance configuration to.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+}
+
+func (m ChangeComputeImageCapabilitySchemaCompartmentDetails) String() string {
+	return common.PointerString(m)
+}

--- a/core/change_compute_image_capability_schema_compartment_request_response.go
+++ b/core/change_compute_image_capability_schema_compartment_request_response.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ChangeComputeImageCapabilitySchemaCompartmentRequest wrapper for the ChangeComputeImageCapabilitySchemaCompartment operation
+type ChangeComputeImageCapabilitySchemaCompartmentRequest struct {
+
+	// The id of the compute image capability schema or the image ocid
+	ComputeImageCapabilitySchemaId *string `mandatory:"true" contributesTo:"path" name:"computeImageCapabilitySchemaId"`
+
+	// Compute Image Capability Schema change compartment details
+	ChangeComputeImageCapabilitySchemaCompartmentDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ChangeComputeImageCapabilitySchemaCompartmentRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ChangeComputeImageCapabilitySchemaCompartmentRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ChangeComputeImageCapabilitySchemaCompartmentRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ChangeComputeImageCapabilitySchemaCompartmentResponse wrapper for the ChangeComputeImageCapabilitySchemaCompartment operation
+type ChangeComputeImageCapabilitySchemaCompartmentResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ChangeComputeImageCapabilitySchemaCompartmentResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ChangeComputeImageCapabilitySchemaCompartmentResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/core/compute_global_image_capability_schema.go
+++ b/core/compute_global_image_capability_schema.go
@@ -17,38 +17,37 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// UpdateBootVolumeDetails The representation of UpdateBootVolumeDetails
-type UpdateBootVolumeDetails struct {
+// ComputeGlobalImageCapabilitySchema Compute Global Image Capability Schema is a container for a set of compute global image capability schema versions
+type ComputeGlobalImageCapabilitySchema struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute global image capability schema
+	Id *string `mandatory:"true" json:"id"`
+
+	// A user-friendly name for the compute global image capability schema
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The date and time the compute global image capability schema was created, in the format defined by
+	// RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The OCID of the compartment that contains the resource.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The name of the global capabilities version resource that is considered the current version.
+	CurrentVersionName *string `mandatory:"false" json:"currentVersionName"`
 
 	// Defined tags for this resource. Each key is predefined and scoped to a
 	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
-	// A user-friendly name. Does not have to be unique, and it's changeable.
-	// Avoid entering confidential information.
-	DisplayName *string `mandatory:"false" json:"displayName"`
-
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
 	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
-
-	// The size to resize the volume to in GBs. Has to be larger than the current size.
-	SizeInGBs *int64 `mandatory:"false" json:"sizeInGBs"`
-
-	// The number of volume performance units (VPUs) that will be applied to this volume per GB,
-	// representing the Block Volume service's elastic performance options.
-	// See Block Volume Elastic Performance (https://docs.cloud.oracle.com/Content/Block/Concepts/blockvolumeelasticperformance.htm) for more information.
-	// Allowed values:
-	//   * `10`: Represents Balanced option.
-	//   * `20`: Represents Higher Performance option.
-	VpusPerGB *int64 `mandatory:"false" json:"vpusPerGB"`
-
-	// Specifies whether the auto-tune performance is enabled for this boot volume.
-	IsAutoTuneEnabled *bool `mandatory:"false" json:"isAutoTuneEnabled"`
 }
 
-func (m UpdateBootVolumeDetails) String() string {
+func (m ComputeGlobalImageCapabilitySchema) String() string {
 	return common.PointerString(m)
 }

--- a/core/compute_global_image_capability_schema_summary.go
+++ b/core/compute_global_image_capability_schema_summary.go
@@ -17,38 +17,37 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// UpdateBootVolumeDetails The representation of UpdateBootVolumeDetails
-type UpdateBootVolumeDetails struct {
+// ComputeGlobalImageCapabilitySchemaSummary Summary information for a compute global image capability schema
+type ComputeGlobalImageCapabilitySchemaSummary struct {
+
+	// The compute global image capability schema OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	Id *string `mandatory:"true" json:"id"`
+
+	// A user-friendly name for the compute global image capability schema.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The date and time the compute global image capability schema was created, in the format defined by
+	// RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The OCID of the compartment containing the compute global image capability schema
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The name of the global capabilities version resource that is considered the current version.
+	CurrentVersionName *string `mandatory:"false" json:"currentVersionName"`
 
 	// Defined tags for this resource. Each key is predefined and scoped to a
 	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
-	// A user-friendly name. Does not have to be unique, and it's changeable.
-	// Avoid entering confidential information.
-	DisplayName *string `mandatory:"false" json:"displayName"`
-
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
 	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
-
-	// The size to resize the volume to in GBs. Has to be larger than the current size.
-	SizeInGBs *int64 `mandatory:"false" json:"sizeInGBs"`
-
-	// The number of volume performance units (VPUs) that will be applied to this volume per GB,
-	// representing the Block Volume service's elastic performance options.
-	// See Block Volume Elastic Performance (https://docs.cloud.oracle.com/Content/Block/Concepts/blockvolumeelasticperformance.htm) for more information.
-	// Allowed values:
-	//   * `10`: Represents Balanced option.
-	//   * `20`: Represents Higher Performance option.
-	VpusPerGB *int64 `mandatory:"false" json:"vpusPerGB"`
-
-	// Specifies whether the auto-tune performance is enabled for this boot volume.
-	IsAutoTuneEnabled *bool `mandatory:"false" json:"isAutoTuneEnabled"`
 }
 
-func (m UpdateBootVolumeDetails) String() string {
+func (m ComputeGlobalImageCapabilitySchemaSummary) String() string {
 	return common.PointerString(m)
 }

--- a/core/compute_global_image_capability_schema_version.go
+++ b/core/compute_global_image_capability_schema_version.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ComputeGlobalImageCapabilitySchemaVersion Compute Global Image Capability Schema Version is a set of all possible capabilities for a collection of images.
+type ComputeGlobalImageCapabilitySchemaVersion struct {
+
+	// The name of the compute global image capability schema version
+	Name *string `mandatory:"true" json:"name"`
+
+	// The ocid of the compute global image capability schema
+	ComputeGlobalImageCapabilitySchemaId *string `mandatory:"true" json:"computeGlobalImageCapabilitySchemaId"`
+
+	// A user-friendly name for the compute global image capability schema
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The map of each capability name to its ImageCapabilityDescriptor.
+	SchemaData map[string]ImageCapabilitySchemaDescriptor `mandatory:"true" json:"schemaData"`
+
+	// The date and time the compute global image capability schema version was created, in the format defined by
+	// RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+}
+
+func (m ComputeGlobalImageCapabilitySchemaVersion) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *ComputeGlobalImageCapabilitySchemaVersion) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Name                                 *string                                    `json:"name"`
+		ComputeGlobalImageCapabilitySchemaId *string                                    `json:"computeGlobalImageCapabilitySchemaId"`
+		DisplayName                          *string                                    `json:"displayName"`
+		SchemaData                           map[string]imagecapabilityschemadescriptor `json:"schemaData"`
+		TimeCreated                          *common.SDKTime                            `json:"timeCreated"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Name = model.Name
+
+	m.ComputeGlobalImageCapabilitySchemaId = model.ComputeGlobalImageCapabilitySchemaId
+
+	m.DisplayName = model.DisplayName
+
+	m.SchemaData = make(map[string]ImageCapabilitySchemaDescriptor)
+	for k, v := range model.SchemaData {
+		nn, e = v.UnmarshalPolymorphicJSON(v.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.SchemaData[k] = nn.(ImageCapabilitySchemaDescriptor)
+		} else {
+			m.SchemaData[k] = nil
+		}
+	}
+
+	m.TimeCreated = model.TimeCreated
+
+	return
+}

--- a/core/compute_global_image_capability_schema_version_summary.go
+++ b/core/compute_global_image_capability_schema_version_summary.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ComputeGlobalImageCapabilitySchemaVersionSummary Summary information for a compute global image capability schema
+type ComputeGlobalImageCapabilitySchemaVersionSummary struct {
+
+	// The compute global image capability schema version name
+	Name *string `mandatory:"true" json:"name"`
+
+	// The OCID of the compute global image capability schema
+	ComputeGlobalImageCapabilitySchemaId *string `mandatory:"true" json:"computeGlobalImageCapabilitySchemaId"`
+
+	// The date and time the compute global image capability schema version was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The display name of the version
+	DisplayName *string `mandatory:"false" json:"displayName"`
+}
+
+func (m ComputeGlobalImageCapabilitySchemaVersionSummary) String() string {
+	return common.PointerString(m)
+}

--- a/core/compute_image_capability_schema.go
+++ b/core/compute_image_capability_schema.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ComputeImageCapabilitySchema Compute Image Capability Schema is a set of capabilities that filter the compute global capability schema
+// version for an image.
+type ComputeImageCapabilitySchema struct {
+
+	// The id of the compute global image capability schema version
+	Id *string `mandatory:"true" json:"id"`
+
+	// The ocid of the compute global image capability schema
+	ComputeGlobalImageCapabilitySchemaId *string `mandatory:"true" json:"computeGlobalImageCapabilitySchemaId"`
+
+	// The name of the compute global image capability schema version
+	ComputeGlobalImageCapabilitySchemaVersionName *string `mandatory:"true" json:"computeGlobalImageCapabilitySchemaVersionName"`
+
+	// The OCID of the image associated with this compute image capability schema
+	ImageId *string `mandatory:"true" json:"imageId"`
+
+	// A user-friendly name for the compute global image capability schema
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The map of each capability name to its ImageCapabilityDescriptor.
+	SchemaData map[string]ImageCapabilitySchemaDescriptor `mandatory:"true" json:"schemaData"`
+
+	// The date and time the compute image capability schema was created, in the format defined by
+	// RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The OCID of the compartment that contains the resource.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+}
+
+func (m ComputeImageCapabilitySchema) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *ComputeImageCapabilitySchema) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		CompartmentId                                 *string                                    `json:"compartmentId"`
+		DefinedTags                                   map[string]map[string]interface{}          `json:"definedTags"`
+		FreeformTags                                  map[string]string                          `json:"freeformTags"`
+		Id                                            *string                                    `json:"id"`
+		ComputeGlobalImageCapabilitySchemaId          *string                                    `json:"computeGlobalImageCapabilitySchemaId"`
+		ComputeGlobalImageCapabilitySchemaVersionName *string                                    `json:"computeGlobalImageCapabilitySchemaVersionName"`
+		ImageId                                       *string                                    `json:"imageId"`
+		DisplayName                                   *string                                    `json:"displayName"`
+		SchemaData                                    map[string]imagecapabilityschemadescriptor `json:"schemaData"`
+		TimeCreated                                   *common.SDKTime                            `json:"timeCreated"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.CompartmentId = model.CompartmentId
+
+	m.DefinedTags = model.DefinedTags
+
+	m.FreeformTags = model.FreeformTags
+
+	m.Id = model.Id
+
+	m.ComputeGlobalImageCapabilitySchemaId = model.ComputeGlobalImageCapabilitySchemaId
+
+	m.ComputeGlobalImageCapabilitySchemaVersionName = model.ComputeGlobalImageCapabilitySchemaVersionName
+
+	m.ImageId = model.ImageId
+
+	m.DisplayName = model.DisplayName
+
+	m.SchemaData = make(map[string]ImageCapabilitySchemaDescriptor)
+	for k, v := range model.SchemaData {
+		nn, e = v.UnmarshalPolymorphicJSON(v.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.SchemaData[k] = nn.(ImageCapabilitySchemaDescriptor)
+		} else {
+			m.SchemaData[k] = nil
+		}
+	}
+
+	m.TimeCreated = model.TimeCreated
+
+	return
+}

--- a/core/compute_image_capability_schema_summary.go
+++ b/core/compute_image_capability_schema_summary.go
@@ -17,38 +17,39 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// UpdateBootVolumeDetails The representation of UpdateBootVolumeDetails
-type UpdateBootVolumeDetails struct {
+// ComputeImageCapabilitySchemaSummary Summary information for a compute image capability schema
+type ComputeImageCapabilitySchemaSummary struct {
+
+	// The compute image capability schema OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	Id *string `mandatory:"true" json:"id"`
+
+	// The name of the compute global image capability schema version
+	ComputeGlobalImageCapabilitySchemaVersionName *string `mandatory:"true" json:"computeGlobalImageCapabilitySchemaVersionName"`
+
+	// The OCID of the image associated with this compute image capability schema
+	ImageId *string `mandatory:"true" json:"imageId"`
+
+	// A user-friendly name for the compute image capability schema.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The date and time the compute image capability schema was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The OCID of the compartment containing the compute global image capability schema
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
 
 	// Defined tags for this resource. Each key is predefined and scoped to a
 	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
-	// A user-friendly name. Does not have to be unique, and it's changeable.
-	// Avoid entering confidential information.
-	DisplayName *string `mandatory:"false" json:"displayName"`
-
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
 	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
-
-	// The size to resize the volume to in GBs. Has to be larger than the current size.
-	SizeInGBs *int64 `mandatory:"false" json:"sizeInGBs"`
-
-	// The number of volume performance units (VPUs) that will be applied to this volume per GB,
-	// representing the Block Volume service's elastic performance options.
-	// See Block Volume Elastic Performance (https://docs.cloud.oracle.com/Content/Block/Concepts/blockvolumeelasticperformance.htm) for more information.
-	// Allowed values:
-	//   * `10`: Represents Balanced option.
-	//   * `20`: Represents Higher Performance option.
-	VpusPerGB *int64 `mandatory:"false" json:"vpusPerGB"`
-
-	// Specifies whether the auto-tune performance is enabled for this boot volume.
-	IsAutoTuneEnabled *bool `mandatory:"false" json:"isAutoTuneEnabled"`
 }
 
-func (m UpdateBootVolumeDetails) String() string {
+func (m ComputeImageCapabilitySchemaSummary) String() string {
 	return common.PointerString(m)
 }

--- a/core/core_compute_client.go
+++ b/core/core_compute_client.go
@@ -350,6 +350,60 @@ func (client ComputeClient) captureConsoleHistory(ctx context.Context, request c
 	return response, err
 }
 
+// ChangeComputeImageCapabilitySchemaCompartment Moves a compute image capability schema into a different compartment within the same tenancy.
+// For information about moving resources between compartments, see
+//         Moving Resources to a Different Compartment (https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+func (client ComputeClient) ChangeComputeImageCapabilitySchemaCompartment(ctx context.Context, request ChangeComputeImageCapabilitySchemaCompartmentRequest) (response ChangeComputeImageCapabilitySchemaCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.changeComputeImageCapabilitySchemaCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ChangeComputeImageCapabilitySchemaCompartmentResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ChangeComputeImageCapabilitySchemaCompartmentResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeComputeImageCapabilitySchemaCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeComputeImageCapabilitySchemaCompartmentResponse")
+	}
+	return
+}
+
+// changeComputeImageCapabilitySchemaCompartment implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) changeComputeImageCapabilitySchemaCompartment(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/computeImageCapabilitySchemas/{computeImageCapabilitySchemaId}/actions/changeCompartment")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeComputeImageCapabilitySchemaCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // ChangeDedicatedVmHostCompartment Moves a dedicated virtual machine host from one compartment to another.
 func (client ComputeClient) ChangeDedicatedVmHostCompartment(ctx context.Context, request ChangeDedicatedVmHostCompartmentRequest) (response ChangeDedicatedVmHostCompartmentResponse, err error) {
 	var ociResponse common.OCIResponse
@@ -552,6 +606,58 @@ func (client ComputeClient) createAppCatalogSubscription(ctx context.Context, re
 	}
 
 	var response CreateAppCatalogSubscriptionResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateComputeImageCapabilitySchema Creates compute image capability schema.
+func (client ComputeClient) CreateComputeImageCapabilitySchema(ctx context.Context, request CreateComputeImageCapabilitySchemaRequest) (response CreateComputeImageCapabilitySchemaResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createComputeImageCapabilitySchema, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateComputeImageCapabilitySchemaResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateComputeImageCapabilitySchemaResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateComputeImageCapabilitySchemaResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateComputeImageCapabilitySchemaResponse")
+	}
+	return
+}
+
+// createComputeImageCapabilitySchema implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) createComputeImageCapabilitySchema(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/computeImageCapabilitySchemas")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateComputeImageCapabilitySchemaResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -777,6 +883,53 @@ func (client ComputeClient) deleteAppCatalogSubscription(ctx context.Context, re
 	}
 
 	var response DeleteAppCatalogSubscriptionResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteComputeImageCapabilitySchema Deletes the specified Compute Image Capability Schema
+func (client ComputeClient) DeleteComputeImageCapabilitySchema(ctx context.Context, request DeleteComputeImageCapabilitySchemaRequest) (response DeleteComputeImageCapabilitySchemaResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteComputeImageCapabilitySchema, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteComputeImageCapabilitySchemaResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteComputeImageCapabilitySchemaResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteComputeImageCapabilitySchemaResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteComputeImageCapabilitySchemaResponse")
+	}
+	return
+}
+
+// deleteComputeImageCapabilitySchema implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) deleteComputeImageCapabilitySchema(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/computeImageCapabilitySchemas/{computeImageCapabilitySchemaId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteComputeImageCapabilitySchemaResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -1366,6 +1519,147 @@ func (client ComputeClient) getBootVolumeAttachment(ctx context.Context, request
 	}
 
 	var response GetBootVolumeAttachmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetComputeGlobalImageCapabilitySchema Gets the specified Compute Global Image Capability Schema
+func (client ComputeClient) GetComputeGlobalImageCapabilitySchema(ctx context.Context, request GetComputeGlobalImageCapabilitySchemaRequest) (response GetComputeGlobalImageCapabilitySchemaResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getComputeGlobalImageCapabilitySchema, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetComputeGlobalImageCapabilitySchemaResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetComputeGlobalImageCapabilitySchemaResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetComputeGlobalImageCapabilitySchemaResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetComputeGlobalImageCapabilitySchemaResponse")
+	}
+	return
+}
+
+// getComputeGlobalImageCapabilitySchema implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) getComputeGlobalImageCapabilitySchema(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/computeGlobalImageCapabilitySchemas/{computeGlobalImageCapabilitySchemaId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetComputeGlobalImageCapabilitySchemaResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetComputeGlobalImageCapabilitySchemaVersion Gets the specified Compute Global Image Capability Schema Version
+func (client ComputeClient) GetComputeGlobalImageCapabilitySchemaVersion(ctx context.Context, request GetComputeGlobalImageCapabilitySchemaVersionRequest) (response GetComputeGlobalImageCapabilitySchemaVersionResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getComputeGlobalImageCapabilitySchemaVersion, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetComputeGlobalImageCapabilitySchemaVersionResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetComputeGlobalImageCapabilitySchemaVersionResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetComputeGlobalImageCapabilitySchemaVersionResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetComputeGlobalImageCapabilitySchemaVersionResponse")
+	}
+	return
+}
+
+// getComputeGlobalImageCapabilitySchemaVersion implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) getComputeGlobalImageCapabilitySchemaVersion(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/computeGlobalImageCapabilitySchemas/{computeGlobalImageCapabilitySchemaId}/versions/{computeGlobalImageCapabilitySchemaVersionName}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetComputeGlobalImageCapabilitySchemaVersionResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetComputeImageCapabilitySchema Gets the specified Compute Image Capability Schema
+func (client ComputeClient) GetComputeImageCapabilitySchema(ctx context.Context, request GetComputeImageCapabilitySchemaRequest) (response GetComputeImageCapabilitySchemaResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getComputeImageCapabilitySchema, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetComputeImageCapabilitySchemaResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetComputeImageCapabilitySchemaResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetComputeImageCapabilitySchemaResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetComputeImageCapabilitySchemaResponse")
+	}
+	return
+}
+
+// getComputeImageCapabilitySchema implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) getComputeImageCapabilitySchema(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/computeImageCapabilitySchemas/{computeImageCapabilitySchemaId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetComputeImageCapabilitySchemaResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -2187,6 +2481,147 @@ func (client ComputeClient) listBootVolumeAttachments(ctx context.Context, reque
 	return response, err
 }
 
+// ListComputeGlobalImageCapabilitySchemaVersions Lists Compute Global Image Capability Schema versions in the specified compartment.
+func (client ComputeClient) ListComputeGlobalImageCapabilitySchemaVersions(ctx context.Context, request ListComputeGlobalImageCapabilitySchemaVersionsRequest) (response ListComputeGlobalImageCapabilitySchemaVersionsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listComputeGlobalImageCapabilitySchemaVersions, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListComputeGlobalImageCapabilitySchemaVersionsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListComputeGlobalImageCapabilitySchemaVersionsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListComputeGlobalImageCapabilitySchemaVersionsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListComputeGlobalImageCapabilitySchemaVersionsResponse")
+	}
+	return
+}
+
+// listComputeGlobalImageCapabilitySchemaVersions implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) listComputeGlobalImageCapabilitySchemaVersions(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/computeGlobalImageCapabilitySchemas/{computeGlobalImageCapabilitySchemaId}/versions")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListComputeGlobalImageCapabilitySchemaVersionsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListComputeGlobalImageCapabilitySchemas Lists Compute Global Image Capability Schema in the specified compartment.
+func (client ComputeClient) ListComputeGlobalImageCapabilitySchemas(ctx context.Context, request ListComputeGlobalImageCapabilitySchemasRequest) (response ListComputeGlobalImageCapabilitySchemasResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listComputeGlobalImageCapabilitySchemas, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListComputeGlobalImageCapabilitySchemasResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListComputeGlobalImageCapabilitySchemasResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListComputeGlobalImageCapabilitySchemasResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListComputeGlobalImageCapabilitySchemasResponse")
+	}
+	return
+}
+
+// listComputeGlobalImageCapabilitySchemas implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) listComputeGlobalImageCapabilitySchemas(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/computeGlobalImageCapabilitySchemas")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListComputeGlobalImageCapabilitySchemasResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListComputeImageCapabilitySchemas Lists Compute Image Capability Schema in the specified compartment. You can also query by a specific imageId.
+func (client ComputeClient) ListComputeImageCapabilitySchemas(ctx context.Context, request ListComputeImageCapabilitySchemasRequest) (response ListComputeImageCapabilitySchemasResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listComputeImageCapabilitySchemas, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListComputeImageCapabilitySchemasResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListComputeImageCapabilitySchemasResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListComputeImageCapabilitySchemasResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListComputeImageCapabilitySchemasResponse")
+	}
+	return
+}
+
+// listComputeImageCapabilitySchemas implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) listComputeImageCapabilitySchemas(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/computeImageCapabilitySchemas")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListComputeImageCapabilitySchemasResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // ListConsoleHistories Lists the console history metadata for the specified compartment or instance.
 func (client ComputeClient) ListConsoleHistories(ctx context.Context, request ListConsoleHistoriesRequest) (response ListConsoleHistoriesResponse, err error) {
 	var ociResponse common.OCIResponse
@@ -2918,6 +3353,53 @@ func (client ComputeClient) terminateInstance(ctx context.Context, request commo
 	}
 
 	var response TerminateInstanceResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateComputeImageCapabilitySchema Updates the specified Compute Image Capability Schema
+func (client ComputeClient) UpdateComputeImageCapabilitySchema(ctx context.Context, request UpdateComputeImageCapabilitySchemaRequest) (response UpdateComputeImageCapabilitySchemaResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateComputeImageCapabilitySchema, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateComputeImageCapabilitySchemaResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateComputeImageCapabilitySchemaResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateComputeImageCapabilitySchemaResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateComputeImageCapabilitySchemaResponse")
+	}
+	return
+}
+
+// updateComputeImageCapabilitySchema implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) updateComputeImageCapabilitySchema(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/computeImageCapabilitySchemas/{computeImageCapabilitySchemaId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateComputeImageCapabilitySchemaResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)

--- a/core/create_boot_volume_details.go
+++ b/core/create_boot_volume_details.go
@@ -64,6 +64,9 @@ type CreateBootVolumeDetails struct {
 	//   * `10`: Represents Balanced option.
 	//   * `20`: Represents Higher Performance option.
 	VpusPerGB *int64 `mandatory:"false" json:"vpusPerGB"`
+
+	// Specifies whether the auto-tune performance is enabled for this boot volume.
+	IsAutoTuneEnabled *bool `mandatory:"false" json:"isAutoTuneEnabled"`
 }
 
 func (m CreateBootVolumeDetails) String() string {
@@ -80,6 +83,7 @@ func (m *CreateBootVolumeDetails) UnmarshalJSON(data []byte) (e error) {
 		KmsKeyId           *string                           `json:"kmsKeyId"`
 		SizeInGBs          *int64                            `json:"sizeInGBs"`
 		VpusPerGB          *int64                            `json:"vpusPerGB"`
+		IsAutoTuneEnabled  *bool                             `json:"isAutoTuneEnabled"`
 		AvailabilityDomain *string                           `json:"availabilityDomain"`
 		CompartmentId      *string                           `json:"compartmentId"`
 		SourceDetails      bootvolumesourcedetails           `json:"sourceDetails"`
@@ -103,6 +107,8 @@ func (m *CreateBootVolumeDetails) UnmarshalJSON(data []byte) (e error) {
 	m.SizeInGBs = model.SizeInGBs
 
 	m.VpusPerGB = model.VpusPerGB
+
+	m.IsAutoTuneEnabled = model.IsAutoTuneEnabled
 
 	m.AvailabilityDomain = model.AvailabilityDomain
 

--- a/core/create_compute_image_capability_schema_details.go
+++ b/core/create_compute_image_capability_schema_details.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateComputeImageCapabilitySchemaDetails Create Image Capability Schema for an image.
+type CreateComputeImageCapabilitySchemaDetails struct {
+
+	// The OCID of the compartment that contains the resource.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The name of the compute global image capability schema version
+	ComputeGlobalImageCapabilitySchemaVersionName *string `mandatory:"true" json:"computeGlobalImageCapabilitySchemaVersionName"`
+
+	// The ocid of the image
+	ImageId *string `mandatory:"true" json:"imageId"`
+
+	// The map of each capability name to its ImageCapabilitySchemaDescriptor.
+	SchemaData map[string]ImageCapabilitySchemaDescriptor `mandatory:"true" json:"schemaData"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// A user-friendly name for the compute image capability schema
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m CreateComputeImageCapabilitySchemaDetails) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *CreateComputeImageCapabilitySchemaDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		FreeformTags                                  map[string]string                          `json:"freeformTags"`
+		DisplayName                                   *string                                    `json:"displayName"`
+		DefinedTags                                   map[string]map[string]interface{}          `json:"definedTags"`
+		CompartmentId                                 *string                                    `json:"compartmentId"`
+		ComputeGlobalImageCapabilitySchemaVersionName *string                                    `json:"computeGlobalImageCapabilitySchemaVersionName"`
+		ImageId                                       *string                                    `json:"imageId"`
+		SchemaData                                    map[string]imagecapabilityschemadescriptor `json:"schemaData"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.FreeformTags = model.FreeformTags
+
+	m.DisplayName = model.DisplayName
+
+	m.DefinedTags = model.DefinedTags
+
+	m.CompartmentId = model.CompartmentId
+
+	m.ComputeGlobalImageCapabilitySchemaVersionName = model.ComputeGlobalImageCapabilitySchemaVersionName
+
+	m.ImageId = model.ImageId
+
+	m.SchemaData = make(map[string]ImageCapabilitySchemaDescriptor)
+	for k, v := range model.SchemaData {
+		nn, e = v.UnmarshalPolymorphicJSON(v.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.SchemaData[k] = nn.(ImageCapabilitySchemaDescriptor)
+		} else {
+			m.SchemaData[k] = nil
+		}
+	}
+
+	return
+}

--- a/core/create_compute_image_capability_schema_request_response.go
+++ b/core/create_compute_image_capability_schema_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateComputeImageCapabilitySchemaRequest wrapper for the CreateComputeImageCapabilitySchema operation
+type CreateComputeImageCapabilitySchemaRequest struct {
+
+	// Compute Image Capability Schema creation details
+	CreateComputeImageCapabilitySchemaDetails `contributesTo:"body"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateComputeImageCapabilitySchemaRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateComputeImageCapabilitySchemaRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateComputeImageCapabilitySchemaRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateComputeImageCapabilitySchemaResponse wrapper for the CreateComputeImageCapabilitySchema operation
+type CreateComputeImageCapabilitySchemaResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ComputeImageCapabilitySchema instance
+	ComputeImageCapabilitySchema `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateComputeImageCapabilitySchemaResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateComputeImageCapabilitySchemaResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/core/create_image_details.go
+++ b/core/create_image_details.go
@@ -49,7 +49,7 @@ type CreateImageDetails struct {
 	// Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
 	// * `NATIVE` - VM instances launch with paravirtualized boot and VFIO devices. The default value for Oracle-provided images.
 	// * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
 	// * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
 	LaunchMode CreateImageDetailsLaunchModeEnum `mandatory:"false" json:"launchMode,omitempty"`
 }

--- a/core/create_volume_details.go
+++ b/core/create_volume_details.go
@@ -75,6 +75,9 @@ type CreateVolumeDetails struct {
 	// This field is deprecated. Use the sourceDetails field instead to specify the
 	// backup for the volume.
 	VolumeBackupId *string `mandatory:"false" json:"volumeBackupId"`
+
+	// Specifies whether the auto-tune performance is enabled for this volume.
+	IsAutoTuneEnabled *bool `mandatory:"false" json:"isAutoTuneEnabled"`
 }
 
 func (m CreateVolumeDetails) String() string {
@@ -94,6 +97,7 @@ func (m *CreateVolumeDetails) UnmarshalJSON(data []byte) (e error) {
 		SizeInMBs          *int64                            `json:"sizeInMBs"`
 		SourceDetails      volumesourcedetails               `json:"sourceDetails"`
 		VolumeBackupId     *string                           `json:"volumeBackupId"`
+		IsAutoTuneEnabled  *bool                             `json:"isAutoTuneEnabled"`
 		AvailabilityDomain *string                           `json:"availabilityDomain"`
 		CompartmentId      *string                           `json:"compartmentId"`
 	}{}
@@ -130,6 +134,8 @@ func (m *CreateVolumeDetails) UnmarshalJSON(data []byte) (e error) {
 	}
 
 	m.VolumeBackupId = model.VolumeBackupId
+
+	m.IsAutoTuneEnabled = model.IsAutoTuneEnabled
 
 	m.AvailabilityDomain = model.AvailabilityDomain
 

--- a/core/delete_compute_image_capability_schema_request_response.go
+++ b/core/delete_compute_image_capability_schema_request_response.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteComputeImageCapabilitySchemaRequest wrapper for the DeleteComputeImageCapabilitySchema operation
+type DeleteComputeImageCapabilitySchemaRequest struct {
+
+	// The id of the compute image capability schema or the image ocid
+	ComputeImageCapabilitySchemaId *string `mandatory:"true" contributesTo:"path" name:"computeImageCapabilitySchemaId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteComputeImageCapabilitySchemaRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteComputeImageCapabilitySchemaRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteComputeImageCapabilitySchemaRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteComputeImageCapabilitySchemaResponse wrapper for the DeleteComputeImageCapabilitySchema operation
+type DeleteComputeImageCapabilitySchemaResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteComputeImageCapabilitySchemaResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteComputeImageCapabilitySchemaResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/core/enum_integer_image_capability_descriptor.go
+++ b/core/enum_integer_image_capability_descriptor.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// EnumIntegerImageCapabilityDescriptor Enum Integer type CapabilityDescriptor
+type EnumIntegerImageCapabilityDescriptor struct {
+
+	// the list of values for the enum
+	Values []int `mandatory:"true" json:"values"`
+
+	// the default value
+	DefaultValue *int `mandatory:"false" json:"defaultValue"`
+
+	Source ImageCapabilitySchemaDescriptorSourceEnum `mandatory:"true" json:"source"`
+}
+
+//GetSource returns Source
+func (m EnumIntegerImageCapabilityDescriptor) GetSource() ImageCapabilitySchemaDescriptorSourceEnum {
+	return m.Source
+}
+
+func (m EnumIntegerImageCapabilityDescriptor) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m EnumIntegerImageCapabilityDescriptor) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeEnumIntegerImageCapabilityDescriptor EnumIntegerImageCapabilityDescriptor
+	s := struct {
+		DiscriminatorParam string `json:"descriptorType"`
+		MarshalTypeEnumIntegerImageCapabilityDescriptor
+	}{
+		"enuminteger",
+		(MarshalTypeEnumIntegerImageCapabilityDescriptor)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/core/enum_string_image_capability_schema_descriptor.go
+++ b/core/enum_string_image_capability_schema_descriptor.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// EnumStringImageCapabilitySchemaDescriptor Enum String type of ImageCapabilitySchemaDescriptor
+type EnumStringImageCapabilitySchemaDescriptor struct {
+
+	// the list of values for the enum
+	Values []string `mandatory:"true" json:"values"`
+
+	// the default value
+	DefaultValue *string `mandatory:"false" json:"defaultValue"`
+
+	Source ImageCapabilitySchemaDescriptorSourceEnum `mandatory:"true" json:"source"`
+}
+
+//GetSource returns Source
+func (m EnumStringImageCapabilitySchemaDescriptor) GetSource() ImageCapabilitySchemaDescriptorSourceEnum {
+	return m.Source
+}
+
+func (m EnumStringImageCapabilitySchemaDescriptor) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m EnumStringImageCapabilitySchemaDescriptor) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeEnumStringImageCapabilitySchemaDescriptor EnumStringImageCapabilitySchemaDescriptor
+	s := struct {
+		DiscriminatorParam string `json:"descriptorType"`
+		MarshalTypeEnumStringImageCapabilitySchemaDescriptor
+	}{
+		"enumstring",
+		(MarshalTypeEnumStringImageCapabilitySchemaDescriptor)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/core/get_compute_global_image_capability_schema_request_response.go
+++ b/core/get_compute_global_image_capability_schema_request_response.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetComputeGlobalImageCapabilitySchemaRequest wrapper for the GetComputeGlobalImageCapabilitySchema operation
+type GetComputeGlobalImageCapabilitySchemaRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compute global image capability schema
+	ComputeGlobalImageCapabilitySchemaId *string `mandatory:"true" contributesTo:"path" name:"computeGlobalImageCapabilitySchemaId"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetComputeGlobalImageCapabilitySchemaRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetComputeGlobalImageCapabilitySchemaRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetComputeGlobalImageCapabilitySchemaRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetComputeGlobalImageCapabilitySchemaResponse wrapper for the GetComputeGlobalImageCapabilitySchema operation
+type GetComputeGlobalImageCapabilitySchemaResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ComputeGlobalImageCapabilitySchema instance
+	ComputeGlobalImageCapabilitySchema `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetComputeGlobalImageCapabilitySchemaResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetComputeGlobalImageCapabilitySchemaResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/core/get_compute_global_image_capability_schema_version_request_response.go
+++ b/core/get_compute_global_image_capability_schema_version_request_response.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetComputeGlobalImageCapabilitySchemaVersionRequest wrapper for the GetComputeGlobalImageCapabilitySchemaVersion operation
+type GetComputeGlobalImageCapabilitySchemaVersionRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compute global image capability schema
+	ComputeGlobalImageCapabilitySchemaId *string `mandatory:"true" contributesTo:"path" name:"computeGlobalImageCapabilitySchemaId"`
+
+	// The name of the compute global image capability schema version
+	ComputeGlobalImageCapabilitySchemaVersionName *string `mandatory:"true" contributesTo:"path" name:"computeGlobalImageCapabilitySchemaVersionName"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetComputeGlobalImageCapabilitySchemaVersionRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetComputeGlobalImageCapabilitySchemaVersionRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetComputeGlobalImageCapabilitySchemaVersionRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetComputeGlobalImageCapabilitySchemaVersionResponse wrapper for the GetComputeGlobalImageCapabilitySchemaVersion operation
+type GetComputeGlobalImageCapabilitySchemaVersionResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ComputeGlobalImageCapabilitySchemaVersion instance
+	ComputeGlobalImageCapabilitySchemaVersion `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetComputeGlobalImageCapabilitySchemaVersionResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetComputeGlobalImageCapabilitySchemaVersionResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/core/get_compute_image_capability_schema_request_response.go
+++ b/core/get_compute_image_capability_schema_request_response.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetComputeImageCapabilitySchemaRequest wrapper for the GetComputeImageCapabilitySchema operation
+type GetComputeImageCapabilitySchemaRequest struct {
+
+	// The id of the compute image capability schema or the image ocid
+	ComputeImageCapabilitySchemaId *string `mandatory:"true" contributesTo:"path" name:"computeImageCapabilitySchemaId"`
+
+	// Merge the image capability schema with the global image capability schema
+	IsMergeEnabled *bool `mandatory:"false" contributesTo:"query" name:"isMergeEnabled"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetComputeImageCapabilitySchemaRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetComputeImageCapabilitySchemaRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetComputeImageCapabilitySchemaRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetComputeImageCapabilitySchemaResponse wrapper for the GetComputeImageCapabilitySchema operation
+type GetComputeImageCapabilitySchemaResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ComputeImageCapabilitySchema instance
+	ComputeImageCapabilitySchema `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetComputeImageCapabilitySchemaResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetComputeImageCapabilitySchemaResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/core/image.go
+++ b/core/image.go
@@ -73,7 +73,7 @@ type Image struct {
 	// Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
 	// * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
 	// * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
 	// * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
 	LaunchMode ImageLaunchModeEnum `mandatory:"false" json:"launchMode,omitempty"`
 

--- a/core/image_capability_schema_descriptor.go
+++ b/core/image_capability_schema_descriptor.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ImageCapabilitySchemaDescriptor Image Capability Schema Descriptor is a type of capability for an image.
+type ImageCapabilitySchemaDescriptor interface {
+	GetSource() ImageCapabilitySchemaDescriptorSourceEnum
+}
+
+type imagecapabilityschemadescriptor struct {
+	JsonData       []byte
+	Source         ImageCapabilitySchemaDescriptorSourceEnum `mandatory:"true" json:"source"`
+	DescriptorType string                                    `json:"descriptorType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *imagecapabilityschemadescriptor) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerimagecapabilityschemadescriptor imagecapabilityschemadescriptor
+	s := struct {
+		Model Unmarshalerimagecapabilityschemadescriptor
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Source = s.Model.Source
+	m.DescriptorType = s.Model.DescriptorType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *imagecapabilityschemadescriptor) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.DescriptorType {
+	case "enumstring":
+		mm := EnumStringImageCapabilitySchemaDescriptor{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "enuminteger":
+		mm := EnumIntegerImageCapabilityDescriptor{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "boolean":
+		mm := BooleanImageCapabilitySchemaDescriptor{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetSource returns Source
+func (m imagecapabilityschemadescriptor) GetSource() ImageCapabilitySchemaDescriptorSourceEnum {
+	return m.Source
+}
+
+func (m imagecapabilityschemadescriptor) String() string {
+	return common.PointerString(m)
+}
+
+// ImageCapabilitySchemaDescriptorSourceEnum Enum with underlying type: string
+type ImageCapabilitySchemaDescriptorSourceEnum string
+
+// Set of constants representing the allowable values for ImageCapabilitySchemaDescriptorSourceEnum
+const (
+	ImageCapabilitySchemaDescriptorSourceGlobal ImageCapabilitySchemaDescriptorSourceEnum = "GLOBAL"
+	ImageCapabilitySchemaDescriptorSourceImage  ImageCapabilitySchemaDescriptorSourceEnum = "IMAGE"
+)
+
+var mappingImageCapabilitySchemaDescriptorSource = map[string]ImageCapabilitySchemaDescriptorSourceEnum{
+	"GLOBAL": ImageCapabilitySchemaDescriptorSourceGlobal,
+	"IMAGE":  ImageCapabilitySchemaDescriptorSourceImage,
+}
+
+// GetImageCapabilitySchemaDescriptorSourceEnumValues Enumerates the set of values for ImageCapabilitySchemaDescriptorSourceEnum
+func GetImageCapabilitySchemaDescriptorSourceEnumValues() []ImageCapabilitySchemaDescriptorSourceEnum {
+	values := make([]ImageCapabilitySchemaDescriptorSourceEnum, 0)
+	for _, v := range mappingImageCapabilitySchemaDescriptorSource {
+		values = append(values, v)
+	}
+	return values
+}

--- a/core/instance.go
+++ b/core/instance.go
@@ -70,8 +70,10 @@ type Instance struct {
 	// Example: `My bare metal instance`
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// Additional metadata key/value pairs that you provide. They serve the same purpose and functionality as fields in the 'metadata' object.
-	// They are distinguished from 'metadata' fields in that these can be nested JSON objects (whereas 'metadata' fields are string/string maps only).
+	// Additional metadata key/value pairs that you provide. They serve the same purpose and functionality
+	// as fields in the `metadata` object.
+	// They are distinguished from `metadata` fields in that these can be nested JSON objects (whereas `metadata`
+	// fields are string/string maps only).
 	ExtendedMetadata map[string]interface{} `mandatory:"false" json:"extendedMetadata"`
 
 	// The name of the fault domain the instance is running in.
@@ -80,8 +82,7 @@ type Instance struct {
 	// instances so that they are not on the same physical hardware within a single availability domain.
 	// A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
 	// instances in other fault domains.
-	// If you do not specify the fault domain, the system selects one for you. To change the fault
-	// domain for an instance, terminate it and launch a new instance in the preferred fault domain.
+	// If you do not specify the fault domain, the system selects one for you.
 	// Example: `FAULT-DOMAIN-1`
 	FaultDomain *string `mandatory:"false" json:"faultDomain"`
 
@@ -116,7 +117,7 @@ type Instance struct {
 	// Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
 	// * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
 	// * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
 	// * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
 	LaunchMode InstanceLaunchModeEnum `mandatory:"false" json:"launchMode,omitempty"`
 

--- a/core/instance_configuration_launch_instance_details.go
+++ b/core/instance_configuration_launch_instance_details.go
@@ -44,8 +44,12 @@ type InstanceConfigurationLaunchInstanceDetails struct {
 	// Example: `My bare metal instance`
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// Additional metadata key/value pairs that you provide. They serve the same purpose and functionality as fields in the 'metadata' object.
-	// They are distinguished from 'metadata' fields in that these can be nested JSON objects (whereas 'metadata' fields are string/string maps only).
+	// Additional metadata key/value pairs that you provide. They serve the same purpose and
+	// functionality as fields in the `metadata` object.
+	// They are distinguished from `metadata` fields in that these can be nested JSON objects
+	// (whereas `metadata` fields are string/string maps only).
+	// The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+	// 32,000 bytes.
 	ExtendedMetadata map[string]interface{} `mandatory:"false" json:"extendedMetadata"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
@@ -108,6 +112,7 @@ type InstanceConfigurationLaunchInstanceDetails struct {
 	//      curl -H "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/instance/metadata/<any-key-name>
 	//  You'll get back a response that includes all the instance information; only the metadata information; or
 	//  the metadata information for the specified key name, respectively.
+	//  The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of 32,000 bytes.
 	Metadata map[string]string `mandatory:"false" json:"metadata"`
 
 	// The shape of an instance. The shape determines the number of CPUs, amount of memory,
@@ -126,8 +131,8 @@ type InstanceConfigurationLaunchInstanceDetails struct {
 	// instances so that they are not on the same physical hardware within a single availability domain.
 	// A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
 	// instances in other fault domains.
-	// If you do not specify the fault domain, the system selects one for you. To change the fault
-	// domain for an instance, terminate it and launch a new instance in the preferred fault domain.
+	// If you do not specify the fault domain, the system selects one for you.
+	//
 	// To get a list of fault domains, use the
 	// ListFaultDomains operation in the
 	// Identity and Access Management Service API.
@@ -142,7 +147,7 @@ type InstanceConfigurationLaunchInstanceDetails struct {
 	// Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
 	// * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
 	// * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
 	// * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
 	LaunchMode InstanceConfigurationLaunchInstanceDetailsLaunchModeEnum `mandatory:"false" json:"launchMode,omitempty"`
 

--- a/core/instance_configuration_launch_options.go
+++ b/core/instance_configuration_launch_options.go
@@ -21,38 +21,38 @@ import (
 // default values.
 type InstanceConfigurationLaunchOptions struct {
 
-	// Emulation type for volume.
+	// Emulation type for the boot volume.
 	// * `ISCSI` - ISCSI attached block storage device.
 	// * `SCSI` - Emulated SCSI disk.
 	// * `IDE` - Emulated IDE disk.
-	// * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
+	// * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
 	// volumes on Oracle provided images.
-	// * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
-	// Storage volumes on Oracle provided images.
+	// * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+	// storage volumes on Oracle-provided images.
 	BootVolumeType InstanceConfigurationLaunchOptionsBootVolumeTypeEnum `mandatory:"false" json:"bootVolumeType,omitempty"`
 
 	// Firmware used to boot VM.  Select the option that matches your operating system.
 	// * `BIOS` - Boot VM using BIOS style firmware.  This is compatible with both 32 bit and 64 bit operating
 	// systems that boot using MBR style bootloaders.
 	// * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems.  This is the
-	// default for Oracle provided images.
+	// default for Oracle-provided images.
 	Firmware InstanceConfigurationLaunchOptionsFirmwareEnum `mandatory:"false" json:"firmware,omitempty"`
 
 	// Emulation type for the physical network interface card (NIC).
 	// * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver.
 	// * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
 	// when you launch an instance using hardware-assisted (SR-IOV) networking.
-	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
 	NetworkType InstanceConfigurationLaunchOptionsNetworkTypeEnum `mandatory:"false" json:"networkType,omitempty"`
 
 	// Emulation type for volume.
 	// * `ISCSI` - ISCSI attached block storage device.
 	// * `SCSI` - Emulated SCSI disk.
 	// * `IDE` - Emulated IDE disk.
-	// * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
+	// * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
 	// volumes on Oracle provided images.
-	// * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
-	// Storage volumes on Oracle provided images.
+	// * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+	// storage volumes on Oracle-provided images.
 	RemoteDataVolumeType InstanceConfigurationLaunchOptionsRemoteDataVolumeTypeEnum `mandatory:"false" json:"remoteDataVolumeType,omitempty"`
 
 	// Deprecated. Instead use `isPvEncryptionInTransitEnabled` in

--- a/core/instance_summary.go
+++ b/core/instance_summary.go
@@ -45,7 +45,7 @@ type InstanceSummary struct {
 	// The user-friendly name.  Does not have to be unique.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// The name of the Fault Domain the instance is running in.
+	// The fault domain the instance is running in.
 	FaultDomain *string `mandatory:"false" json:"faultDomain"`
 
 	// The shape of an instance. The shape determines the number of CPUs, amount of memory,

--- a/core/launch_instance_details.go
+++ b/core/launch_instance_details.go
@@ -51,8 +51,12 @@ type LaunchInstanceDetails struct {
 	// Example: `My bare metal instance`
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// Additional metadata key/value pairs that you provide. They serve the same purpose and functionality as fields in the 'metadata' object.
-	// They are distinguished from 'metadata' fields in that these can be nested JSON objects (whereas 'metadata' fields are string/string maps only).
+	// Additional metadata key/value pairs that you provide. They serve the same purpose and
+	// functionality as fields in the `metadata` object.
+	// They are distinguished from `metadata` fields in that these can be nested JSON objects
+	// (whereas `metadata` fields are string/string maps only).
+	// The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+	// 32,000 bytes.
 	ExtendedMetadata map[string]interface{} `mandatory:"false" json:"extendedMetadata"`
 
 	// A fault domain is a grouping of hardware and infrastructure within an availability domain.
@@ -60,8 +64,8 @@ type LaunchInstanceDetails struct {
 	// instances so that they are not on the same physical hardware within a single availability domain.
 	// A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
 	// instances in other fault domains.
-	// If you do not specify the fault domain, the system selects one for you. To change the fault
-	// domain for an instance, terminate it and launch a new instance in the preferred fault domain.
+	// If you do not specify the fault domain, the system selects one for you.
+	//
 	// To get a list of fault domains, use the
 	// ListFaultDomains operation in the
 	// Identity and Access Management Service API.
@@ -141,6 +145,7 @@ type LaunchInstanceDetails struct {
 	//      curl -H "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/instance/metadata/<any-key-name>
 	//  You'll get back a response that includes all the instance information; only the metadata information; or
 	//  the metadata information for the specified key name, respectively.
+	//  The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of 32,000 bytes.
 	Metadata map[string]string `mandatory:"false" json:"metadata"`
 
 	AgentConfig *LaunchInstanceAgentConfigDetails `mandatory:"false" json:"agentConfig"`

--- a/core/launch_options.go
+++ b/core/launch_options.go
@@ -21,38 +21,38 @@ import (
 // default values.
 type LaunchOptions struct {
 
-	// Emulation type for volume.
+	// Emulation type for the boot volume.
 	// * `ISCSI` - ISCSI attached block storage device.
 	// * `SCSI` - Emulated SCSI disk.
 	// * `IDE` - Emulated IDE disk.
-	// * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
-	// volumes on Oracle provided images.
-	// * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
-	// Storage volumes on Oracle provided images.
+	// * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+	// volumes on Oracle-provided images.
+	// * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+	// storage volumes on Oracle-provided images.
 	BootVolumeType LaunchOptionsBootVolumeTypeEnum `mandatory:"false" json:"bootVolumeType,omitempty"`
 
 	// Firmware used to boot VM.  Select the option that matches your operating system.
 	// * `BIOS` - Boot VM using BIOS style firmware.  This is compatible with both 32 bit and 64 bit operating
 	// systems that boot using MBR style bootloaders.
 	// * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems.  This is the
-	// default for Oracle provided images.
+	// default for Oracle-provided images.
 	Firmware LaunchOptionsFirmwareEnum `mandatory:"false" json:"firmware,omitempty"`
 
 	// Emulation type for the physical network interface card (NIC).
 	// * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver.
 	// * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
 	// when you launch an instance using hardware-assisted (SR-IOV) networking.
-	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
 	NetworkType LaunchOptionsNetworkTypeEnum `mandatory:"false" json:"networkType,omitempty"`
 
 	// Emulation type for volume.
 	// * `ISCSI` - ISCSI attached block storage device.
 	// * `SCSI` - Emulated SCSI disk.
 	// * `IDE` - Emulated IDE disk.
-	// * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
-	// volumes on Oracle provided images.
-	// * `PARAVIRTUALIZED` - Paravirtualized disk.This is the default for Boot Volumes and Remote Block
-	// Storage volumes on Oracle provided images.
+	// * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+	// volumes on Oracle-provided images.
+	// * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+	// storage volumes on Oracle-provided images.
 	RemoteDataVolumeType LaunchOptionsRemoteDataVolumeTypeEnum `mandatory:"false" json:"remoteDataVolumeType,omitempty"`
 
 	// Deprecated. Instead use `isPvEncryptionInTransitEnabled` in

--- a/core/list_compute_global_image_capability_schema_versions_request_response.go
+++ b/core/list_compute_global_image_capability_schema_versions_request_response.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListComputeGlobalImageCapabilitySchemaVersionsRequest wrapper for the ListComputeGlobalImageCapabilitySchemaVersions operation
+type ListComputeGlobalImageCapabilitySchemaVersionsRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compute global image capability schema
+	ComputeGlobalImageCapabilitySchemaId *string `mandatory:"true" contributesTo:"path" name:"computeGlobalImageCapabilitySchemaId"`
+
+	// A filter to return only resources that match the given display name exactly.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated
+	// "List" call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// Example: `50`
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List"
+	// call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+	// TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+	// sort order is case sensitive.
+	// **Note:** In general, some "List" operations (for example, `ListInstances`) let you
+	// optionally filter by availability domain if the scope of the resource type is within a
+	// single availability domain. If you call one of these "List" operations without specifying
+	// an availability domain, the resources are grouped by availability domain, then sorted.
+	SortBy ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+	// is case sensitive.
+	SortOrder ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListComputeGlobalImageCapabilitySchemaVersionsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListComputeGlobalImageCapabilitySchemaVersionsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListComputeGlobalImageCapabilitySchemaVersionsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListComputeGlobalImageCapabilitySchemaVersionsResponse wrapper for the ListComputeGlobalImageCapabilitySchemaVersions operation
+type ListComputeGlobalImageCapabilitySchemaVersionsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []ComputeGlobalImageCapabilitySchemaVersionSummary instances
+	Items []ComputeGlobalImageCapabilitySchemaVersionSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListComputeGlobalImageCapabilitySchemaVersionsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListComputeGlobalImageCapabilitySchemaVersionsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum Enum with underlying type: string
+type ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum string
+
+// Set of constants representing the allowable values for ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum
+const (
+	ListComputeGlobalImageCapabilitySchemaVersionsSortByTimecreated ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum = "TIMECREATED"
+	ListComputeGlobalImageCapabilitySchemaVersionsSortByDisplayname ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum = "DISPLAYNAME"
+)
+
+var mappingListComputeGlobalImageCapabilitySchemaVersionsSortBy = map[string]ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum{
+	"TIMECREATED": ListComputeGlobalImageCapabilitySchemaVersionsSortByTimecreated,
+	"DISPLAYNAME": ListComputeGlobalImageCapabilitySchemaVersionsSortByDisplayname,
+}
+
+// GetListComputeGlobalImageCapabilitySchemaVersionsSortByEnumValues Enumerates the set of values for ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum
+func GetListComputeGlobalImageCapabilitySchemaVersionsSortByEnumValues() []ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum {
+	values := make([]ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum, 0)
+	for _, v := range mappingListComputeGlobalImageCapabilitySchemaVersionsSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum Enum with underlying type: string
+type ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum
+const (
+	ListComputeGlobalImageCapabilitySchemaVersionsSortOrderAsc  ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum = "ASC"
+	ListComputeGlobalImageCapabilitySchemaVersionsSortOrderDesc ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum = "DESC"
+)
+
+var mappingListComputeGlobalImageCapabilitySchemaVersionsSortOrder = map[string]ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum{
+	"ASC":  ListComputeGlobalImageCapabilitySchemaVersionsSortOrderAsc,
+	"DESC": ListComputeGlobalImageCapabilitySchemaVersionsSortOrderDesc,
+}
+
+// GetListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnumValues Enumerates the set of values for ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum
+func GetListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnumValues() []ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum {
+	values := make([]ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum, 0)
+	for _, v := range mappingListComputeGlobalImageCapabilitySchemaVersionsSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/core/list_compute_global_image_capability_schemas_request_response.go
+++ b/core/list_compute_global_image_capability_schemas_request_response.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListComputeGlobalImageCapabilitySchemasRequest wrapper for the ListComputeGlobalImageCapabilitySchemas operation
+type ListComputeGlobalImageCapabilitySchemasRequest struct {
+
+	// A filter to return only resources that match the given compartment OCID exactly.
+	CompartmentId *string `mandatory:"false" contributesTo:"query" name:"compartmentId"`
+
+	// A filter to return only resources that match the given display name exactly.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated
+	// "List" call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// Example: `50`
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List"
+	// call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+	// TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+	// sort order is case sensitive.
+	// **Note:** In general, some "List" operations (for example, `ListInstances`) let you
+	// optionally filter by availability domain if the scope of the resource type is within a
+	// single availability domain. If you call one of these "List" operations without specifying
+	// an availability domain, the resources are grouped by availability domain, then sorted.
+	SortBy ListComputeGlobalImageCapabilitySchemasSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+	// is case sensitive.
+	SortOrder ListComputeGlobalImageCapabilitySchemasSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListComputeGlobalImageCapabilitySchemasRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListComputeGlobalImageCapabilitySchemasRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListComputeGlobalImageCapabilitySchemasRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListComputeGlobalImageCapabilitySchemasResponse wrapper for the ListComputeGlobalImageCapabilitySchemas operation
+type ListComputeGlobalImageCapabilitySchemasResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []ComputeGlobalImageCapabilitySchemaSummary instances
+	Items []ComputeGlobalImageCapabilitySchemaSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListComputeGlobalImageCapabilitySchemasResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListComputeGlobalImageCapabilitySchemasResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListComputeGlobalImageCapabilitySchemasSortByEnum Enum with underlying type: string
+type ListComputeGlobalImageCapabilitySchemasSortByEnum string
+
+// Set of constants representing the allowable values for ListComputeGlobalImageCapabilitySchemasSortByEnum
+const (
+	ListComputeGlobalImageCapabilitySchemasSortByTimecreated ListComputeGlobalImageCapabilitySchemasSortByEnum = "TIMECREATED"
+	ListComputeGlobalImageCapabilitySchemasSortByDisplayname ListComputeGlobalImageCapabilitySchemasSortByEnum = "DISPLAYNAME"
+)
+
+var mappingListComputeGlobalImageCapabilitySchemasSortBy = map[string]ListComputeGlobalImageCapabilitySchemasSortByEnum{
+	"TIMECREATED": ListComputeGlobalImageCapabilitySchemasSortByTimecreated,
+	"DISPLAYNAME": ListComputeGlobalImageCapabilitySchemasSortByDisplayname,
+}
+
+// GetListComputeGlobalImageCapabilitySchemasSortByEnumValues Enumerates the set of values for ListComputeGlobalImageCapabilitySchemasSortByEnum
+func GetListComputeGlobalImageCapabilitySchemasSortByEnumValues() []ListComputeGlobalImageCapabilitySchemasSortByEnum {
+	values := make([]ListComputeGlobalImageCapabilitySchemasSortByEnum, 0)
+	for _, v := range mappingListComputeGlobalImageCapabilitySchemasSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListComputeGlobalImageCapabilitySchemasSortOrderEnum Enum with underlying type: string
+type ListComputeGlobalImageCapabilitySchemasSortOrderEnum string
+
+// Set of constants representing the allowable values for ListComputeGlobalImageCapabilitySchemasSortOrderEnum
+const (
+	ListComputeGlobalImageCapabilitySchemasSortOrderAsc  ListComputeGlobalImageCapabilitySchemasSortOrderEnum = "ASC"
+	ListComputeGlobalImageCapabilitySchemasSortOrderDesc ListComputeGlobalImageCapabilitySchemasSortOrderEnum = "DESC"
+)
+
+var mappingListComputeGlobalImageCapabilitySchemasSortOrder = map[string]ListComputeGlobalImageCapabilitySchemasSortOrderEnum{
+	"ASC":  ListComputeGlobalImageCapabilitySchemasSortOrderAsc,
+	"DESC": ListComputeGlobalImageCapabilitySchemasSortOrderDesc,
+}
+
+// GetListComputeGlobalImageCapabilitySchemasSortOrderEnumValues Enumerates the set of values for ListComputeGlobalImageCapabilitySchemasSortOrderEnum
+func GetListComputeGlobalImageCapabilitySchemasSortOrderEnumValues() []ListComputeGlobalImageCapabilitySchemasSortOrderEnum {
+	values := make([]ListComputeGlobalImageCapabilitySchemasSortOrderEnum, 0)
+	for _, v := range mappingListComputeGlobalImageCapabilitySchemasSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/core/list_compute_image_capability_schemas_request_response.go
+++ b/core/list_compute_image_capability_schemas_request_response.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListComputeImageCapabilitySchemasRequest wrapper for the ListComputeImageCapabilitySchemas operation
+type ListComputeImageCapabilitySchemasRequest struct {
+
+	// A filter to return only resources that match the given compartment OCID exactly.
+	CompartmentId *string `mandatory:"false" contributesTo:"query" name:"compartmentId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of an image.
+	ImageId *string `mandatory:"false" contributesTo:"query" name:"imageId"`
+
+	// A filter to return only resources that match the given display name exactly.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated
+	// "List" call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// Example: `50`
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List"
+	// call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+	// TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+	// sort order is case sensitive.
+	// **Note:** In general, some "List" operations (for example, `ListInstances`) let you
+	// optionally filter by availability domain if the scope of the resource type is within a
+	// single availability domain. If you call one of these "List" operations without specifying
+	// an availability domain, the resources are grouped by availability domain, then sorted.
+	SortBy ListComputeImageCapabilitySchemasSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+	// is case sensitive.
+	SortOrder ListComputeImageCapabilitySchemasSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListComputeImageCapabilitySchemasRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListComputeImageCapabilitySchemasRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListComputeImageCapabilitySchemasRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListComputeImageCapabilitySchemasResponse wrapper for the ListComputeImageCapabilitySchemas operation
+type ListComputeImageCapabilitySchemasResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []ComputeImageCapabilitySchemaSummary instances
+	Items []ComputeImageCapabilitySchemaSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListComputeImageCapabilitySchemasResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListComputeImageCapabilitySchemasResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListComputeImageCapabilitySchemasSortByEnum Enum with underlying type: string
+type ListComputeImageCapabilitySchemasSortByEnum string
+
+// Set of constants representing the allowable values for ListComputeImageCapabilitySchemasSortByEnum
+const (
+	ListComputeImageCapabilitySchemasSortByTimecreated ListComputeImageCapabilitySchemasSortByEnum = "TIMECREATED"
+	ListComputeImageCapabilitySchemasSortByDisplayname ListComputeImageCapabilitySchemasSortByEnum = "DISPLAYNAME"
+)
+
+var mappingListComputeImageCapabilitySchemasSortBy = map[string]ListComputeImageCapabilitySchemasSortByEnum{
+	"TIMECREATED": ListComputeImageCapabilitySchemasSortByTimecreated,
+	"DISPLAYNAME": ListComputeImageCapabilitySchemasSortByDisplayname,
+}
+
+// GetListComputeImageCapabilitySchemasSortByEnumValues Enumerates the set of values for ListComputeImageCapabilitySchemasSortByEnum
+func GetListComputeImageCapabilitySchemasSortByEnumValues() []ListComputeImageCapabilitySchemasSortByEnum {
+	values := make([]ListComputeImageCapabilitySchemasSortByEnum, 0)
+	for _, v := range mappingListComputeImageCapabilitySchemasSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListComputeImageCapabilitySchemasSortOrderEnum Enum with underlying type: string
+type ListComputeImageCapabilitySchemasSortOrderEnum string
+
+// Set of constants representing the allowable values for ListComputeImageCapabilitySchemasSortOrderEnum
+const (
+	ListComputeImageCapabilitySchemasSortOrderAsc  ListComputeImageCapabilitySchemasSortOrderEnum = "ASC"
+	ListComputeImageCapabilitySchemasSortOrderDesc ListComputeImageCapabilitySchemasSortOrderEnum = "DESC"
+)
+
+var mappingListComputeImageCapabilitySchemasSortOrder = map[string]ListComputeImageCapabilitySchemasSortOrderEnum{
+	"ASC":  ListComputeImageCapabilitySchemasSortOrderAsc,
+	"DESC": ListComputeImageCapabilitySchemasSortOrderDesc,
+}
+
+// GetListComputeImageCapabilitySchemasSortOrderEnumValues Enumerates the set of values for ListComputeImageCapabilitySchemasSortOrderEnum
+func GetListComputeImageCapabilitySchemasSortOrderEnumValues() []ListComputeImageCapabilitySchemasSortOrderEnum {
+	values := make([]ListComputeImageCapabilitySchemasSortOrderEnum, 0)
+	for _, v := range mappingListComputeImageCapabilitySchemasSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/core/update_compute_image_capability_schema_details.go
+++ b/core/update_compute_image_capability_schema_details.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateComputeImageCapabilitySchemaDetails Create Image Capability Schema for an image.
+type UpdateComputeImageCapabilitySchemaDetails struct {
+
+	// A user-friendly name for the compute image capability schema
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// The map of each capability name to its ImageCapabilitySchemaDescriptor.
+	SchemaData map[string]ImageCapabilitySchemaDescriptor `mandatory:"false" json:"schemaData"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m UpdateComputeImageCapabilitySchemaDetails) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *UpdateComputeImageCapabilitySchemaDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		DisplayName  *string                                    `json:"displayName"`
+		FreeformTags map[string]string                          `json:"freeformTags"`
+		SchemaData   map[string]imagecapabilityschemadescriptor `json:"schemaData"`
+		DefinedTags  map[string]map[string]interface{}          `json:"definedTags"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.DisplayName = model.DisplayName
+
+	m.FreeformTags = model.FreeformTags
+
+	m.SchemaData = make(map[string]ImageCapabilitySchemaDescriptor)
+	for k, v := range model.SchemaData {
+		nn, e = v.UnmarshalPolymorphicJSON(v.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.SchemaData[k] = nn.(ImageCapabilitySchemaDescriptor)
+		} else {
+			m.SchemaData[k] = nil
+		}
+	}
+
+	m.DefinedTags = model.DefinedTags
+
+	return
+}

--- a/core/update_compute_image_capability_schema_request_response.go
+++ b/core/update_compute_image_capability_schema_request_response.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateComputeImageCapabilitySchemaRequest wrapper for the UpdateComputeImageCapabilitySchema operation
+type UpdateComputeImageCapabilitySchemaRequest struct {
+
+	// The id of the compute image capability schema or the image ocid
+	ComputeImageCapabilitySchemaId *string `mandatory:"true" contributesTo:"path" name:"computeImageCapabilitySchemaId"`
+
+	// Updates the freeFormTags, definedTags, and display name of the image capability schema
+	UpdateComputeImageCapabilitySchemaDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateComputeImageCapabilitySchemaRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateComputeImageCapabilitySchemaRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateComputeImageCapabilitySchemaRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateComputeImageCapabilitySchemaResponse wrapper for the UpdateComputeImageCapabilitySchema operation
+type UpdateComputeImageCapabilitySchemaResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ComputeImageCapabilitySchema instance
+	ComputeImageCapabilitySchema `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateComputeImageCapabilitySchemaResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateComputeImageCapabilitySchemaResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/core/update_instance_details.go
+++ b/core/update_instance_details.go
@@ -39,28 +39,32 @@ type UpdateInstanceDetails struct {
 	AgentConfig *UpdateInstanceAgentConfigDetails `mandatory:"false" json:"agentConfig"`
 
 	// Custom metadata key/value string pairs that you provide. Any set of key/value pairs
-	// provided here will completely replace the current set of key/value pairs in the 'metadata'
+	// provided here will completely replace the current set of key/value pairs in the `metadata`
 	// field on the instance.
-	// Both the 'user_data' and 'ssh_authorized_keys' fields cannot be changed after an instance
-	// has launched. Any request which updates, removes, or adds either of these fields will be
-	// rejected. You must provide the same values for 'user_data' and 'ssh_authorized_keys' that
+	// The "user_data" field and the "ssh_authorized_keys" field cannot be changed after an instance
+	// has launched. Any request that updates, removes, or adds either of these fields will be
+	// rejected. You must provide the same values for "user_data" and "ssh_authorized_keys" that
 	// already exist on the instance.
+	// The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+	// 32,000 bytes.
 	Metadata map[string]string `mandatory:"false" json:"metadata"`
 
 	// Additional metadata key/value pairs that you provide. They serve the same purpose and
-	// functionality as fields in the 'metadata' object.
-	// They are distinguished from 'metadata' fields in that these can be nested JSON objects
-	// (whereas 'metadata' fields are string/string maps only).
-	// Both the 'user_data' and 'ssh_authorized_keys' fields cannot be changed after an instance
-	// has launched. Any request which updates, removes, or adds either of these fields will be
-	// rejected. You must provide the same values for 'user_data' and 'ssh_authorized_keys' that
+	// functionality as fields in the `metadata` object.
+	// They are distinguished from `metadata` fields in that these can be nested JSON objects
+	// (whereas `metadata` fields are string/string maps only).
+	// The "user_data" field and the "ssh_authorized_keys" field cannot be changed after an instance
+	// has launched. Any request that updates, removes, or adds either of these fields will be
+	// rejected. You must provide the same values for "user_data" and "ssh_authorized_keys" that
 	// already exist on the instance.
+	// The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+	// 32,000 bytes.
 	ExtendedMetadata map[string]interface{} `mandatory:"false" json:"extendedMetadata"`
 
 	// The shape of the instance. The shape determines the number of CPUs and the amount of memory
 	// allocated to the instance. For more information about how to change shapes, and a list of
 	// shapes that are supported, see
-	// Changing the Shape of an Instance (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/resizinginstances.htm).
+	// Editing an Instance (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/resizinginstances.htm).
 	// For details about the CPUs, memory, and other properties of each shape, see
 	// Compute Shapes (https://docs.cloud.oracle.com/iaas/Content/Compute/References/computeshapes.htm).
 	// The new shape must be compatible with the image that was used to launch the instance. You
@@ -71,6 +75,20 @@ type UpdateInstanceDetails struct {
 	Shape *string `mandatory:"false" json:"shape"`
 
 	ShapeConfig *UpdateInstanceShapeConfigDetails `mandatory:"false" json:"shapeConfig"`
+
+	// A fault domain is a grouping of hardware and infrastructure within an availability domain.
+	// Each availability domain contains three fault domains. Fault domains let you distribute your
+	// instances so that they are not on the same physical hardware within a single availability domain.
+	// A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
+	// instances in other fault domains.
+	// To get a list of fault domains, use the
+	// ListFaultDomains operation in the
+	// Identity and Access Management Service API.
+	// Example: `FAULT-DOMAIN-1`
+	FaultDomain *string `mandatory:"false" json:"faultDomain"`
+
+	// Options for tuning the compatibility and performance of VM shapes.
+	LaunchOptions *UpdateLaunchOptions `mandatory:"false" json:"launchOptions"`
 }
 
 func (m UpdateInstanceDetails) String() string {

--- a/core/update_launch_options.go
+++ b/core/update_launch_options.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateLaunchOptions Options for tuning the compatibility and performance of VM shapes.
+type UpdateLaunchOptions struct {
+
+	// Emulation type for the boot volume.
+	// * `ISCSI` - ISCSI attached block storage device.
+	// * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+	// storage volumes on Oracle-provided plaform images.
+	// Before you change the boot volume attachment type, detach all block volumes and VNICs except for
+	// the boot volume and the primary VNIC.
+	// If the instance is running when you change the boot volume attachment type, it will be rebooted.
+	// **Note:** Some instances might not function properly if you change the boot volume attachment type. After
+	// the instance reboots and is running, connect to it. If the connection fails or the OS doesn't behave
+	// as expected, the changes are not supported. Revert the instance to the original boot volume attachment type.
+	BootVolumeType UpdateLaunchOptionsBootVolumeTypeEnum `mandatory:"false" json:"bootVolumeType,omitempty"`
+
+	// Emulation type for the physical network interface card (NIC).
+	// * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
+	// when you launch an instance using hardware-assisted (SR-IOV) networking.
+	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
+	// Before you change the networking type, detach all VNICs and block volumes except for the primary
+	// VNIC and the boot volume.
+	// The image must have paravirtualized drivers installed. For more information, see
+	// Editing an Instance (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/resizinginstances.htm).
+	// If the instance is running when you change the network type, it will be rebooted.
+	// **Note:** Some instances might not function properly if you change the networking type. After
+	// the instance reboots and is running, connect to it. If the connection fails or the OS doesn't behave
+	// as expected, the changes are not supported. Revert the instance to the original networking type.
+	NetworkType UpdateLaunchOptionsNetworkTypeEnum `mandatory:"false" json:"networkType,omitempty"`
+
+	// Whether to enable in-transit encryption for the boot volume's paravirtualized attachment.
+	// Data in transit is transferred over an internal and highly secure network. If you have specific
+	// compliance requirements related to the encryption of the data while it is moving between the
+	// instance and the boot volume, you can enable in-transit encryption. In-transit encryption is
+	// not enabled by default.
+	// All boot volumes are encrypted at rest.
+	// For more information, see Block Volume Encryption (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm#Encrypti).
+	IsPvEncryptionInTransitEnabled *bool `mandatory:"false" json:"isPvEncryptionInTransitEnabled"`
+}
+
+func (m UpdateLaunchOptions) String() string {
+	return common.PointerString(m)
+}
+
+// UpdateLaunchOptionsBootVolumeTypeEnum Enum with underlying type: string
+type UpdateLaunchOptionsBootVolumeTypeEnum string
+
+// Set of constants representing the allowable values for UpdateLaunchOptionsBootVolumeTypeEnum
+const (
+	UpdateLaunchOptionsBootVolumeTypeIscsi           UpdateLaunchOptionsBootVolumeTypeEnum = "ISCSI"
+	UpdateLaunchOptionsBootVolumeTypeParavirtualized UpdateLaunchOptionsBootVolumeTypeEnum = "PARAVIRTUALIZED"
+)
+
+var mappingUpdateLaunchOptionsBootVolumeType = map[string]UpdateLaunchOptionsBootVolumeTypeEnum{
+	"ISCSI":           UpdateLaunchOptionsBootVolumeTypeIscsi,
+	"PARAVIRTUALIZED": UpdateLaunchOptionsBootVolumeTypeParavirtualized,
+}
+
+// GetUpdateLaunchOptionsBootVolumeTypeEnumValues Enumerates the set of values for UpdateLaunchOptionsBootVolumeTypeEnum
+func GetUpdateLaunchOptionsBootVolumeTypeEnumValues() []UpdateLaunchOptionsBootVolumeTypeEnum {
+	values := make([]UpdateLaunchOptionsBootVolumeTypeEnum, 0)
+	for _, v := range mappingUpdateLaunchOptionsBootVolumeType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// UpdateLaunchOptionsNetworkTypeEnum Enum with underlying type: string
+type UpdateLaunchOptionsNetworkTypeEnum string
+
+// Set of constants representing the allowable values for UpdateLaunchOptionsNetworkTypeEnum
+const (
+	UpdateLaunchOptionsNetworkTypeVfio            UpdateLaunchOptionsNetworkTypeEnum = "VFIO"
+	UpdateLaunchOptionsNetworkTypeParavirtualized UpdateLaunchOptionsNetworkTypeEnum = "PARAVIRTUALIZED"
+)
+
+var mappingUpdateLaunchOptionsNetworkType = map[string]UpdateLaunchOptionsNetworkTypeEnum{
+	"VFIO":            UpdateLaunchOptionsNetworkTypeVfio,
+	"PARAVIRTUALIZED": UpdateLaunchOptionsNetworkTypeParavirtualized,
+}
+
+// GetUpdateLaunchOptionsNetworkTypeEnumValues Enumerates the set of values for UpdateLaunchOptionsNetworkTypeEnum
+func GetUpdateLaunchOptionsNetworkTypeEnumValues() []UpdateLaunchOptionsNetworkTypeEnum {
+	values := make([]UpdateLaunchOptionsNetworkTypeEnum, 0)
+	for _, v := range mappingUpdateLaunchOptionsNetworkType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/core/update_volume_details.go
+++ b/core/update_volume_details.go
@@ -45,6 +45,9 @@ type UpdateVolumeDetails struct {
 
 	// The size to resize the volume to in GBs. Has to be larger than the current size.
 	SizeInGBs *int64 `mandatory:"false" json:"sizeInGBs"`
+
+	// Specifies whether the auto-tune performance is enabled for this volume.
+	IsAutoTuneEnabled *bool `mandatory:"false" json:"isAutoTuneEnabled"`
 }
 
 func (m UpdateVolumeDetails) String() string {

--- a/core/volume.go
+++ b/core/volume.go
@@ -89,6 +89,12 @@ type Volume struct {
 
 	// The OCID of the source volume group.
 	VolumeGroupId *string `mandatory:"false" json:"volumeGroupId"`
+
+	// Specifies whether the auto-tune performance is enabled for this volume.
+	IsAutoTuneEnabled *bool `mandatory:"false" json:"isAutoTuneEnabled"`
+
+	// The number of Volume Performance Units per GB that this volume is effectively tuned to when it's idle.
+	AutoTunedVpusPerGB *int64 `mandatory:"false" json:"autoTunedVpusPerGB"`
 }
 
 func (m Volume) String() string {
@@ -107,6 +113,8 @@ func (m *Volume) UnmarshalJSON(data []byte) (e error) {
 		SizeInGBs          *int64                            `json:"sizeInGBs"`
 		SourceDetails      volumesourcedetails               `json:"sourceDetails"`
 		VolumeGroupId      *string                           `json:"volumeGroupId"`
+		IsAutoTuneEnabled  *bool                             `json:"isAutoTuneEnabled"`
+		AutoTunedVpusPerGB *int64                            `json:"autoTunedVpusPerGB"`
 		AvailabilityDomain *string                           `json:"availabilityDomain"`
 		CompartmentId      *string                           `json:"compartmentId"`
 		DisplayName        *string                           `json:"displayName"`
@@ -146,6 +154,10 @@ func (m *Volume) UnmarshalJSON(data []byte) (e error) {
 	}
 
 	m.VolumeGroupId = model.VolumeGroupId
+
+	m.IsAutoTuneEnabled = model.IsAutoTuneEnabled
+
+	m.AutoTunedVpusPerGB = model.AutoTunedVpusPerGB
 
 	m.AvailabilityDomain = model.AvailabilityDomain
 

--- a/database/update_maintenance_run_details.go
+++ b/database/update_maintenance_run_details.go
@@ -21,6 +21,9 @@ type UpdateMaintenanceRunDetails struct {
 
 	// The scheduled date and time of the Maintenance Run to update.
 	TimeScheduled *common.SDKTime `mandatory:"false" json:"timeScheduled"`
+
+	// If set to `TRUE`, starts patching immediately.
+	IsPatchNowEnabled *bool `mandatory:"false" json:"isPatchNowEnabled"`
 }
 
 func (m UpdateMaintenanceRunDetails) String() string {

--- a/resourcemanager/create_config_source_details.go
+++ b/resourcemanager/create_config_source_details.go
@@ -17,7 +17,7 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// CreateConfigSourceDetails Property details for the configuration source.
+// CreateConfigSourceDetails Property details for the configuration source used for the stack.
 type CreateConfigSourceDetails interface {
 
 	// File path to the directory from which Terraform runs.

--- a/resourcemanager/create_gitlab_access_token_configuration_source_provider_details.go
+++ b/resourcemanager/create_gitlab_access_token_configuration_source_provider_details.go
@@ -22,7 +22,7 @@ import (
 type CreateGitlabAccessTokenConfigurationSourceProviderDetails struct {
 
 	// The Git service API endpoint.
-	// Example: `https://gitlab.com/api/v3/`
+	// Example: `https://gitlab.com/api/v4/`
 	ApiEndpoint *string `mandatory:"true" json:"apiEndpoint"`
 
 	// The personal access token to be configured on the Git repository. Avoid entering confidential information.

--- a/resourcemanager/create_stack_details.go
+++ b/resourcemanager/create_stack_details.go
@@ -17,7 +17,7 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// CreateStackDetails Properties provided for creating a stack.
+// CreateStackDetails The configuration details for creating a stack.
 type CreateStackDetails struct {
 
 	// Unique identifier (OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)) of the compartment in which the stack resides.
@@ -32,7 +32,7 @@ type CreateStackDetails struct {
 	Description *string `mandatory:"false" json:"description"`
 
 	// Terraform variables associated with this resource.
-	// Maximum number of variables supported is 100.
+	// Maximum number of variables supported is 250.
 	// The maximum size of each variable, including both name and value, is 4096 bytes.
 	// Example: `{"CompartmentId": "compartment-id-value"}`
 	Variables map[string]string `mandatory:"false" json:"variables"`

--- a/resourcemanager/gitlab_access_token_configuration_source_provider.go
+++ b/resourcemanager/gitlab_access_token_configuration_source_provider.go
@@ -49,11 +49,8 @@ type GitlabAccessTokenConfigurationSourceProvider struct {
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// The Git service API endpoint.
-	// Example: `https://gitlab.com/api/v3/`
+	// Example: `https://gitlab.com/api/v4/`
 	ApiEndpoint *string `mandatory:"false" json:"apiEndpoint"`
-
-	// The personal access token configured on the Git repository.
-	AccessToken *string `mandatory:"false" json:"accessToken"`
 
 	// The current lifecycle state of the configuration source provider.
 	// For more information about configuration source provider lifecycle states in Resource Manager, see

--- a/resourcemanager/gitlab_access_token_configuration_source_provider_summary.go
+++ b/resourcemanager/gitlab_access_token_configuration_source_provider_summary.go
@@ -49,7 +49,7 @@ type GitlabAccessTokenConfigurationSourceProviderSummary struct {
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// The Git service API endpoint.
-	// Example: `https://gitlab.com/api/v3/`
+	// Example: `https://gitlab.com/api/v4/`
 	ApiEndpoint *string `mandatory:"false" json:"apiEndpoint"`
 
 	// Current state of the specified configuration source provider.

--- a/resourcemanager/job.go
+++ b/resourcemanager/job.go
@@ -68,11 +68,12 @@ type Job struct {
 
 	FailureDetails *FailureDetails `mandatory:"false" json:"failureDetails"`
 
-	// The file path to the directory within the configuration from which the job runs.
+	// File path to the directory from which Terraform runs.
+	// If not specified, the root directory is used.
 	WorkingDirectory *string `mandatory:"false" json:"workingDirectory"`
 
 	// Terraform variables associated with this resource.
-	// Maximum number of variables supported is 100.
+	// Maximum number of variables supported is 250.
 	// The maximum size of each variable, including both name and value, is 4096 bytes.
 	// Example: `{"CompartmentId": "compartment-id-value"}`
 	Variables map[string]string `mandatory:"false" json:"variables"`

--- a/resourcemanager/resourcemanager_client.go
+++ b/resourcemanager/resourcemanager_client.go
@@ -340,7 +340,8 @@ func (client ResourceManagerClient) createJob(ctx context.Context, request commo
 }
 
 // CreateStack Creates a stack in the specified compartment.
-// Specify the compartment using the compartment ID.
+// You can create a stack from a Terraform configuration file.
+// The Terraform configuration file can be directly uploaded or referenced from a source code control system.
 // For more information, see
 // To create a stack (https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Tasks/managingstacksandjobs.htm#CreateStack).
 func (client ResourceManagerClient) CreateStack(ctx context.Context, request CreateStackRequest) (response CreateStackResponse, err error) {

--- a/resourcemanager/stack.go
+++ b/resourcemanager/stack.go
@@ -46,7 +46,7 @@ type Stack struct {
 	ConfigSource ConfigSource `mandatory:"false" json:"configSource"`
 
 	// Terraform variables associated with this resource.
-	// Maximum number of variables supported is 100.
+	// Maximum number of variables supported is 250.
 	// The maximum size of each variable, including both name and value, is 4096 bytes.
 	// Example: `{"CompartmentId": "compartment-id-value"}`
 	Variables map[string]string `mandatory:"false" json:"variables"`

--- a/resourcemanager/stack_resource_drift_collection.go
+++ b/resourcemanager/stack_resource_drift_collection.go
@@ -20,7 +20,7 @@ import (
 type StackResourceDriftCollection struct {
 
 	// Collection of drift status details for all resources defined in the stack.
-	Items []StackResourceDriftSummary `mandatory:"false" json:"items"`
+	Items []StackResourceDriftSummary `mandatory:"true" json:"items"`
 }
 
 func (m StackResourceDriftCollection) String() string {

--- a/resourcemanager/update_gitlab_access_token_configuration_source_provider_details.go
+++ b/resourcemanager/update_gitlab_access_token_configuration_source_provider_details.go
@@ -38,7 +38,7 @@ type UpdateGitlabAccessTokenConfigurationSourceProviderDetails struct {
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
 	// The Git service API endpoint.
-	// Example: `https://gitlab.com/api/v3/`
+	// Example: `https://gitlab.com/api/v4/`
 	ApiEndpoint *string `mandatory:"false" json:"apiEndpoint"`
 
 	// The personal access token to be configured on the Git repository.

--- a/resourcemanager/update_stack_details.go
+++ b/resourcemanager/update_stack_details.go
@@ -29,7 +29,7 @@ type UpdateStackDetails struct {
 	ConfigSource UpdateConfigSourceDetails `mandatory:"false" json:"configSource"`
 
 	// Terraform variables associated with this resource.
-	// The maximum number of variables supported is 100.
+	// The maximum number of variables supported is 250.
 	// The maximum size of each variable, including both name and value, is 4096 bytes.
 	// Example: `{"CompartmentId": "compartment-id-value"}`
 	Variables map[string]string `mandatory:"false" json:"variables"`


### PR DESCRIPTION
### Added

- Support for calling Oracle Cloud Infrastructure services in the us-sanjose-1 region

- Support for PKCS#8 format API Keys

- Support for updating the fault domain and launch options of VM instances in the Compute service

- Support for image capability schemas and schema versions in the Compute service

- Support for 'Patch Now' maintenance runs for autonomous Exadata infrastructure and autonomous container database resources in the Database service

- Support for automatic performance and cost tuning on volumes in the Block Storage service



### Breaking changes

- Removed the accessToken field from the GitlabAccessTokenConfigurationSourceProvider model in the Resource Manager service