### PR TITLE
Releasing version 38.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## 38.1.0 - 2021-04-06
+### Added
+- Support for scheduling the suspension and resumption of compute instance pools based on predefined schedules in the Autoscaling service
+- Support for database software images for Cloud@Customer in the Database service
+- Support for OCIC IDCS authorization details in the Application Migration service
+- Support for cross-region asynchronous volume replication in the Block Storage service
+- Support for SDK generation in the API Gateway service
+- Support for container image signing in the Registry service
+- Support for cluster features as a part of the Container Engine for Kubernetes service
+- Support for filtering dedicated virtual machine hosts by remaining memory and OCPUs in the Compute service
+- Support for read/write-any object from buckets using pre-authenticated requests in the Object Storage service
+- Support for restricting pre-authenticated requests by prefix in the Object Storage service
+- Support for route filtering on public virtual circuits in the Virtual Networking service
+
 ## 38.0.0 - 2021-03-30
 ### Added
 - Support for the Vulnerability Scanning service

--- a/README.md
+++ b/README.md
@@ -18,44 +18,29 @@ Are you a Developer using the OCI SDK? If so, please fill out our survey to help
 
 
 ## Installing
-Use the following command to install this SDK:
+OCI Go SDK supports both `go get` and Go Modules installing.
 
+If you want to install the SDK under $GOPATH, you can use `go get` to retrieve the SDK:
 ```
 go get -u github.com/oracle/oci-go-sdk
 ```
-Alternatively you can git clone this repo.
+Alternatively, you can also clone the repo from [Github](https://github.com/oracle/oci-go-sdk).
 
-We've applied Go Module after v25.0.0, for legacy user not using Go Module, you can still clone the repo under Go Path and use same import as before.
 
-If you're using Go Module to import OCI Go SDK and you want to use the latest or specific Go SDK version, you need to update your require in `go.mod`:
-
+If you are using Go modules, you can install the latest or specific version(v25.0.0+) when adding the following in the go.mod file:
 ```go
 require github.com/oracle/oci-go-sdk/{major-version} {version}
 ```
-
-And in the code, you also need to update the import following this pattern:
-
+One example is:
 ```go
-import (
- "github.com/oracle/oci-go-sdk/{major-version}/common"
-)
+require github.com/oracle/oci-go-sdk/v38 v38.0.0
 ```
+Run `go mod tidy`
 
-If you don't update your import and use your import like this `github.com/oracle/oci-go-sdk/common`, your Go SDK version will remain at version: v24.3.0
-
-Everytime after a major version release (which means it will include some breaking changes), you'll need to update the version in require and import to get the latest changes.
+In your project, you also need to add/update the major-version to make sure `go build` works
 ```go
-import (
-    "github.com/oracle/oci-go-sdk/v25"
-)
+import "github.com/oracle/oci-go-sdk/v38/common"
 ```
-in `go.mod` or run `go mod tidy` / `go build` after updating the import
-```go
-require (
-    github.com/oracle/oci-go-sdk/{updated-major-version} {version}
-)
-```
-The version will not be impacted without updating the import
 
 ## Working with the Go SDK
 To start working with the Go SDK, you import the service package, create a client, and then use that client to make calls.

--- a/apigateway/apigateway_client.go
+++ b/apigateway/apigateway_client.go
@@ -317,6 +317,65 @@ func (client ApiGatewayClient) createCertificate(ctx context.Context, request co
 	return response, err
 }
 
+// CreateSdk Creates a new SDK.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/apigateway/CreateSdk.go.html to see an example of how to use CreateSdk API.
+func (client ApiGatewayClient) CreateSdk(ctx context.Context, request CreateSdkRequest) (response CreateSdkResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createSdk, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateSdkResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateSdkResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateSdkResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateSdkResponse")
+	}
+	return
+}
+
+// createSdk implements the OCIOperation interface (enables retrying operations)
+func (client ApiGatewayClient) createSdk(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/sdks")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateSdkResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // DeleteApi Deletes the API with the given identifier.
 //
 // See also
@@ -413,6 +472,60 @@ func (client ApiGatewayClient) deleteCertificate(ctx context.Context, request co
 	}
 
 	var response DeleteCertificateResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteSdk Deletes provided SDK.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/apigateway/DeleteSdk.go.html to see an example of how to use DeleteSdk API.
+func (client ApiGatewayClient) DeleteSdk(ctx context.Context, request DeleteSdkRequest) (response DeleteSdkResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteSdk, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteSdkResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteSdkResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteSdkResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteSdkResponse")
+	}
+	return
+}
+
+// deleteSdk implements the OCIOperation interface (enables retrying operations)
+func (client ApiGatewayClient) deleteSdk(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/sdks/{sdkId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteSdkResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -694,6 +807,60 @@ func (client ApiGatewayClient) getCertificate(ctx context.Context, request commo
 	return response, err
 }
 
+// GetSdk Return object store downloadable URL and metadata.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/apigateway/GetSdk.go.html to see an example of how to use GetSdk API.
+func (client ApiGatewayClient) GetSdk(ctx context.Context, request GetSdkRequest) (response GetSdkResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getSdk, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetSdkResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetSdkResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetSdkResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetSdkResponse")
+	}
+	return
+}
+
+// getSdk implements the OCIOperation interface (enables retrying operations)
+func (client ApiGatewayClient) getSdk(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/sdks/{sdkId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetSdkResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // ListApis Returns a list of APIs.
 //
 // See also
@@ -802,6 +969,114 @@ func (client ApiGatewayClient) listCertificates(ctx context.Context, request com
 	return response, err
 }
 
+// ListSdkLanguageTypes Lists programming languages in which SDK can be generated.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/apigateway/ListSdkLanguageTypes.go.html to see an example of how to use ListSdkLanguageTypes API.
+func (client ApiGatewayClient) ListSdkLanguageTypes(ctx context.Context, request ListSdkLanguageTypesRequest) (response ListSdkLanguageTypesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listSdkLanguageTypes, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListSdkLanguageTypesResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListSdkLanguageTypesResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListSdkLanguageTypesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListSdkLanguageTypesResponse")
+	}
+	return
+}
+
+// listSdkLanguageTypes implements the OCIOperation interface (enables retrying operations)
+func (client ApiGatewayClient) listSdkLanguageTypes(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/sdkLanguageTypes")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListSdkLanguageTypesResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListSdks Returns list of generated SDKs.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/apigateway/ListSdks.go.html to see an example of how to use ListSdks API.
+func (client ApiGatewayClient) ListSdks(ctx context.Context, request ListSdksRequest) (response ListSdksResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listSdks, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListSdksResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListSdksResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListSdksResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListSdksResponse")
+	}
+	return
+}
+
+// listSdks implements the OCIOperation interface (enables retrying operations)
+func (client ApiGatewayClient) listSdks(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/sdks")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListSdksResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // UpdateApi Updates the API with the given identifier.
 //
 // See also
@@ -898,6 +1173,60 @@ func (client ApiGatewayClient) updateCertificate(ctx context.Context, request co
 	}
 
 	var response UpdateCertificateResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateSdk Updates the SDK with the given identifier.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/apigateway/UpdateSdk.go.html to see an example of how to use UpdateSdk API.
+func (client ApiGatewayClient) UpdateSdk(ctx context.Context, request UpdateSdkRequest) (response UpdateSdkResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateSdk, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateSdkResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateSdkResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateSdkResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateSdkResponse")
+	}
+	return
+}
+
+// updateSdk implements the OCIOperation interface (enables retrying operations)
+func (client ApiGatewayClient) updateSdk(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/sdks/{sdkId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateSdkResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)

--- a/apigateway/create_deployment_details.go
+++ b/apigateway/create_deployment_details.go
@@ -31,12 +31,12 @@ type CreateDeploymentDetails struct {
 	// Deployment (https://docs.cloud.oracle.com/iaas/Content/APIGateway/Tasks/apigatewaycreatingdeployment.htm).
 	PathPrefix *string `mandatory:"true" json:"pathPrefix"`
 
-	Specification *ApiSpecification `mandatory:"true" json:"specification"`
-
 	// A user-friendly name. Does not have to be unique, and it's changeable.
 	// Avoid entering confidential information.
 	// Example: `My new resource`
 	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	Specification *ApiSpecification `mandatory:"false" json:"specification"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair
 	// with no predefined name, type, or namespace. For more information, see

--- a/apigateway/create_sdk_details.go
+++ b/apigateway/create_sdk_details.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// API Gateway API
+//
+// API for the API Gateway service. Use this API to manage gateways, deployments, and related items.
+// For more information, see
+// Overview of API Gateway (https://docs.cloud.oracle.com/iaas/Content/APIGateway/Concepts/apigatewayoverview.htm).
+//
+
+package apigateway
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// CreateSdkDetails Information about the new SDK.
+type CreateSdkDetails struct {
+
+	// The string representing the target programming language for generating the SDK.
+	TargetLanguage *string `mandatory:"true" json:"targetLanguage"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of API resource
+	ApiId *string `mandatory:"true" json:"apiId"`
+
+	// A user-friendly name. Does not have to be unique, and it's changeable.
+	// Avoid entering confidential information.
+	// Example: `My new resource`
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair
+	// with no predefined name, type, or namespace. For more information, see
+	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see
+	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Additional optional configurations that can be passed to generate SDK Api.
+	// The applicable parameters are listed under "parameters" when "/sdkLanguageTypes" is called.
+	// Example: `{"configName": "configValue"}`
+	Parameters map[string]string `mandatory:"false" json:"parameters"`
+}
+
+func (m CreateSdkDetails) String() string {
+	return common.PointerString(m)
+}

--- a/apigateway/create_sdk_request_response.go
+++ b/apigateway/create_sdk_request_response.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package apigateway
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+	"net/http"
+)
+
+// CreateSdkRequest wrapper for the CreateSdk operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/apigateway/CreateSdk.go.html to see an example of how to use CreateSdkRequest.
+type CreateSdkRequest struct {
+
+	// Details for the new SDK.
+	CreateSdkDetails `contributesTo:"body"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// might be rejected.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// The client request id for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateSdkRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateSdkRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateSdkRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateSdkResponse wrapper for the CreateSdk operation
+type CreateSdkResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Sdk instance
+	Sdk `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// The OCID of the work request. Use
+	// GetWorkRequest with
+	// this id to track the status
+	// of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to
+	// contact Oracle about a particular request, please provide the request
+	// id.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Location of the resource.
+	Location *string `presentIn:"header" name:"location"`
+}
+
+func (response CreateSdkResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateSdkResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/apigateway/delete_sdk_request_response.go
+++ b/apigateway/delete_sdk_request_response.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package apigateway
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+	"net/http"
+)
+
+// DeleteSdkRequest wrapper for the DeleteSdk operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/apigateway/DeleteSdk.go.html to see an example of how to use DeleteSdkRequest.
+type DeleteSdkRequest struct {
+
+	// The ocid of the SDK.
+	SdkId *string `mandatory:"true" contributesTo:"path" name:"sdkId"`
+
+	// The client request id for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call
+	// for a resource, set the `if-match` parameter to the value of the
+	// etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you
+	// provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteSdkRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteSdkRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteSdkRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteSdkResponse wrapper for the DeleteSdk operation
+type DeleteSdkResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request. Use
+	// GetWorkRequest with
+	// this id to track the status
+	// of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to
+	// contact Oracle about a particular request, please provide the request
+	// id.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteSdkResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteSdkResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/apigateway/deployment.go
+++ b/apigateway/deployment.go
@@ -39,12 +39,12 @@ type Deployment struct {
 	// The endpoint to access this deployment on the gateway.
 	Endpoint *string `mandatory:"true" json:"endpoint"`
 
-	Specification *ApiSpecification `mandatory:"true" json:"specification"`
-
 	// A user-friendly name. Does not have to be unique, and it's changeable.
 	// Avoid entering confidential information.
 	// Example: `My new resource`
 	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	Specification *ApiSpecification `mandatory:"false" json:"specification"`
 
 	// The time this resource was created. An RFC3339 formatted datetime string.
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`

--- a/apigateway/get_sdk_request_response.go
+++ b/apigateway/get_sdk_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package apigateway
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+	"net/http"
+)
+
+// GetSdkRequest wrapper for the GetSdk operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/apigateway/GetSdk.go.html to see an example of how to use GetSdkRequest.
+type GetSdkRequest struct {
+
+	// The ocid of the SDK.
+	SdkId *string `mandatory:"true" contributesTo:"path" name:"sdkId"`
+
+	// The client request id for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetSdkRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetSdkRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetSdkRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetSdkResponse wrapper for the GetSdk operation
+type GetSdkResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Sdk instance
+	Sdk `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to
+	// contact Oracle about a particular request, please provide the request
+	// id.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetSdkResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetSdkResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/apigateway/list_sdk_language_types_request_response.go
+++ b/apigateway/list_sdk_language_types_request_response.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package apigateway
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+	"net/http"
+)
+
+// ListSdkLanguageTypesRequest wrapper for the ListSdkLanguageTypes operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/apigateway/ListSdkLanguageTypes.go.html to see an example of how to use ListSdkLanguageTypesRequest.
+type ListSdkLanguageTypesRequest struct {
+
+	// The ocid of the compartment in which to list resources.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// A user-friendly name. Does not have to be unique, and it's changeable.
+	// Example: `My new resource`
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The sort order to use, either 'asc' or 'desc'. The default order depends on the sortBy value.
+	SortOrder ListSdkLanguageTypesSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The field to sort by. You can provide one sort order (`sortOrder`).
+	// Default order for `timeCreated` is descending. Default order for
+	// `displayName` is ascending. The `displayName` sort order is case
+	// sensitive.
+	SortBy ListSdkLanguageTypesSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The client request id for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListSdkLanguageTypesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListSdkLanguageTypesRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListSdkLanguageTypesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListSdkLanguageTypesResponse wrapper for the ListSdkLanguageTypes operation
+type ListSdkLanguageTypesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of SdkLanguageTypeCollection instances
+	SdkLanguageTypeCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to
+	// contact Oracle about a particular request, please provide the request
+	// id.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For list pagination. When this header appears in the response,
+	// additional pages of results remain. For important details about how
+	// pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// For list pagination. When this header appears in the response,
+	// additional pages of results were seen previously. For important details
+	// about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+}
+
+func (response ListSdkLanguageTypesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListSdkLanguageTypesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListSdkLanguageTypesSortOrderEnum Enum with underlying type: string
+type ListSdkLanguageTypesSortOrderEnum string
+
+// Set of constants representing the allowable values for ListSdkLanguageTypesSortOrderEnum
+const (
+	ListSdkLanguageTypesSortOrderAsc  ListSdkLanguageTypesSortOrderEnum = "ASC"
+	ListSdkLanguageTypesSortOrderDesc ListSdkLanguageTypesSortOrderEnum = "DESC"
+)
+
+var mappingListSdkLanguageTypesSortOrder = map[string]ListSdkLanguageTypesSortOrderEnum{
+	"ASC":  ListSdkLanguageTypesSortOrderAsc,
+	"DESC": ListSdkLanguageTypesSortOrderDesc,
+}
+
+// GetListSdkLanguageTypesSortOrderEnumValues Enumerates the set of values for ListSdkLanguageTypesSortOrderEnum
+func GetListSdkLanguageTypesSortOrderEnumValues() []ListSdkLanguageTypesSortOrderEnum {
+	values := make([]ListSdkLanguageTypesSortOrderEnum, 0)
+	for _, v := range mappingListSdkLanguageTypesSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListSdkLanguageTypesSortByEnum Enum with underlying type: string
+type ListSdkLanguageTypesSortByEnum string
+
+// Set of constants representing the allowable values for ListSdkLanguageTypesSortByEnum
+const (
+	ListSdkLanguageTypesSortByTimecreated ListSdkLanguageTypesSortByEnum = "timeCreated"
+	ListSdkLanguageTypesSortByDisplayname ListSdkLanguageTypesSortByEnum = "displayName"
+)
+
+var mappingListSdkLanguageTypesSortBy = map[string]ListSdkLanguageTypesSortByEnum{
+	"timeCreated": ListSdkLanguageTypesSortByTimecreated,
+	"displayName": ListSdkLanguageTypesSortByDisplayname,
+}
+
+// GetListSdkLanguageTypesSortByEnumValues Enumerates the set of values for ListSdkLanguageTypesSortByEnum
+func GetListSdkLanguageTypesSortByEnumValues() []ListSdkLanguageTypesSortByEnum {
+	values := make([]ListSdkLanguageTypesSortByEnum, 0)
+	for _, v := range mappingListSdkLanguageTypesSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/apigateway/list_sdks_request_response.go
+++ b/apigateway/list_sdks_request_response.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package apigateway
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+	"net/http"
+)
+
+// ListSdksRequest wrapper for the ListSdks operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/apigateway/ListSdks.go.html to see an example of how to use ListSdksRequest.
+type ListSdksRequest struct {
+
+	// The ocid of the SDK.
+	SdkId *string `mandatory:"false" contributesTo:"query" name:"sdkId"`
+
+	// A user-friendly name. Does not have to be unique, and it's changeable.
+	// Example: `My new resource`
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// A filter to return only resources that match the given lifecycle state.
+	// Example: `ACTIVE` or `DELETED`
+	LifecycleState SdkLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The sort order to use, either 'asc' or 'desc'. The default order depends on the sortBy value.
+	SortOrder ListSdksSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The field to sort by. You can provide one sort order (`sortOrder`).
+	// Default order for `timeCreated` is descending. Default order for
+	// `displayName` is ascending. The `displayName` sort order is case
+	// sensitive.
+	SortBy ListSdksSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The ocid of the API.
+	ApiId *string `mandatory:"false" contributesTo:"query" name:"apiId"`
+
+	// The client request id for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListSdksRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListSdksRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListSdksRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListSdksResponse wrapper for the ListSdks operation
+type ListSdksResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of SdkCollection instances
+	SdkCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to
+	// contact Oracle about a particular request, please provide the request
+	// id.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For list pagination. When this header appears in the response,
+	// additional pages of results remain. For important details about how
+	// pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// For list pagination. When this header appears in the response,
+	// additional pages of results were seen previously. For important details
+	// about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+}
+
+func (response ListSdksResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListSdksResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListSdksSortOrderEnum Enum with underlying type: string
+type ListSdksSortOrderEnum string
+
+// Set of constants representing the allowable values for ListSdksSortOrderEnum
+const (
+	ListSdksSortOrderAsc  ListSdksSortOrderEnum = "ASC"
+	ListSdksSortOrderDesc ListSdksSortOrderEnum = "DESC"
+)
+
+var mappingListSdksSortOrder = map[string]ListSdksSortOrderEnum{
+	"ASC":  ListSdksSortOrderAsc,
+	"DESC": ListSdksSortOrderDesc,
+}
+
+// GetListSdksSortOrderEnumValues Enumerates the set of values for ListSdksSortOrderEnum
+func GetListSdksSortOrderEnumValues() []ListSdksSortOrderEnum {
+	values := make([]ListSdksSortOrderEnum, 0)
+	for _, v := range mappingListSdksSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListSdksSortByEnum Enum with underlying type: string
+type ListSdksSortByEnum string
+
+// Set of constants representing the allowable values for ListSdksSortByEnum
+const (
+	ListSdksSortByTimecreated ListSdksSortByEnum = "timeCreated"
+	ListSdksSortByDisplayname ListSdksSortByEnum = "displayName"
+)
+
+var mappingListSdksSortBy = map[string]ListSdksSortByEnum{
+	"timeCreated": ListSdksSortByTimecreated,
+	"displayName": ListSdksSortByDisplayname,
+}
+
+// GetListSdksSortByEnumValues Enumerates the set of values for ListSdksSortByEnum
+func GetListSdksSortByEnumValues() []ListSdksSortByEnum {
+	values := make([]ListSdksSortByEnum, 0)
+	for _, v := range mappingListSdksSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/apigateway/sdk.go
+++ b/apigateway/sdk.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// API Gateway API
+//
+// API for the API Gateway service. Use this API to manage gateways, deployments, and related items.
+// For more information, see
+// Overview of API Gateway (https://docs.cloud.oracle.com/iaas/Content/APIGateway/Concepts/apigatewayoverview.htm).
+//
+
+package apigateway
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// Sdk Information about the SDK.
+type Sdk struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the resource.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of API resource
+	ApiId *string `mandatory:"true" json:"apiId"`
+
+	// A user-friendly name. Does not have to be unique, and it's changeable.
+	// Avoid entering confidential information.
+	// Example: `My new resource`
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The string representing the target programming language for generating the SDK.
+	TargetLanguage *string `mandatory:"true" json:"targetLanguage"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment in which the
+	// resource is created.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The time this resource was created. An RFC3339 formatted datetime string.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The time this resource was last updated. An RFC3339 formatted datetime string.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// File location for generated SDK.
+	ArtifactUrl *string `mandatory:"false" json:"artifactUrl"`
+
+	// Expiry of artifact url.
+	TimeArtifactUrlExpiresAt *common.SDKTime `mandatory:"false" json:"timeArtifactUrlExpiresAt"`
+
+	// The current state of the SDK.
+	// - The SDK will be in CREATING state if the SDK creation is in progress.
+	// - The SDK will be in ACTIVE state if create is successful.
+	// - The SDK will be in FAILED state if the create, or delete fails.
+	// - The SDK will be in DELETING state if the deletion in in progress.
+	// - The SDK will be in DELETED state if the delete is successful.
+	LifecycleState SdkLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// A message describing the current state in more detail.
+	// For example, can be used to provide actionable information for a
+	// resource in a Failed state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair
+	// with no predefined name, type, or namespace. For more information, see
+	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see
+	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Additional optional configurations passed.
+	// The applicable config keys are listed under "parameters" when "/sdkLanguageTypes" is called.
+	// Example: `{"configName": "configValue"}`
+	Parameters map[string]string `mandatory:"false" json:"parameters"`
+}
+
+func (m Sdk) String() string {
+	return common.PointerString(m)
+}
+
+// SdkLifecycleStateEnum Enum with underlying type: string
+type SdkLifecycleStateEnum string
+
+// Set of constants representing the allowable values for SdkLifecycleStateEnum
+const (
+	SdkLifecycleStateCreating SdkLifecycleStateEnum = "CREATING"
+	SdkLifecycleStateActive   SdkLifecycleStateEnum = "ACTIVE"
+	SdkLifecycleStateFailed   SdkLifecycleStateEnum = "FAILED"
+	SdkLifecycleStateDeleting SdkLifecycleStateEnum = "DELETING"
+	SdkLifecycleStateDeleted  SdkLifecycleStateEnum = "DELETED"
+)
+
+var mappingSdkLifecycleState = map[string]SdkLifecycleStateEnum{
+	"CREATING": SdkLifecycleStateCreating,
+	"ACTIVE":   SdkLifecycleStateActive,
+	"FAILED":   SdkLifecycleStateFailed,
+	"DELETING": SdkLifecycleStateDeleting,
+	"DELETED":  SdkLifecycleStateDeleted,
+}
+
+// GetSdkLifecycleStateEnumValues Enumerates the set of values for SdkLifecycleStateEnum
+func GetSdkLifecycleStateEnumValues() []SdkLifecycleStateEnum {
+	values := make([]SdkLifecycleStateEnum, 0)
+	for _, v := range mappingSdkLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}

--- a/apigateway/sdk_collection.go
+++ b/apigateway/sdk_collection.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// API Gateway API
+//
+// API for the API Gateway service. Use this API to manage gateways, deployments, and related items.
+// For more information, see
+// Overview of API Gateway (https://docs.cloud.oracle.com/iaas/Content/APIGateway/Concepts/apigatewayoverview.htm).
+//
+
+package apigateway
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// SdkCollection Collection of the existing SDKs.
+type SdkCollection struct {
+
+	// SDK summaries.
+	Items []SdkSummary `mandatory:"true" json:"items"`
+}
+
+func (m SdkCollection) String() string {
+	return common.PointerString(m)
+}

--- a/apigateway/sdk_language_optional_parameters.go
+++ b/apigateway/sdk_language_optional_parameters.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// API Gateway API
+//
+// API for the API Gateway service. Use this API to manage gateways, deployments, and related items.
+// For more information, see
+// Overview of API Gateway (https://docs.cloud.oracle.com/iaas/Content/APIGateway/Concepts/apigatewayoverview.htm).
+//
+
+package apigateway
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// SdkLanguageOptionalParameters List of additional applicable parameters for any given target language.
+type SdkLanguageOptionalParameters struct {
+
+	// Name of the parameter.
+	ParamName *string `mandatory:"true" json:"paramName"`
+
+	// Display name of the parameter.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Description for the parameter.
+	Description *string `mandatory:"false" json:"description"`
+
+	// Information on whether the parameter is required or not.
+	IsRequired *bool `mandatory:"false" json:"isRequired"`
+
+	// Maximum size as input value for this parameter.
+	MaxSize *float32 `mandatory:"false" json:"maxSize"`
+
+	// The input type for this param.
+	// - Input type is ENUM when only specific list of input strings are allowed.
+	// - Input type is EMAIL when input type is an email ID.
+	// - Input type is URI when input type is an URI.
+	// - Input type is STRING in all other cases.
+	InputType SdkLanguageOptionalParametersInputTypeEnum `mandatory:"false" json:"inputType,omitempty"`
+
+	// List of allowed input values.
+	// Example: `[{"name": "name1", "description": "description1"}, ...]`
+	AllowedValues []SdkLanguageOptionalParametersAllowedValue `mandatory:"false" json:"allowedValues"`
+}
+
+func (m SdkLanguageOptionalParameters) String() string {
+	return common.PointerString(m)
+}
+
+// SdkLanguageOptionalParametersInputTypeEnum Enum with underlying type: string
+type SdkLanguageOptionalParametersInputTypeEnum string
+
+// Set of constants representing the allowable values for SdkLanguageOptionalParametersInputTypeEnum
+const (
+	SdkLanguageOptionalParametersInputTypeEnumvalue SdkLanguageOptionalParametersInputTypeEnum = "ENUM"
+	SdkLanguageOptionalParametersInputTypeEmail     SdkLanguageOptionalParametersInputTypeEnum = "EMAIL"
+	SdkLanguageOptionalParametersInputTypeUri       SdkLanguageOptionalParametersInputTypeEnum = "URI"
+	SdkLanguageOptionalParametersInputTypeString    SdkLanguageOptionalParametersInputTypeEnum = "STRING"
+)
+
+var mappingSdkLanguageOptionalParametersInputType = map[string]SdkLanguageOptionalParametersInputTypeEnum{
+	"ENUM":   SdkLanguageOptionalParametersInputTypeEnumvalue,
+	"EMAIL":  SdkLanguageOptionalParametersInputTypeEmail,
+	"URI":    SdkLanguageOptionalParametersInputTypeUri,
+	"STRING": SdkLanguageOptionalParametersInputTypeString,
+}
+
+// GetSdkLanguageOptionalParametersInputTypeEnumValues Enumerates the set of values for SdkLanguageOptionalParametersInputTypeEnum
+func GetSdkLanguageOptionalParametersInputTypeEnumValues() []SdkLanguageOptionalParametersInputTypeEnum {
+	values := make([]SdkLanguageOptionalParametersInputTypeEnum, 0)
+	for _, v := range mappingSdkLanguageOptionalParametersInputType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/apigateway/sdk_language_optional_parameters_allowed_value.go
+++ b/apigateway/sdk_language_optional_parameters_allowed_value.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// API Gateway API
+//
+// API for the API Gateway service. Use this API to manage gateways, deployments, and related items.
+// For more information, see
+// Overview of API Gateway (https://docs.cloud.oracle.com/iaas/Content/APIGateway/Concepts/apigatewayoverview.htm).
+//
+
+package apigateway
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// SdkLanguageOptionalParametersAllowedValue Allowed value object.
+type SdkLanguageOptionalParametersAllowedValue struct {
+
+	// Name of the allowed value.
+	Name *string `mandatory:"false" json:"name"`
+
+	// Description for the allowed value.
+	Description *string `mandatory:"false" json:"description"`
+}
+
+func (m SdkLanguageOptionalParametersAllowedValue) String() string {
+	return common.PointerString(m)
+}

--- a/apigateway/sdk_language_type_collection.go
+++ b/apigateway/sdk_language_type_collection.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// API Gateway API
+//
+// API for the API Gateway service. Use this API to manage gateways, deployments, and related items.
+// For more information, see
+// Overview of API Gateway (https://docs.cloud.oracle.com/iaas/Content/APIGateway/Concepts/apigatewayoverview.htm).
+//
+
+package apigateway
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// SdkLanguageTypeCollection Collection of available SDK target languages.
+type SdkLanguageTypeCollection struct {
+
+	// SDK target language details.
+	Items []SdkLanguageTypeSummary `mandatory:"true" json:"items"`
+}
+
+func (m SdkLanguageTypeCollection) String() string {
+	return common.PointerString(m)
+}

--- a/apigateway/sdk_language_type_summary.go
+++ b/apigateway/sdk_language_type_summary.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// API Gateway API
+//
+// API for the API Gateway service. Use this API to manage gateways, deployments, and related items.
+// For more information, see
+// Overview of API Gateway (https://docs.cloud.oracle.com/iaas/Content/APIGateway/Concepts/apigatewayoverview.htm).
+//
+
+package apigateway
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// SdkLanguageTypeSummary SDK target language details.
+type SdkLanguageTypeSummary struct {
+
+	// Name of the programming language.
+	Name *string `mandatory:"true" json:"name"`
+
+	// Version string of the programming language defined in name.
+	Version *string `mandatory:"true" json:"version"`
+
+	// Display name of the target programming language.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Additional details.
+	Description *string `mandatory:"false" json:"description"`
+
+	// List of optional configurations that can be used while generating SDK for the given target language.
+	Parameters []SdkLanguageOptionalParameters `mandatory:"false" json:"parameters"`
+}
+
+func (m SdkLanguageTypeSummary) String() string {
+	return common.PointerString(m)
+}

--- a/apigateway/sdk_language_types.go
+++ b/apigateway/sdk_language_types.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// API Gateway API
+//
+// API for the API Gateway service. Use this API to manage gateways, deployments, and related items.
+// For more information, see
+// Overview of API Gateway (https://docs.cloud.oracle.com/iaas/Content/APIGateway/Concepts/apigatewayoverview.htm).
+//
+
+package apigateway
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// SdkLanguageTypes SDK target language details.
+type SdkLanguageTypes struct {
+
+	// Name of the programming language.
+	Name *string `mandatory:"true" json:"name"`
+
+	// Version string of the programming language defined in name.
+	Version *string `mandatory:"true" json:"version"`
+
+	// Display name of the target programming language.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Additional details.
+	Description *string `mandatory:"false" json:"description"`
+
+	// List of optional configurations that can be used while generating SDK for the given target language.
+	Parameters []SdkLanguageOptionalParameters `mandatory:"false" json:"parameters"`
+}
+
+func (m SdkLanguageTypes) String() string {
+	return common.PointerString(m)
+}

--- a/apigateway/sdk_summary.go
+++ b/apigateway/sdk_summary.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// API Gateway API
+//
+// API for the API Gateway service. Use this API to manage gateways, deployments, and related items.
+// For more information, see
+// Overview of API Gateway (https://docs.cloud.oracle.com/iaas/Content/APIGateway/Concepts/apigatewayoverview.htm).
+//
+
+package apigateway
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// SdkSummary A summary of the SDK.
+type SdkSummary struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the resource.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The time this resource was created. An RFC3339 formatted datetime string.
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// A user-friendly name. Does not have to be unique, and it's changeable.
+	// Avoid entering confidential information.
+	// Example: `My new resource`
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The string representing the target programming language for generating the SDK.
+	TargetLanguage *string `mandatory:"true" json:"targetLanguage"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment in which the
+	// resource is created.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The time this resource was last updated. An RFC3339 formatted datetime string.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// The current state of the SDK.
+	LifecycleState SdkLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair
+	// with no predefined name, type, or namespace. For more information, see
+	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see
+	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m SdkSummary) String() string {
+	return common.PointerString(m)
+}

--- a/apigateway/update_sdk_details.go
+++ b/apigateway/update_sdk_details.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// API Gateway API
+//
+// API for the API Gateway service. Use this API to manage gateways, deployments, and related items.
+// For more information, see
+// Overview of API Gateway (https://docs.cloud.oracle.com/iaas/Content/APIGateway/Concepts/apigatewayoverview.htm).
+//
+
+package apigateway
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// UpdateSdkDetails The information to be updated.
+type UpdateSdkDetails struct {
+
+	// A user-friendly name. Does not have to be unique, and it's changeable.
+	// Avoid entering confidential information.
+	// Example: `My new resource`
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair
+	// with no predefined name, type, or namespace. For more information, see
+	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see
+	// Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m UpdateSdkDetails) String() string {
+	return common.PointerString(m)
+}

--- a/apigateway/update_sdk_request_response.go
+++ b/apigateway/update_sdk_request_response.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package apigateway
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+	"net/http"
+)
+
+// UpdateSdkRequest wrapper for the UpdateSdk operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/apigateway/UpdateSdk.go.html to see an example of how to use UpdateSdkRequest.
+type UpdateSdkRequest struct {
+
+	// The ocid of the SDK.
+	SdkId *string `mandatory:"true" contributesTo:"path" name:"sdkId"`
+
+	// The information to be updated.
+	UpdateSdkDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call
+	// for a resource, set the `if-match` parameter to the value of the
+	// etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you
+	// provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request id for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateSdkRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateSdkRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateSdkRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateSdkResponse wrapper for the UpdateSdk operation
+type UpdateSdkResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to
+	// contact Oracle about a particular request, please provide the request
+	// id.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateSdkResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateSdkResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/apigateway/work_request.go
+++ b/apigateway/work_request.go
@@ -71,6 +71,8 @@ const (
 	WorkRequestOperationTypeUpdateApi         WorkRequestOperationTypeEnum = "UPDATE_API"
 	WorkRequestOperationTypeDeleteApi         WorkRequestOperationTypeEnum = "DELETE_API"
 	WorkRequestOperationTypeValidateApi       WorkRequestOperationTypeEnum = "VALIDATE_API"
+	WorkRequestOperationTypeCreateSdk         WorkRequestOperationTypeEnum = "CREATE_SDK"
+	WorkRequestOperationTypeDeleteSdk         WorkRequestOperationTypeEnum = "DELETE_SDK"
 )
 
 var mappingWorkRequestOperationType = map[string]WorkRequestOperationTypeEnum{
@@ -87,6 +89,8 @@ var mappingWorkRequestOperationType = map[string]WorkRequestOperationTypeEnum{
 	"UPDATE_API":         WorkRequestOperationTypeUpdateApi,
 	"DELETE_API":         WorkRequestOperationTypeDeleteApi,
 	"VALIDATE_API":       WorkRequestOperationTypeValidateApi,
+	"CREATE_SDK":         WorkRequestOperationTypeCreateSdk,
+	"DELETE_SDK":         WorkRequestOperationTypeDeleteSdk,
 }
 
 // GetWorkRequestOperationTypeEnumValues Enumerates the set of values for WorkRequestOperationTypeEnum

--- a/applicationmigration/authorization_details.go
+++ b/applicationmigration/authorization_details.go
@@ -60,6 +60,10 @@ func (m *authorizationdetails) UnmarshalPolymorphicJSON(data []byte) (interface{
 		mm := InternalAuthorizationDetails{}
 		err = json.Unmarshal(data, &mm)
 		return mm, err
+	case "OCIC_IDCS":
+		mm := OcicAuthorizationTokenDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
 	case "OCIC":
 		mm := OcicAuthorizationDetails{}
 		err = json.Unmarshal(data, &mm)

--- a/applicationmigration/create_migration_details.go
+++ b/applicationmigration/create_migration_details.go
@@ -45,7 +45,7 @@ type CreateMigrationDetails struct {
 	Description *string `mandatory:"false" json:"description"`
 
 	// The pre-existing database type to be used in this migration. Currently, Application migration only supports Oracle Cloud
-	// Infrastrure databases and this option is currently available only for `JAVA_CLOUD_SERVICE` and `WEBLOGIC_CLOUD_SERVICE` target instance types.
+	// Infrastructure databases and this option is currently available only for `JAVA_CLOUD_SERVICE` and `WEBLOGIC_CLOUD_SERVICE` target instance types.
 	PreCreatedTargetDatabaseType TargetDatabaseTypesEnum `mandatory:"false" json:"preCreatedTargetDatabaseType,omitempty"`
 
 	// If set to `true`, Application Migration migrates the application resources selectively depending on the source.

--- a/applicationmigration/migration.go
+++ b/applicationmigration/migration.go
@@ -49,10 +49,10 @@ type Migration struct {
 	ApplicationType MigrationTypesEnum `mandatory:"false" json:"applicationType,omitempty"`
 
 	// The pre-existing database type to be used in this migration. Currently, Application migration only supports Oracle Cloud
-	// Infrastrure databases and this option is currently available only for `JAVA_CLOUD_SERVICE` and `WEBLOGIC_CLOUD_SERVICE` target instance types.
+	// Infrastructure databases and this option is currently available only for `JAVA_CLOUD_SERVICE` and `WEBLOGIC_CLOUD_SERVICE` target instance types.
 	PreCreatedTargetDatabaseType TargetDatabaseTypesEnum `mandatory:"false" json:"preCreatedTargetDatabaseType,omitempty"`
 
-	// If set to `true`, Application Migration migrates the application resources selectively depending on the source.
+	// If set to `true`, Application Migration migrates only the application resources that you specify. If set to `false`, Application Migration migrates the entire application. When you migrate the entire application, all the application resources are migrated to the target environment. You can selectively migrate resources only for the Oracle Integration Cloud and Oracle Integration Cloud Service applications.
 	IsSelectiveMigration *bool `mandatory:"false" json:"isSelectiveMigration"`
 
 	// Configuration required to migrate the application. In addition to the key and value, additional fields are provided

--- a/applicationmigration/occ_authorization_details.go
+++ b/applicationmigration/occ_authorization_details.go
@@ -17,10 +17,10 @@ import (
 	"github.com/oracle/oci-go-sdk/v38/common"
 )
 
-// OccAuthorizationDetails Credentials to access Oracle Cloud @ Customer, which is the source environment from which you want to migrate the application.
+// OccAuthorizationDetails Credentials to access Oracle Cloud@Customer, which is the source environment from which you want to migrate the application.
 type OccAuthorizationDetails struct {
 
-	// User with Compute Operations role in Oracle Cloud @ Customer.
+	// User with Compute Operations role in Oracle Cloud@Customer.
 	Username *string `mandatory:"true" json:"username"`
 
 	// Password for this user.

--- a/applicationmigration/occ_source_details.go
+++ b/applicationmigration/occ_source_details.go
@@ -17,11 +17,11 @@ import (
 	"github.com/oracle/oci-go-sdk/v38/common"
 )
 
-// OccSourceDetails Details about the Oracle Cloud @ Customer account, the source environment from which you want to migrate the application.
+// OccSourceDetails Details about the Oracle Cloud@Customer account, the source environment from which you want to migrate the application.
 type OccSourceDetails struct {
 
-	// If you are using a Oracle Cloud @ Customer account with Identity Cloud Service (IDCS), enter the service instance ID.
-	// For example, if Compute-567890123 is the account name of your Oracle Cloud @ Customer Compute service entitlement,
+	// If you are using an Oracle Cloud@Customer account with Identity Cloud Service (IDCS), enter the service instance ID.
+	// For example, if Compute-567890123 is the account name of your Oracle Cloud@Customer Compute service entitlement,
 	// then enter 567890123.
 	ComputeAccount *string `mandatory:"true" json:"computeAccount"`
 }

--- a/applicationmigration/ocic_authorization_token_details.go
+++ b/applicationmigration/ocic_authorization_token_details.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Application Migration API
+//
+// Application Migration simplifies the migration of applications from Oracle Cloud Infrastructure Classic to Oracle Cloud Infrastructure.
+// You can use Application Migration API to migrate applications, such as Oracle Java Cloud Service, SOA Cloud Service, and Integration Classic
+// instances, to Oracle Cloud Infrastructure. For more information, see
+// Overview of Application Migration (https://docs.cloud.oracle.com/iaas/application-migration/appmigrationoverview.htm).
+//
+
+package applicationmigration
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// OcicAuthorizationTokenDetails Auth Token and endpoint to access Oracle Cloud Infrastructure - Classic, which is the source environment from which you want to migrate the application.
+type OcicAuthorizationTokenDetails struct {
+
+	// AuthClient app url resource that the accesstoken is for.
+	ClientAppUrl *string `mandatory:"true" json:"clientAppUrl"`
+
+	// AccessToken to access the app endpoint.
+	AccessToken *string `mandatory:"true" json:"accessToken"`
+}
+
+func (m OcicAuthorizationTokenDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m OcicAuthorizationTokenDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeOcicAuthorizationTokenDetails OcicAuthorizationTokenDetails
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeOcicAuthorizationTokenDetails
+	}{
+		"OCIC_IDCS",
+		(MarshalTypeOcicAuthorizationTokenDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/applicationmigration/ocic_source_details.go
+++ b/applicationmigration/ocic_source_details.go
@@ -23,7 +23,7 @@ type OcicSourceDetails struct {
 	// The Oracle Cloud Infrastructure - Classic region from which you want to migrate your applications. For example, uscom-east-1 or uscom-central-1.
 	Region *string `mandatory:"true" json:"region"`
 
-	// If you are using a Oracle Cloud Infrastructure - Classic account with Identity Cloud Service (IDCS), enter the service instance ID.
+	// If you are using an Oracle Cloud Infrastructure - Classic account with Identity Cloud Service (IDCS), enter the service instance ID.
 	// For example, if Compute-567890123 is the account name of your Oracle Cloud Infrastructure Classic Compute service entitlement,
 	// then enter 567890123.
 	// If you are using a traditional Oracle Cloud Infrastructure - Classic account, enter your identity domain ID.

--- a/applicationmigration/source_details.go
+++ b/applicationmigration/source_details.go
@@ -22,7 +22,7 @@ import (
 // SOA Cloud Service applications from Oracle Cloud Infrastructure - Classic.
 // Specify `INTERNAL_COMPUTE` if you have a traditional Oracle Cloud Infrastructure - Classic account and you want to migrate Oracle
 // Process Cloud Service or Oracle Integration Cloud Service applications.
-// Specify `OCC` if you have an Oracle Cloud @ Customer account.
+// Specify `OCC` if you want to migrate applications from Oracle Cloud@Customer.
 type SourceDetails interface {
 }
 

--- a/applicationmigration/source_types.go
+++ b/applicationmigration/source_types.go
@@ -20,12 +20,14 @@ const (
 	SourceTypesOcic            SourceTypesEnum = "OCIC"
 	SourceTypesInternalCompute SourceTypesEnum = "INTERNAL_COMPUTE"
 	SourceTypesOcc             SourceTypesEnum = "OCC"
+	SourceTypesOcicIdcs        SourceTypesEnum = "OCIC_IDCS"
 )
 
 var mappingSourceTypes = map[string]SourceTypesEnum{
 	"OCIC":             SourceTypesOcic,
 	"INTERNAL_COMPUTE": SourceTypesInternalCompute,
 	"OCC":              SourceTypesOcc,
+	"OCIC_IDCS":        SourceTypesOcicIdcs,
 }
 
 // GetSourceTypesEnumValues Enumerates the set of values for SourceTypesEnum

--- a/artifacts/artifacts_client.go
+++ b/artifacts/artifacts_client.go
@@ -141,6 +141,65 @@ func (client ArtifactsClient) changeContainerRepositoryCompartment(ctx context.C
 	return response, err
 }
 
+// CreateContainerImageSignature Upload a signature to an image.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/artifacts/CreateContainerImageSignature.go.html to see an example of how to use CreateContainerImageSignature API.
+func (client ArtifactsClient) CreateContainerImageSignature(ctx context.Context, request CreateContainerImageSignatureRequest) (response CreateContainerImageSignatureResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createContainerImageSignature, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateContainerImageSignatureResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateContainerImageSignatureResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateContainerImageSignatureResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateContainerImageSignatureResponse")
+	}
+	return
+}
+
+// createContainerImageSignature implements the OCIOperation interface (enables retrying operations)
+func (client ArtifactsClient) createContainerImageSignature(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/container/imageSignatures")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateContainerImageSignatureResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // CreateContainerRepository Create a new empty container repository. Avoid entering confidential information.
 //
 // See also
@@ -242,6 +301,60 @@ func (client ArtifactsClient) deleteContainerImage(ctx context.Context, request 
 	}
 
 	var response DeleteContainerImageResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteContainerImageSignature Delete a container image signature.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/artifacts/DeleteContainerImageSignature.go.html to see an example of how to use DeleteContainerImageSignature API.
+func (client ArtifactsClient) DeleteContainerImageSignature(ctx context.Context, request DeleteContainerImageSignatureRequest) (response DeleteContainerImageSignatureResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteContainerImageSignature, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteContainerImageSignatureResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteContainerImageSignatureResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteContainerImageSignatureResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteContainerImageSignatureResponse")
+	}
+	return
+}
+
+// deleteContainerImageSignature implements the OCIOperation interface (enables retrying operations)
+func (client ArtifactsClient) deleteContainerImageSignature(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/container/imageSignatures/{imageSignatureId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteContainerImageSignatureResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -416,6 +529,60 @@ func (client ArtifactsClient) getContainerImage(ctx context.Context, request com
 	return response, err
 }
 
+// GetContainerImageSignature Get container image signature metadata.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/artifacts/GetContainerImageSignature.go.html to see an example of how to use GetContainerImageSignature API.
+func (client ArtifactsClient) GetContainerImageSignature(ctx context.Context, request GetContainerImageSignatureRequest) (response GetContainerImageSignatureResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getContainerImageSignature, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetContainerImageSignatureResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetContainerImageSignatureResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetContainerImageSignatureResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetContainerImageSignatureResponse")
+	}
+	return
+}
+
+// getContainerImageSignature implements the OCIOperation interface (enables retrying operations)
+func (client ArtifactsClient) getContainerImageSignature(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/container/imageSignatures/{imageSignatureId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetContainerImageSignatureResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // GetContainerRepository Get container repository.
 //
 // See also
@@ -458,6 +625,60 @@ func (client ArtifactsClient) getContainerRepository(ctx context.Context, reques
 	}
 
 	var response GetContainerRepositoryResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListContainerImageSignatures List container image signatures in an image.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/artifacts/ListContainerImageSignatures.go.html to see an example of how to use ListContainerImageSignatures API.
+func (client ArtifactsClient) ListContainerImageSignatures(ctx context.Context, request ListContainerImageSignaturesRequest) (response ListContainerImageSignaturesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listContainerImageSignatures, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListContainerImageSignaturesResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListContainerImageSignaturesResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListContainerImageSignaturesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListContainerImageSignaturesResponse")
+	}
+	return
+}
+
+// listContainerImageSignatures implements the OCIOperation interface (enables retrying operations)
+func (client ArtifactsClient) listContainerImageSignatures(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/container/imageSignatures")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListContainerImageSignaturesResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)

--- a/artifacts/container_image_signature.go
+++ b/artifacts/container_image_signature.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Images API
+//
+// API covering the Registry (https://docs.cloud.oracle.com/iaas/Content/Registry/Concepts/registryoverview.htm) services.
+// Use this API to manage resources such as container images and repositories.
+//
+
+package artifacts
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// ContainerImageSignature Container image signature metadata.
+type ContainerImageSignature struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment in which the container repository exists.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The id of the user or principal that created the resource.
+	CreatedBy *string `mandatory:"true" json:"createdBy"`
+
+	// The last 10 characters of the kmsKeyId, the last 10 characters of the kmsKeyVersionId, the signingAlgorithm, and the last 10 characters of the signatureId.
+	// Example: `wrmz22sixa::qdwyc2ptun::SHA_256_RSA_PKCS_PSS::2vwmobasva`
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the container image signature.
+	// Example: `ocid1.containerimagesignature.oc1..exampleuniqueID`
+	Id *string `mandatory:"true" json:"id"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the container image.
+	// Example: `ocid1.containerimage.oc1..exampleuniqueID`
+	ImageId *string `mandatory:"true" json:"imageId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the kmsKeyId used to sign the container image.
+	// Example: `ocid1.key.oc1..exampleuniqueID`
+	KmsKeyId *string `mandatory:"true" json:"kmsKeyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the kmsKeyVersionId used to sign the container image.
+	// Example: `ocid1.keyversion.oc1..exampleuniqueID`
+	KmsKeyVersionId *string `mandatory:"true" json:"kmsKeyVersionId"`
+
+	// The base64 encoded signature payload that was signed.
+	Message *string `mandatory:"true" json:"message"`
+
+	// The signature of the message field using the kmsKeyId, the kmsKeyVersionId, and the signingAlgorithm.
+	Signature *string `mandatory:"true" json:"signature"`
+
+	// The algorithm to be used for signing. These are the only supported signing algorithms for container images.
+	SigningAlgorithm ContainerImageSignatureSigningAlgorithmEnum `mandatory:"true" json:"signingAlgorithm"`
+
+	// An RFC 3339 timestamp indicating when the image was created.
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+}
+
+func (m ContainerImageSignature) String() string {
+	return common.PointerString(m)
+}
+
+// ContainerImageSignatureSigningAlgorithmEnum Enum with underlying type: string
+type ContainerImageSignatureSigningAlgorithmEnum string
+
+// Set of constants representing the allowable values for ContainerImageSignatureSigningAlgorithmEnum
+const (
+	ContainerImageSignatureSigningAlgorithm224RsaPkcsPss ContainerImageSignatureSigningAlgorithmEnum = "SHA_224_RSA_PKCS_PSS"
+	ContainerImageSignatureSigningAlgorithm256RsaPkcsPss ContainerImageSignatureSigningAlgorithmEnum = "SHA_256_RSA_PKCS_PSS"
+	ContainerImageSignatureSigningAlgorithm384RsaPkcsPss ContainerImageSignatureSigningAlgorithmEnum = "SHA_384_RSA_PKCS_PSS"
+	ContainerImageSignatureSigningAlgorithm512RsaPkcsPss ContainerImageSignatureSigningAlgorithmEnum = "SHA_512_RSA_PKCS_PSS"
+)
+
+var mappingContainerImageSignatureSigningAlgorithm = map[string]ContainerImageSignatureSigningAlgorithmEnum{
+	"SHA_224_RSA_PKCS_PSS": ContainerImageSignatureSigningAlgorithm224RsaPkcsPss,
+	"SHA_256_RSA_PKCS_PSS": ContainerImageSignatureSigningAlgorithm256RsaPkcsPss,
+	"SHA_384_RSA_PKCS_PSS": ContainerImageSignatureSigningAlgorithm384RsaPkcsPss,
+	"SHA_512_RSA_PKCS_PSS": ContainerImageSignatureSigningAlgorithm512RsaPkcsPss,
+}
+
+// GetContainerImageSignatureSigningAlgorithmEnumValues Enumerates the set of values for ContainerImageSignatureSigningAlgorithmEnum
+func GetContainerImageSignatureSigningAlgorithmEnumValues() []ContainerImageSignatureSigningAlgorithmEnum {
+	values := make([]ContainerImageSignatureSigningAlgorithmEnum, 0)
+	for _, v := range mappingContainerImageSignatureSigningAlgorithm {
+		values = append(values, v)
+	}
+	return values
+}

--- a/artifacts/container_image_signature_collection.go
+++ b/artifacts/container_image_signature_collection.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Images API
+//
+// API covering the Registry (https://docs.cloud.oracle.com/iaas/Content/Registry/Concepts/registryoverview.htm) services.
+// Use this API to manage resources such as container images and repositories.
+//
+
+package artifacts
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// ContainerImageSignatureCollection List container image signature results.
+type ContainerImageSignatureCollection struct {
+
+	// Page of matching container image signatures.
+	Items []ContainerImageSignatureSummary `mandatory:"true" json:"items"`
+
+	// Estimated number of remaining results.
+	RemainingItemsCount *int `mandatory:"true" json:"remainingItemsCount"`
+}
+
+func (m ContainerImageSignatureCollection) String() string {
+	return common.PointerString(m)
+}

--- a/artifacts/container_image_signature_summary.go
+++ b/artifacts/container_image_signature_summary.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Images API
+//
+// API covering the Registry (https://docs.cloud.oracle.com/iaas/Content/Registry/Concepts/registryoverview.htm) services.
+// Use this API to manage resources such as container images and repositories.
+//
+
+package artifacts
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// ContainerImageSignatureSummary Container image signature summary.
+type ContainerImageSignatureSummary struct {
+
+	// The OCID of the compartment in which the container repository exists.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The last 10 characters of the kmsKeyId, the last 10 characters of the kmsKeyVersionId, the signingAlgorithm, and the last 10 characters of the signatureId.
+	// Example: `wrmz22sixa::qdwyc2ptun::SHA_256_RSA_PKCS_PSS::2vwmobasva`
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the container image signature.
+	// Example: `ocid1.containerimagesignature.oc1..exampleuniqueID`
+	Id *string `mandatory:"true" json:"id"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the container image.
+	// Example: `ocid1.containerimage.oc1..exampleuniqueID`
+	ImageId *string `mandatory:"true" json:"imageId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the kmsKeyId used to sign the container image.
+	// Example: `ocid1.key.oc1..exampleuniqueID`
+	KmsKeyId *string `mandatory:"true" json:"kmsKeyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the kmsKeyVersionId used to sign the container image.
+	// Example: `ocid1.keyversion.oc1..exampleuniqueID`
+	KmsKeyVersionId *string `mandatory:"true" json:"kmsKeyVersionId"`
+
+	// The base64 encoded signature payload that was signed.
+	Message *string `mandatory:"true" json:"message"`
+
+	// The signature of the message field using the kmsKeyId, the kmsKeyVersionId, and the signingAlgorithm.
+	Signature *string `mandatory:"true" json:"signature"`
+
+	// The algorithm to be used for signing. These are the only supported signing algorithms for container images.
+	SigningAlgorithm ContainerImageSignatureSummarySigningAlgorithmEnum `mandatory:"true" json:"signingAlgorithm"`
+
+	// An RFC 3339 timestamp indicating when the image was created.
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+}
+
+func (m ContainerImageSignatureSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ContainerImageSignatureSummarySigningAlgorithmEnum Enum with underlying type: string
+type ContainerImageSignatureSummarySigningAlgorithmEnum string
+
+// Set of constants representing the allowable values for ContainerImageSignatureSummarySigningAlgorithmEnum
+const (
+	ContainerImageSignatureSummarySigningAlgorithm224RsaPkcsPss ContainerImageSignatureSummarySigningAlgorithmEnum = "SHA_224_RSA_PKCS_PSS"
+	ContainerImageSignatureSummarySigningAlgorithm256RsaPkcsPss ContainerImageSignatureSummarySigningAlgorithmEnum = "SHA_256_RSA_PKCS_PSS"
+	ContainerImageSignatureSummarySigningAlgorithm384RsaPkcsPss ContainerImageSignatureSummarySigningAlgorithmEnum = "SHA_384_RSA_PKCS_PSS"
+	ContainerImageSignatureSummarySigningAlgorithm512RsaPkcsPss ContainerImageSignatureSummarySigningAlgorithmEnum = "SHA_512_RSA_PKCS_PSS"
+)
+
+var mappingContainerImageSignatureSummarySigningAlgorithm = map[string]ContainerImageSignatureSummarySigningAlgorithmEnum{
+	"SHA_224_RSA_PKCS_PSS": ContainerImageSignatureSummarySigningAlgorithm224RsaPkcsPss,
+	"SHA_256_RSA_PKCS_PSS": ContainerImageSignatureSummarySigningAlgorithm256RsaPkcsPss,
+	"SHA_384_RSA_PKCS_PSS": ContainerImageSignatureSummarySigningAlgorithm384RsaPkcsPss,
+	"SHA_512_RSA_PKCS_PSS": ContainerImageSignatureSummarySigningAlgorithm512RsaPkcsPss,
+}
+
+// GetContainerImageSignatureSummarySigningAlgorithmEnumValues Enumerates the set of values for ContainerImageSignatureSummarySigningAlgorithmEnum
+func GetContainerImageSignatureSummarySigningAlgorithmEnumValues() []ContainerImageSignatureSummarySigningAlgorithmEnum {
+	values := make([]ContainerImageSignatureSummarySigningAlgorithmEnum, 0)
+	for _, v := range mappingContainerImageSignatureSummarySigningAlgorithm {
+		values = append(values, v)
+	}
+	return values
+}

--- a/artifacts/create_container_image_signature_details.go
+++ b/artifacts/create_container_image_signature_details.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Images API
+//
+// API covering the Registry (https://docs.cloud.oracle.com/iaas/Content/Registry/Concepts/registryoverview.htm) services.
+// Use this API to manage resources such as container images and repositories.
+//
+
+package artifacts
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// CreateContainerImageSignatureDetails Upload container image signature request details.
+type CreateContainerImageSignatureDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment in which the container repository exists.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the container image.
+	// Example: `ocid1.containerimage.oc1..exampleuniqueID`
+	ImageId *string `mandatory:"true" json:"imageId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the kmsKeyId used to sign the container image.
+	// Example: `ocid1.key.oc1..exampleuniqueID`
+	KmsKeyId *string `mandatory:"true" json:"kmsKeyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the kmsKeyVersionId used to sign the container image.
+	// Example: `ocid1.keyversion.oc1..exampleuniqueID`
+	KmsKeyVersionId *string `mandatory:"true" json:"kmsKeyVersionId"`
+
+	// The base64 encoded signature payload that was signed.
+	Message *string `mandatory:"true" json:"message"`
+
+	// The signature of the message field using the kmsKeyId, the kmsKeyVersionId, and the signingAlgorithm.
+	Signature *string `mandatory:"true" json:"signature"`
+
+	// The algorithm to be used for signing. These are the only supported signing algorithms for container images.
+	SigningAlgorithm CreateContainerImageSignatureDetailsSigningAlgorithmEnum `mandatory:"true" json:"signingAlgorithm"`
+}
+
+func (m CreateContainerImageSignatureDetails) String() string {
+	return common.PointerString(m)
+}
+
+// CreateContainerImageSignatureDetailsSigningAlgorithmEnum Enum with underlying type: string
+type CreateContainerImageSignatureDetailsSigningAlgorithmEnum string
+
+// Set of constants representing the allowable values for CreateContainerImageSignatureDetailsSigningAlgorithmEnum
+const (
+	CreateContainerImageSignatureDetailsSigningAlgorithm224RsaPkcsPss CreateContainerImageSignatureDetailsSigningAlgorithmEnum = "SHA_224_RSA_PKCS_PSS"
+	CreateContainerImageSignatureDetailsSigningAlgorithm256RsaPkcsPss CreateContainerImageSignatureDetailsSigningAlgorithmEnum = "SHA_256_RSA_PKCS_PSS"
+	CreateContainerImageSignatureDetailsSigningAlgorithm384RsaPkcsPss CreateContainerImageSignatureDetailsSigningAlgorithmEnum = "SHA_384_RSA_PKCS_PSS"
+	CreateContainerImageSignatureDetailsSigningAlgorithm512RsaPkcsPss CreateContainerImageSignatureDetailsSigningAlgorithmEnum = "SHA_512_RSA_PKCS_PSS"
+)
+
+var mappingCreateContainerImageSignatureDetailsSigningAlgorithm = map[string]CreateContainerImageSignatureDetailsSigningAlgorithmEnum{
+	"SHA_224_RSA_PKCS_PSS": CreateContainerImageSignatureDetailsSigningAlgorithm224RsaPkcsPss,
+	"SHA_256_RSA_PKCS_PSS": CreateContainerImageSignatureDetailsSigningAlgorithm256RsaPkcsPss,
+	"SHA_384_RSA_PKCS_PSS": CreateContainerImageSignatureDetailsSigningAlgorithm384RsaPkcsPss,
+	"SHA_512_RSA_PKCS_PSS": CreateContainerImageSignatureDetailsSigningAlgorithm512RsaPkcsPss,
+}
+
+// GetCreateContainerImageSignatureDetailsSigningAlgorithmEnumValues Enumerates the set of values for CreateContainerImageSignatureDetailsSigningAlgorithmEnum
+func GetCreateContainerImageSignatureDetailsSigningAlgorithmEnumValues() []CreateContainerImageSignatureDetailsSigningAlgorithmEnum {
+	values := make([]CreateContainerImageSignatureDetailsSigningAlgorithmEnum, 0)
+	for _, v := range mappingCreateContainerImageSignatureDetailsSigningAlgorithm {
+		values = append(values, v)
+	}
+	return values
+}

--- a/artifacts/create_container_image_signature_request_response.go
+++ b/artifacts/create_container_image_signature_request_response.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package artifacts
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+	"net/http"
+)
+
+// CreateContainerImageSignatureRequest wrapper for the CreateContainerImageSignature operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/artifacts/CreateContainerImageSignature.go.html to see an example of how to use CreateContainerImageSignatureRequest.
+type CreateContainerImageSignatureRequest struct {
+
+	// Upload container image signature details
+	CreateContainerImageSignatureDetails `contributesTo:"body"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource. The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateContainerImageSignatureRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateContainerImageSignatureRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateContainerImageSignatureRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateContainerImageSignatureResponse wrapper for the CreateContainerImageSignature operation
+type CreateContainerImageSignatureResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ContainerImageSignature instance
+	ContainerImageSignature `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateContainerImageSignatureResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateContainerImageSignatureResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/artifacts/delete_container_image_signature_request_response.go
+++ b/artifacts/delete_container_image_signature_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package artifacts
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+	"net/http"
+)
+
+// DeleteContainerImageSignatureRequest wrapper for the DeleteContainerImageSignature operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/artifacts/DeleteContainerImageSignature.go.html to see an example of how to use DeleteContainerImageSignatureRequest.
+type DeleteContainerImageSignatureRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the container image signature.
+	// Example: `ocid1.containersignature.oc1..exampleuniqueID`
+	ImageSignatureId *string `mandatory:"true" contributesTo:"path" name:"imageSignatureId"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource. The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteContainerImageSignatureRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteContainerImageSignatureRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteContainerImageSignatureRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteContainerImageSignatureResponse wrapper for the DeleteContainerImageSignature operation
+type DeleteContainerImageSignatureResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteContainerImageSignatureResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteContainerImageSignatureResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/artifacts/get_container_image_signature_request_response.go
+++ b/artifacts/get_container_image_signature_request_response.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package artifacts
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+	"net/http"
+)
+
+// GetContainerImageSignatureRequest wrapper for the GetContainerImageSignature operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/artifacts/GetContainerImageSignature.go.html to see an example of how to use GetContainerImageSignatureRequest.
+type GetContainerImageSignatureRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the container image signature.
+	// Example: `ocid1.containersignature.oc1..exampleuniqueID`
+	ImageSignatureId *string `mandatory:"true" contributesTo:"path" name:"imageSignatureId"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetContainerImageSignatureRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetContainerImageSignatureRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetContainerImageSignatureRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetContainerImageSignatureResponse wrapper for the GetContainerImageSignature operation
+type GetContainerImageSignatureResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ContainerImageSignature instance
+	ContainerImageSignature `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetContainerImageSignatureResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetContainerImageSignatureResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/artifacts/list_container_image_signatures_request_response.go
+++ b/artifacts/list_container_image_signatures_request_response.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package artifacts
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+	"net/http"
+)
+
+// ListContainerImageSignaturesRequest wrapper for the ListContainerImageSignatures operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/artifacts/ListContainerImageSignatures.go.html to see an example of how to use ListContainerImageSignaturesRequest.
+type ListContainerImageSignaturesRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// When set to true, the hierarchy of compartments is traversed
+	// and all compartments and subcompartments in the tenancy are
+	// inspected depending on the the setting of `accessLevel`.
+	// Default is false. Can only be set to true when calling the API
+	// on the tenancy (root compartment).
+	CompartmentIdInSubtree *bool `mandatory:"false" contributesTo:"query" name:"compartmentIdInSubtree"`
+
+	// A filter to return a container image summary only for the specified container image OCID.
+	ImageId *string `mandatory:"false" contributesTo:"query" name:"imageId"`
+
+	// A filter to return container images only for the specified container repository OCID.
+	RepositoryId *string `mandatory:"false" contributesTo:"query" name:"repositoryId"`
+
+	// A filter to return container images or container image signatures that match the repository name.
+	// Example: `foo` or `foo*`
+	RepositoryName *string `mandatory:"false" contributesTo:"query" name:"repositoryName"`
+
+	// The digest of the container image.
+	// Example: `sha256:e7d38b3517548a1c71e41bffe9c8ae6d6d29546ce46bf62159837aad072c90aa`
+	ImageDigest *string `mandatory:"false" contributesTo:"query" name:"imageDigest"`
+
+	// A filter to return only resources that match the given display name exactly.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the kmsKeyVersionId used to sign the container image.
+	// Example: `ocid1.keyversion.oc1..exampleuniqueID`
+	KmsKeyId *string `mandatory:"false" contributesTo:"query" name:"kmsKeyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the kmsKeyVersionId used to sign the container image.
+	// Example: `ocid1.keyversion.oc1..exampleuniqueID`
+	KmsKeyVersionId *string `mandatory:"false" contributesTo:"query" name:"kmsKeyVersionId"`
+
+	// The algorithm to be used for signing. These are the only supported signing algorithms for container images.
+	SigningAlgorithm ListContainerImageSignaturesSigningAlgorithmEnum `mandatory:"false" contributesTo:"query" name:"signingAlgorithm" omitEmpty:"true"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated
+	// "List" call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// Example: `50`
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List"
+	// call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+	// TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+	// sort order is case sensitive.
+	// **Note:** In general, some "List" operations (for example, `ListInstances`) let you
+	// optionally filter by availability domain if the scope of the resource type is within a
+	// single availability domain. If you call one of these "List" operations without specifying
+	// an availability domain, the resources are grouped by availability domain, then sorted.
+	SortBy ListContainerImageSignaturesSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+	// is case sensitive.
+	SortOrder ListContainerImageSignaturesSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListContainerImageSignaturesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListContainerImageSignaturesRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListContainerImageSignaturesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListContainerImageSignaturesResponse wrapper for the ListContainerImageSignatures operation
+type ListContainerImageSignaturesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of ContainerImageSignatureCollection instances
+	ContainerImageSignatureCollection `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListContainerImageSignaturesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListContainerImageSignaturesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListContainerImageSignaturesSigningAlgorithmEnum Enum with underlying type: string
+type ListContainerImageSignaturesSigningAlgorithmEnum string
+
+// Set of constants representing the allowable values for ListContainerImageSignaturesSigningAlgorithmEnum
+const (
+	ListContainerImageSignaturesSigningAlgorithm224RsaPkcsPss ListContainerImageSignaturesSigningAlgorithmEnum = "SHA_224_RSA_PKCS_PSS"
+	ListContainerImageSignaturesSigningAlgorithm256RsaPkcsPss ListContainerImageSignaturesSigningAlgorithmEnum = "SHA_256_RSA_PKCS_PSS"
+	ListContainerImageSignaturesSigningAlgorithm384RsaPkcsPss ListContainerImageSignaturesSigningAlgorithmEnum = "SHA_384_RSA_PKCS_PSS"
+	ListContainerImageSignaturesSigningAlgorithm512RsaPkcsPss ListContainerImageSignaturesSigningAlgorithmEnum = "SHA_512_RSA_PKCS_PSS"
+)
+
+var mappingListContainerImageSignaturesSigningAlgorithm = map[string]ListContainerImageSignaturesSigningAlgorithmEnum{
+	"SHA_224_RSA_PKCS_PSS": ListContainerImageSignaturesSigningAlgorithm224RsaPkcsPss,
+	"SHA_256_RSA_PKCS_PSS": ListContainerImageSignaturesSigningAlgorithm256RsaPkcsPss,
+	"SHA_384_RSA_PKCS_PSS": ListContainerImageSignaturesSigningAlgorithm384RsaPkcsPss,
+	"SHA_512_RSA_PKCS_PSS": ListContainerImageSignaturesSigningAlgorithm512RsaPkcsPss,
+}
+
+// GetListContainerImageSignaturesSigningAlgorithmEnumValues Enumerates the set of values for ListContainerImageSignaturesSigningAlgorithmEnum
+func GetListContainerImageSignaturesSigningAlgorithmEnumValues() []ListContainerImageSignaturesSigningAlgorithmEnum {
+	values := make([]ListContainerImageSignaturesSigningAlgorithmEnum, 0)
+	for _, v := range mappingListContainerImageSignaturesSigningAlgorithm {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListContainerImageSignaturesSortByEnum Enum with underlying type: string
+type ListContainerImageSignaturesSortByEnum string
+
+// Set of constants representing the allowable values for ListContainerImageSignaturesSortByEnum
+const (
+	ListContainerImageSignaturesSortByTimecreated ListContainerImageSignaturesSortByEnum = "TIMECREATED"
+	ListContainerImageSignaturesSortByDisplayname ListContainerImageSignaturesSortByEnum = "DISPLAYNAME"
+)
+
+var mappingListContainerImageSignaturesSortBy = map[string]ListContainerImageSignaturesSortByEnum{
+	"TIMECREATED": ListContainerImageSignaturesSortByTimecreated,
+	"DISPLAYNAME": ListContainerImageSignaturesSortByDisplayname,
+}
+
+// GetListContainerImageSignaturesSortByEnumValues Enumerates the set of values for ListContainerImageSignaturesSortByEnum
+func GetListContainerImageSignaturesSortByEnumValues() []ListContainerImageSignaturesSortByEnum {
+	values := make([]ListContainerImageSignaturesSortByEnum, 0)
+	for _, v := range mappingListContainerImageSignaturesSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListContainerImageSignaturesSortOrderEnum Enum with underlying type: string
+type ListContainerImageSignaturesSortOrderEnum string
+
+// Set of constants representing the allowable values for ListContainerImageSignaturesSortOrderEnum
+const (
+	ListContainerImageSignaturesSortOrderAsc  ListContainerImageSignaturesSortOrderEnum = "ASC"
+	ListContainerImageSignaturesSortOrderDesc ListContainerImageSignaturesSortOrderEnum = "DESC"
+)
+
+var mappingListContainerImageSignaturesSortOrder = map[string]ListContainerImageSignaturesSortOrderEnum{
+	"ASC":  ListContainerImageSignaturesSortOrderAsc,
+	"DESC": ListContainerImageSignaturesSortOrderDesc,
+}
+
+// GetListContainerImageSignaturesSortOrderEnumValues Enumerates the set of values for ListContainerImageSignaturesSortOrderEnum
+func GetListContainerImageSignaturesSortOrderEnumValues() []ListContainerImageSignaturesSortOrderEnum {
+	values := make([]ListContainerImageSignaturesSortOrderEnum, 0)
+	for _, v := range mappingListContainerImageSignaturesSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/autoscaling/auto_scaling_configuration.go
+++ b/autoscaling/auto_scaling_configuration.go
@@ -18,7 +18,7 @@ import (
 	"github.com/oracle/oci-go-sdk/v38/common"
 )
 
-// AutoScalingConfiguration An autoscaling configuration allows you to dynamically scale the resources in a Compute instance pool.
+// AutoScalingConfiguration An autoscaling configuration lets you dynamically scale the resources in a Compute instance pool.
 // For more information, see Autoscaling (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/autoscalinginstancepools.htm).
 type AutoScalingConfiguration struct {
 
@@ -32,10 +32,9 @@ type AutoScalingConfiguration struct {
 
 	// Autoscaling policy definitions for the autoscaling configuration. An autoscaling policy defines the criteria that
 	// trigger autoscaling actions and the actions to take.
-	// Each autoscaling configuration can have one autoscaling policy.
 	Policies []AutoScalingPolicy `mandatory:"true" json:"policies"`
 
-	// The date and time the AutoScalingConfiguration was created, in the format defined by RFC3339.
+	// The date and time the autoscaling configuration was created, in the format defined by RFC3339.
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
@@ -52,8 +51,10 @@ type AutoScalingConfiguration struct {
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 
-	// The minimum period of time to wait between scaling actions. The cooldown period gives the system time to stabilize
-	// before rescaling. The minimum value is 300 seconds, which is also the default.
+	// For threshold-based autoscaling policies, this value is the minimum period of time to wait between scaling actions.
+	// The cooldown period gives the system time to stabilize before rescaling. The minimum value is 300 seconds, which
+	// is also the default. The cooldown period starts when the instance pool reaches the running state.
+	// For schedule-based autoscaling policies, this value is not used.
 	CoolDownInSeconds *int `mandatory:"false" json:"coolDownInSeconds"`
 
 	// Whether the autoscaling configuration is enabled.

--- a/autoscaling/auto_scaling_configuration_summary.go
+++ b/autoscaling/auto_scaling_configuration_summary.go
@@ -29,15 +29,17 @@ type AutoScalingConfigurationSummary struct {
 
 	Resource Resource `mandatory:"true" json:"resource"`
 
-	// The date and time the AutoScalingConfiguration was created, in the format defined by RFC3339.
+	// The date and time the autoscaling configuration was created, in the format defined by RFC3339.
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
 	// A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// The minimum period of time to wait between scaling actions. The cooldown period gives the system time to stabilize
-	// before rescaling. The minimum value is 300 seconds, which is also the default.
+	// For threshold-based autoscaling policies, this value is the minimum period of time to wait between scaling actions.
+	// The cooldown period gives the system time to stabilize before rescaling. The minimum value is 300 seconds, which
+	// is also the default. The cooldown period starts when the instance pool reaches the running state.
+	// For schedule-based autoscaling policies, this value is not used.
 	CoolDownInSeconds *int `mandatory:"false" json:"coolDownInSeconds"`
 
 	// Whether the autoscaling configuration is enabled.

--- a/autoscaling/auto_scaling_policy.go
+++ b/autoscaling/auto_scaling_policy.go
@@ -21,14 +21,18 @@ import (
 // AutoScalingPolicy Autoscaling policies define the criteria that trigger autoscaling actions and the actions to take.
 // An autoscaling policy is part of an autoscaling configuration. For more information, see
 // Autoscaling (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/autoscalinginstancepools.htm).
+// You can create the following types of autoscaling policies:
+//
+//   - **Schedule-based:** Autoscaling events take place at the specific times that you schedule.
+//   - **Threshold-based:** An autoscaling action is triggered when a performance metric meets or exceeds a threshold.
 type AutoScalingPolicy interface {
-
-	// The capacity requirements of the autoscaling policy.
-	GetCapacity() *Capacity
 
 	// The date and time the autoscaling configuration was created, in the format defined by RFC3339.
 	// Example: `2016-08-25T21:10:29.600Z`
 	GetTimeCreated() *common.SDKTime
+
+	// The capacity requirements of the autoscaling policy.
+	GetCapacity() *Capacity
 
 	// The ID of the autoscaling policy that is assigned after creation.
 	GetId() *string
@@ -36,14 +40,14 @@ type AutoScalingPolicy interface {
 	// A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 	GetDisplayName() *string
 
-	// Boolean field indicating whether this policy is enabled or not.
+	// Whether the autoscaling policy is enabled.
 	GetIsEnabled() *bool
 }
 
 type autoscalingpolicy struct {
 	JsonData    []byte
-	Capacity    *Capacity       `mandatory:"true" json:"capacity"`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+	Capacity    *Capacity       `mandatory:"false" json:"capacity"`
 	Id          *string         `mandatory:"false" json:"id"`
 	DisplayName *string         `mandatory:"false" json:"displayName"`
 	IsEnabled   *bool           `mandatory:"false" json:"isEnabled"`
@@ -61,8 +65,8 @@ func (m *autoscalingpolicy) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	m.Capacity = s.Model.Capacity
 	m.TimeCreated = s.Model.TimeCreated
+	m.Capacity = s.Model.Capacity
 	m.Id = s.Model.Id
 	m.DisplayName = s.Model.DisplayName
 	m.IsEnabled = s.Model.IsEnabled
@@ -93,14 +97,14 @@ func (m *autoscalingpolicy) UnmarshalPolymorphicJSON(data []byte) (interface{}, 
 	}
 }
 
-//GetCapacity returns Capacity
-func (m autoscalingpolicy) GetCapacity() *Capacity {
-	return m.Capacity
-}
-
 //GetTimeCreated returns TimeCreated
 func (m autoscalingpolicy) GetTimeCreated() *common.SDKTime {
 	return m.TimeCreated
+}
+
+//GetCapacity returns Capacity
+func (m autoscalingpolicy) GetCapacity() *Capacity {
+	return m.Capacity
 }
 
 //GetId returns Id

--- a/autoscaling/auto_scaling_policy_summary.go
+++ b/autoscaling/auto_scaling_policy_summary.go
@@ -29,7 +29,7 @@ type AutoScalingPolicySummary struct {
 	// A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// Boolean field indicated whether this policy is enabled or not.
+	// Whether the autoscaling policy is enabled.
 	IsEnabled *bool `mandatory:"false" json:"isEnabled"`
 }
 

--- a/autoscaling/autoscaling_client.go
+++ b/autoscaling/autoscaling_client.go
@@ -206,6 +206,11 @@ func (client AutoScalingClient) createAutoScalingConfiguration(ctx context.Conte
 }
 
 // CreateAutoScalingPolicy Creates an autoscaling policy for the specified autoscaling configuration.
+// You can create the following types of autoscaling policies:
+// - **Schedule-based:** Autoscaling events take place at the specific times that you schedule.
+// - **Threshold-based:** An autoscaling action is triggered when a performance metric meets or exceeds a threshold.
+// An autoscaling configuration can either have multiple schedule-based autoscaling policies, or one
+// threshold-based autoscaling policy.
 //
 // See also
 //

--- a/autoscaling/capacity.go
+++ b/autoscaling/capacity.go
@@ -20,15 +20,22 @@ import (
 // Capacity Capacity limits for the instance pool.
 type Capacity struct {
 
-	// The maximum number of instances the instance pool is allowed to increase to (scale out).
+	// For a threshold-based autoscaling policy, this value is the maximum number of instances the instance pool is allowed
+	// to increase to (scale out).
+	// For a schedule-based autoscaling policy, this value is not used.
 	Max *int `mandatory:"false" json:"max"`
 
-	// The minimum number of instances the instance pool is allowed to decrease to (scale in).
+	// For a threshold-based autoscaling policy, this value is the minimum number of instances the instance pool is allowed
+	// to decrease to (scale in).
+	// For a schedule-based autoscaling policy, this value is not used.
 	Min *int `mandatory:"false" json:"min"`
 
-	// The initial number of instances to launch in the instance pool immediately after autoscaling is
-	// enabled. After autoscaling retrieves performance metrics, the number of instances is automatically adjusted from this
-	// initial number to a number that is based on the limits that you set.
+	// For a threshold-based autoscaling policy, this value is the initial number of instances to launch in the instance pool
+	// immediately after autoscaling is enabled. After autoscaling retrieves performance metrics, the number of
+	// instances is automatically adjusted from this initial number to a number that is based on the limits that
+	// you set.
+	// For a schedule-based autoscaling policy, this value is the target pool size to scale to when executing the schedule
+	// that's defined in the autoscaling policy.
 	Initial *int `mandatory:"false" json:"initial"`
 }
 

--- a/autoscaling/create_auto_scaling_configuration_details.go
+++ b/autoscaling/create_auto_scaling_configuration_details.go
@@ -41,8 +41,10 @@ type CreateAutoScalingConfigurationDetails struct {
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 
-	// The minimum period of time to wait between scaling actions. The cooldown period gives the system time to stabilize
-	// before rescaling. The minimum value is 300 seconds, which is also the default.
+	// For threshold-based autoscaling policies, this value is the minimum period of time to wait between scaling actions.
+	// The cooldown period gives the system time to stabilize before rescaling. The minimum value is 300 seconds, which
+	// is also the default. The cooldown period starts when the instance pool reaches the running state.
+	// For schedule-based autoscaling policies, this value is not used.
 	CoolDownInSeconds *int `mandatory:"false" json:"coolDownInSeconds"`
 
 	// Whether the autoscaling configuration is enabled.

--- a/autoscaling/create_auto_scaling_policy_details.go
+++ b/autoscaling/create_auto_scaling_policy_details.go
@@ -18,10 +18,12 @@ import (
 	"github.com/oracle/oci-go-sdk/v38/common"
 )
 
-// CreateAutoScalingPolicyDetails Creation details for an autoscaling policy.
-// Each autoscaling configuration can have one autoscaling policy.
-// In a threshold-based autoscaling policy, an autoscaling action is triggered when a performance metric meets
+// CreateAutoScalingPolicyDetails Creation details for an autoscaling policy. You can create the following types of autoscaling policies:
+// - **Schedule-based:** Autoscaling events take place at the specific times that you schedule.
+// - **Threshold-based:** An autoscaling action is triggered when a performance metric meets
 // or exceeds a threshold.
+// An autoscaling configuration can either have multiple schedule-based autoscaling policies, or one
+// threshold-based autoscaling policy.
 type CreateAutoScalingPolicyDetails interface {
 
 	// The capacity requirements of the autoscaling policy.
@@ -30,13 +32,13 @@ type CreateAutoScalingPolicyDetails interface {
 	// A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 	GetDisplayName() *string
 
-	// Boolean field indicating whether this policy is enabled or not.
+	// Whether the autoscaling policy is enabled.
 	GetIsEnabled() *bool
 }
 
 type createautoscalingpolicydetails struct {
 	JsonData    []byte
-	Capacity    *Capacity `mandatory:"true" json:"capacity"`
+	Capacity    *Capacity `mandatory:"false" json:"capacity"`
 	DisplayName *string   `mandatory:"false" json:"displayName"`
 	IsEnabled   *bool     `mandatory:"false" json:"isEnabled"`
 	PolicyType  string    `json:"policyType"`

--- a/autoscaling/create_scheduled_policy_details.go
+++ b/autoscaling/create_scheduled_policy_details.go
@@ -19,19 +19,20 @@ import (
 )
 
 // CreateScheduledPolicyDetails Creation details for a schedule-based autoscaling policy.
-// In a schedule-based autoscaling policy, an autoscaling action is triggered when execution time is current.
+// In a schedule-based autoscaling policy, an autoscaling action is triggered at the scheduled execution time.
 type CreateScheduledPolicyDetails struct {
+	ExecutionSchedule ExecutionSchedule `mandatory:"true" json:"executionSchedule"`
 
 	// The capacity requirements of the autoscaling policy.
-	Capacity *Capacity `mandatory:"true" json:"capacity"`
-
-	ExecutionSchedule ExecutionSchedule `mandatory:"true" json:"executionSchedule"`
+	Capacity *Capacity `mandatory:"false" json:"capacity"`
 
 	// A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// Boolean field indicating whether this policy is enabled or not.
+	// Whether the autoscaling policy is enabled.
 	IsEnabled *bool `mandatory:"false" json:"isEnabled"`
+
+	ResourceAction ResourceAction `mandatory:"false" json:"resourceAction"`
 }
 
 //GetCapacity returns Capacity
@@ -70,9 +71,10 @@ func (m CreateScheduledPolicyDetails) MarshalJSON() (buff []byte, e error) {
 // UnmarshalJSON unmarshals from json
 func (m *CreateScheduledPolicyDetails) UnmarshalJSON(data []byte) (e error) {
 	model := struct {
+		Capacity          *Capacity         `json:"capacity"`
 		DisplayName       *string           `json:"displayName"`
 		IsEnabled         *bool             `json:"isEnabled"`
-		Capacity          *Capacity         `json:"capacity"`
+		ResourceAction    resourceaction    `json:"resourceAction"`
 		ExecutionSchedule executionschedule `json:"executionSchedule"`
 	}{}
 
@@ -81,11 +83,21 @@ func (m *CreateScheduledPolicyDetails) UnmarshalJSON(data []byte) (e error) {
 		return
 	}
 	var nn interface{}
+	m.Capacity = model.Capacity
+
 	m.DisplayName = model.DisplayName
 
 	m.IsEnabled = model.IsEnabled
 
-	m.Capacity = model.Capacity
+	nn, e = model.ResourceAction.UnmarshalPolymorphicJSON(model.ResourceAction.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.ResourceAction = nn.(ResourceAction)
+	} else {
+		m.ResourceAction = nil
+	}
 
 	nn, e = model.ExecutionSchedule.UnmarshalPolymorphicJSON(model.ExecutionSchedule.JsonData)
 	if e != nil {

--- a/autoscaling/create_threshold_policy_details.go
+++ b/autoscaling/create_threshold_policy_details.go
@@ -22,16 +22,15 @@ import (
 // In a threshold-based autoscaling policy, an autoscaling action is triggered when a performance metric meets
 // or exceeds a threshold.
 type CreateThresholdPolicyDetails struct {
+	Rules []CreateConditionDetails `mandatory:"true" json:"rules"`
 
 	// The capacity requirements of the autoscaling policy.
-	Capacity *Capacity `mandatory:"true" json:"capacity"`
-
-	Rules []CreateConditionDetails `mandatory:"true" json:"rules"`
+	Capacity *Capacity `mandatory:"false" json:"capacity"`
 
 	// A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// Boolean field indicating whether this policy is enabled or not.
+	// Whether the autoscaling policy is enabled.
 	IsEnabled *bool `mandatory:"false" json:"isEnabled"`
 }
 

--- a/autoscaling/cron_execution_schedule.go
+++ b/autoscaling/cron_execution_schedule.go
@@ -18,13 +18,17 @@ import (
 	"github.com/oracle/oci-go-sdk/v38/common"
 )
 
-// CronExecutionSchedule Specifies the execution schedule of CRON type.
+// CronExecutionSchedule An autoscaling execution schedule that uses a cron expression.
 type CronExecutionSchedule struct {
 
-	// The value representing the execution schedule, as defined by cron format.
+	// A cron expression that represents the time at which to execute the autoscaling policy.
+	// Cron expressions have this format: `<second> <minute> <hour> <day of month> <month> <day of week> <year>`
+	// You can use special characters that are supported with the Quartz cron implementation.
+	// You must specify `0` as the value for seconds.
+	// Example: `0 15 10 ? * *`
 	Expression *string `mandatory:"true" json:"expression"`
 
-	// Specifies the time zone the schedule is in.
+	// The time zone for the execution schedule.
 	Timezone ExecutionScheduleTimezoneEnum `mandatory:"true" json:"timezone"`
 }
 

--- a/autoscaling/execution_schedule.go
+++ b/autoscaling/execution_schedule.go
@@ -18,10 +18,10 @@ import (
 	"github.com/oracle/oci-go-sdk/v38/common"
 )
 
-// ExecutionSchedule Specifies the execution schedule for a policy.
+// ExecutionSchedule An execution schedule for an autoscaling policy.
 type ExecutionSchedule interface {
 
-	// Specifies the time zone the schedule is in.
+	// The time zone for the execution schedule.
 	GetTimezone() ExecutionScheduleTimezoneEnum
 }
 

--- a/autoscaling/list_auto_scaling_configurations_request_response.go
+++ b/autoscaling/list_auto_scaling_configurations_request_response.go
@@ -17,7 +17,7 @@ import (
 type ListAutoScalingConfigurationsRequest struct {
 
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment containing the
-	// resources monitored by the metric that you are searching for. Use tenancyId to search in
+	// resource. Use tenancyId to search in
 	// the root compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 

--- a/autoscaling/resource.go
+++ b/autoscaling/resource.go
@@ -18,7 +18,7 @@ import (
 	"github.com/oracle/oci-go-sdk/v38/common"
 )
 
-// Resource A resource that is managed by an autoscaling configuration. The only supported type is "instancePool."
+// Resource A resource that is managed by an autoscaling configuration. The only supported type is `instancePool`.
 // Each instance pool can have one autoscaling configuration.
 type Resource interface {
 

--- a/autoscaling/resource_action.go
+++ b/autoscaling/resource_action.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Autoscaling API
+//
+// APIs for dynamically scaling Compute resources to meet application requirements. For more information about
+// autoscaling, see Autoscaling (https://docs.cloud.oracle.com/Content/Compute/Tasks/autoscalinginstancepools.htm). For information about the
+// Compute service, see Overview of the Compute Service (https://docs.cloud.oracle.com/Content/Compute/Concepts/computeoverview.htm).
+// **Note:** Autoscaling is not available in US Government Cloud tenancies. For more information, see
+// Oracle Cloud Infrastructure US Government Cloud (https://docs.cloud.oracle.com/Content/General/Concepts/govoverview.htm).
+//
+
+package autoscaling
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// ResourceAction An action that can be executed against a resource.
+type ResourceAction interface {
+}
+
+type resourceaction struct {
+	JsonData   []byte
+	ActionType string `json:"actionType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *resourceaction) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerresourceaction resourceaction
+	s := struct {
+		Model Unmarshalerresourceaction
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.ActionType = s.Model.ActionType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *resourceaction) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.ActionType {
+	case "power":
+		mm := ResourcePowerAction{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m resourceaction) String() string {
+	return common.PointerString(m)
+}

--- a/autoscaling/resource_power_action.go
+++ b/autoscaling/resource_power_action.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Autoscaling API
+//
+// APIs for dynamically scaling Compute resources to meet application requirements. For more information about
+// autoscaling, see Autoscaling (https://docs.cloud.oracle.com/Content/Compute/Tasks/autoscalinginstancepools.htm). For information about the
+// Compute service, see Overview of the Compute Service (https://docs.cloud.oracle.com/Content/Compute/Concepts/computeoverview.htm).
+// **Note:** Autoscaling is not available in US Government Cloud tenancies. For more information, see
+// Oracle Cloud Infrastructure US Government Cloud (https://docs.cloud.oracle.com/Content/General/Concepts/govoverview.htm).
+//
+
+package autoscaling
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// ResourcePowerAction A power action against a resource.
+type ResourcePowerAction struct {
+	Action ResourcePowerActionActionEnum `mandatory:"true" json:"action"`
+}
+
+func (m ResourcePowerAction) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m ResourcePowerAction) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeResourcePowerAction ResourcePowerAction
+	s := struct {
+		DiscriminatorParam string `json:"actionType"`
+		MarshalTypeResourcePowerAction
+	}{
+		"power",
+		(MarshalTypeResourcePowerAction)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// ResourcePowerActionActionEnum Enum with underlying type: string
+type ResourcePowerActionActionEnum string
+
+// Set of constants representing the allowable values for ResourcePowerActionActionEnum
+const (
+	ResourcePowerActionActionStop      ResourcePowerActionActionEnum = "STOP"
+	ResourcePowerActionActionStart     ResourcePowerActionActionEnum = "START"
+	ResourcePowerActionActionSoftreset ResourcePowerActionActionEnum = "SOFTRESET"
+	ResourcePowerActionActionReset     ResourcePowerActionActionEnum = "RESET"
+)
+
+var mappingResourcePowerActionAction = map[string]ResourcePowerActionActionEnum{
+	"STOP":      ResourcePowerActionActionStop,
+	"START":     ResourcePowerActionActionStart,
+	"SOFTRESET": ResourcePowerActionActionSoftreset,
+	"RESET":     ResourcePowerActionActionReset,
+}
+
+// GetResourcePowerActionActionEnumValues Enumerates the set of values for ResourcePowerActionActionEnum
+func GetResourcePowerActionActionEnumValues() []ResourcePowerActionActionEnum {
+	values := make([]ResourcePowerActionActionEnum, 0)
+	for _, v := range mappingResourcePowerActionAction {
+		values = append(values, v)
+	}
+	return values
+}

--- a/autoscaling/scheduled_policy.go
+++ b/autoscaling/scheduled_policy.go
@@ -21,14 +21,15 @@ import (
 // ScheduledPolicy An autoscaling policy that defines execution schedules for an autoscaling configuration.
 type ScheduledPolicy struct {
 
-	// The capacity requirements of the autoscaling policy.
-	Capacity *Capacity `mandatory:"true" json:"capacity"`
-
 	// The date and time the autoscaling configuration was created, in the format defined by RFC3339.
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
+	// The schedule for executing the autoscaling policy.
 	ExecutionSchedule ExecutionSchedule `mandatory:"true" json:"executionSchedule"`
+
+	// The capacity requirements of the autoscaling policy.
+	Capacity *Capacity `mandatory:"false" json:"capacity"`
 
 	// The ID of the autoscaling policy that is assigned after creation.
 	Id *string `mandatory:"false" json:"id"`
@@ -36,8 +37,10 @@ type ScheduledPolicy struct {
 	// A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// Boolean field indicating whether this policy is enabled or not.
+	// Whether the autoscaling policy is enabled.
 	IsEnabled *bool `mandatory:"false" json:"isEnabled"`
+
+	ResourceAction ResourceAction `mandatory:"false" json:"resourceAction"`
 }
 
 //GetCapacity returns Capacity
@@ -86,10 +89,11 @@ func (m ScheduledPolicy) MarshalJSON() (buff []byte, e error) {
 // UnmarshalJSON unmarshals from json
 func (m *ScheduledPolicy) UnmarshalJSON(data []byte) (e error) {
 	model := struct {
+		Capacity          *Capacity         `json:"capacity"`
 		Id                *string           `json:"id"`
 		DisplayName       *string           `json:"displayName"`
 		IsEnabled         *bool             `json:"isEnabled"`
-		Capacity          *Capacity         `json:"capacity"`
+		ResourceAction    resourceaction    `json:"resourceAction"`
 		TimeCreated       *common.SDKTime   `json:"timeCreated"`
 		ExecutionSchedule executionschedule `json:"executionSchedule"`
 	}{}
@@ -99,13 +103,23 @@ func (m *ScheduledPolicy) UnmarshalJSON(data []byte) (e error) {
 		return
 	}
 	var nn interface{}
+	m.Capacity = model.Capacity
+
 	m.Id = model.Id
 
 	m.DisplayName = model.DisplayName
 
 	m.IsEnabled = model.IsEnabled
 
-	m.Capacity = model.Capacity
+	nn, e = model.ResourceAction.UnmarshalPolymorphicJSON(model.ResourceAction.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.ResourceAction = nn.(ResourceAction)
+	} else {
+		m.ResourceAction = nil
+	}
 
 	m.TimeCreated = model.TimeCreated
 

--- a/autoscaling/threshold_policy.go
+++ b/autoscaling/threshold_policy.go
@@ -21,14 +21,14 @@ import (
 // ThresholdPolicy An autoscaling policy that defines threshold-based rules for an autoscaling configuration.
 type ThresholdPolicy struct {
 
-	// The capacity requirements of the autoscaling policy.
-	Capacity *Capacity `mandatory:"true" json:"capacity"`
-
 	// The date and time the autoscaling configuration was created, in the format defined by RFC3339.
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
 	Rules []Condition `mandatory:"true" json:"rules"`
+
+	// The capacity requirements of the autoscaling policy.
+	Capacity *Capacity `mandatory:"false" json:"capacity"`
 
 	// The ID of the autoscaling policy that is assigned after creation.
 	Id *string `mandatory:"false" json:"id"`
@@ -36,7 +36,7 @@ type ThresholdPolicy struct {
 	// A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// Boolean field indicating whether this policy is enabled or not.
+	// Whether the autoscaling policy is enabled.
 	IsEnabled *bool `mandatory:"false" json:"isEnabled"`
 }
 

--- a/autoscaling/update_auto_scaling_configuration_details.go
+++ b/autoscaling/update_auto_scaling_configuration_details.go
@@ -36,8 +36,6 @@ type UpdateAutoScalingConfigurationDetails struct {
 	// Whether the autoscaling configuration is enabled.
 	IsEnabled *bool `mandatory:"false" json:"isEnabled"`
 
-	// The minimum period of time to wait between scaling actions. The cooldown period gives the system time
-	// to stabilize before rescaling. The minimum value is 300 seconds, which is also the default.
 	CoolDownInSeconds *int `mandatory:"false" json:"coolDownInSeconds"`
 }
 

--- a/autoscaling/update_auto_scaling_policy_details.go
+++ b/autoscaling/update_auto_scaling_policy_details.go
@@ -27,7 +27,7 @@ type UpdateAutoScalingPolicyDetails interface {
 	// The capacity requirements of the autoscaling policy.
 	GetCapacity() *Capacity
 
-	// Boolean field indicating whether this policy is enabled or not.
+	// Whether the autoscaling policy is enabled.
 	GetIsEnabled() *bool
 }
 

--- a/autoscaling/update_scheduled_policy_details.go
+++ b/autoscaling/update_scheduled_policy_details.go
@@ -27,10 +27,13 @@ type UpdateScheduledPolicyDetails struct {
 	// The capacity requirements of the autoscaling policy.
 	Capacity *Capacity `mandatory:"false" json:"capacity"`
 
-	// Boolean field indicating whether this policy is enabled or not.
+	// Whether the autoscaling policy is enabled.
 	IsEnabled *bool `mandatory:"false" json:"isEnabled"`
 
+	// The schedule for executing the autoscaling policy.
 	ExecutionSchedule ExecutionSchedule `mandatory:"false" json:"executionSchedule"`
+
+	ResourceAction ResourceAction `mandatory:"false" json:"resourceAction"`
 }
 
 //GetDisplayName returns DisplayName
@@ -73,6 +76,7 @@ func (m *UpdateScheduledPolicyDetails) UnmarshalJSON(data []byte) (e error) {
 		Capacity          *Capacity         `json:"capacity"`
 		IsEnabled         *bool             `json:"isEnabled"`
 		ExecutionSchedule executionschedule `json:"executionSchedule"`
+		ResourceAction    resourceaction    `json:"resourceAction"`
 	}{}
 
 	e = json.Unmarshal(data, &model)
@@ -94,6 +98,16 @@ func (m *UpdateScheduledPolicyDetails) UnmarshalJSON(data []byte) (e error) {
 		m.ExecutionSchedule = nn.(ExecutionSchedule)
 	} else {
 		m.ExecutionSchedule = nil
+	}
+
+	nn, e = model.ResourceAction.UnmarshalPolymorphicJSON(model.ResourceAction.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.ResourceAction = nn.(ResourceAction)
+	} else {
+		m.ResourceAction = nil
 	}
 
 	return

--- a/autoscaling/update_threshold_policy_details.go
+++ b/autoscaling/update_threshold_policy_details.go
@@ -27,7 +27,7 @@ type UpdateThresholdPolicyDetails struct {
 	// The capacity requirements of the autoscaling policy.
 	Capacity *Capacity `mandatory:"false" json:"capacity"`
 
-	// Boolean field indicating whether this policy is enabled or not.
+	// Whether the autoscaling policy is enabled.
 	IsEnabled *bool `mandatory:"false" json:"isEnabled"`
 
 	Rules []UpdateConditionDetails `mandatory:"false" json:"rules"`

--- a/common/version.go
+++ b/common/version.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	major = "38"
-	minor = "0"
+	minor = "1"
 	patch = "0"
 	tag   = ""
 )

--- a/containerengine/cluster.go
+++ b/containerengine/cluster.go
@@ -56,6 +56,9 @@ type Cluster struct {
 
 	// Available Kubernetes versions to which the clusters masters may be upgraded.
 	AvailableKubernetesUpgrades []string `mandatory:"false" json:"availableKubernetesUpgrades"`
+
+	// The image verification policy for signature validation.
+	ImagePolicyConfig *ImagePolicyConfig `mandatory:"false" json:"imagePolicyConfig"`
 }
 
 func (m Cluster) String() string {

--- a/containerengine/cluster_summary.go
+++ b/containerengine/cluster_summary.go
@@ -53,6 +53,9 @@ type ClusterSummary struct {
 
 	// Available Kubernetes versions to which the clusters masters may be upgraded.
 	AvailableKubernetesUpgrades []string `mandatory:"false" json:"availableKubernetesUpgrades"`
+
+	// The image verification policy for signature validation.
+	ImagePolicyConfig *ImagePolicyConfig `mandatory:"false" json:"imagePolicyConfig"`
 }
 
 func (m ClusterSummary) String() string {

--- a/containerengine/create_cluster_details.go
+++ b/containerengine/create_cluster_details.go
@@ -39,6 +39,11 @@ type CreateClusterDetails struct {
 
 	// Optional attributes for the cluster.
 	Options *ClusterCreateOptions `mandatory:"false" json:"options"`
+
+	// The image verification policy for signature validation. Once a policy is created and enabled with
+	// one or more kms keys, the policy will ensure all images deployed has been signed with the key(s)
+	// attached to the policy.
+	ImagePolicyConfig *CreateImagePolicyConfigDetails `mandatory:"false" json:"imagePolicyConfig"`
 }
 
 func (m CreateClusterDetails) String() string {

--- a/containerengine/create_image_policy_config_details.go
+++ b/containerengine/create_image_policy_config_details.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// CreateImagePolicyConfigDetails The properties that define a image verification policy.
+type CreateImagePolicyConfigDetails struct {
+
+	// Whether the image verification policy is enabled. Defaults to false. If set to true, the images will be verified against the policy at runtime.
+	IsPolicyEnabled *bool `mandatory:"false" json:"isPolicyEnabled"`
+
+	// A list of KMS key details.
+	KeyDetails []KeyDetails `mandatory:"false" json:"keyDetails"`
+}
+
+func (m CreateImagePolicyConfigDetails) String() string {
+	return common.PointerString(m)
+}

--- a/containerengine/image_policy_config.go
+++ b/containerengine/image_policy_config.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// ImagePolicyConfig The properties that define a image verification policy.
+type ImagePolicyConfig struct {
+
+	// Whether the image verification policy is enabled. Defaults to false. If set to true, the images will be verified against the policy at runtime.
+	IsPolicyEnabled *bool `mandatory:"false" json:"isPolicyEnabled"`
+
+	// A list of KMS key details.
+	KeyDetails []KeyDetails `mandatory:"false" json:"keyDetails"`
+}
+
+func (m ImagePolicyConfig) String() string {
+	return common.PointerString(m)
+}

--- a/containerengine/key_details.go
+++ b/containerengine/key_details.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// KeyDetails The properties that define the kms keys used by OKE for Image Signature verification.
+type KeyDetails struct {
+
+	// The OCIDs of the KMS key that will be used to verify whether the images are signed by an approved source.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+}
+
+func (m KeyDetails) String() string {
+	return common.PointerString(m)
+}

--- a/containerengine/update_cluster_details.go
+++ b/containerengine/update_cluster_details.go
@@ -25,6 +25,11 @@ type UpdateClusterDetails struct {
 	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
 
 	Options *UpdateClusterOptionsDetails `mandatory:"false" json:"options"`
+
+	// The image verification policy for signature validation. Once a policy is created and enabled with
+	// one or more kms keys, the policy will ensure all images deployed has been signed with the key(s)
+	// attached to the policy.
+	ImagePolicyConfig *UpdateImagePolicyConfigDetails `mandatory:"false" json:"imagePolicyConfig"`
 }
 
 func (m UpdateClusterDetails) String() string {

--- a/containerengine/update_image_policy_config_details.go
+++ b/containerengine/update_image_policy_config_details.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// UpdateImagePolicyConfigDetails The properties that define a image verification policy.
+type UpdateImagePolicyConfigDetails struct {
+
+	// Whether the image verification policy is enabled. Defaults to false. If set to true, the images will be verified against the policy at runtime.
+	IsPolicyEnabled *bool `mandatory:"false" json:"isPolicyEnabled"`
+
+	// A list of KMS key details.
+	KeyDetails []KeyDetails `mandatory:"false" json:"keyDetails"`
+}
+
+func (m UpdateImagePolicyConfigDetails) String() string {
+	return common.PointerString(m)
+}

--- a/core/block_volume_replica.go
+++ b/core/block_volume_replica.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// BlockVolumeReplica An asynchronous replica of a block volume that can then be used to create
+// a new block volume or recover a block volume. For more information, see Overview
+// of Block Volume Replicas (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumereplicas.htm)
+// To use any of the API operations, you must be authorized in an IAM policy.
+// If you're not authorized, talk to an administrator. If you're an administrator
+// who needs to write policies to give users access, see Getting Started with
+// Policies (https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
+// **Warning:** Oracle recommends that you avoid using any confidential information when you
+// supply string values using the API.
+type BlockVolumeReplica struct {
+
+	// The availability domain of the block volume replica.
+	// Example: `Uocm:PHX-AD-1`
+	AvailabilityDomain *string `mandatory:"true" json:"availabilityDomain"`
+
+	// The OCID of the compartment that contains the block volume replica.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// A user-friendly name. Does not have to be unique, and it's changeable.
+	// Avoid entering confidential information.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The block volume replica's Oracle ID (OCID).
+	Id *string `mandatory:"true" json:"id"`
+
+	// The current state of a block volume replica.
+	LifecycleState BlockVolumeReplicaLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// The size of the source block volume, in GBs.
+	SizeInGBs *int64 `mandatory:"true" json:"sizeInGBs"`
+
+	// The date and time the block volume replica was created. Format defined
+	// by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The date and time the block volume replica was last synced from the source block volume.
+	// Format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	TimeLastSynced *common.SDKTime `mandatory:"true" json:"timeLastSynced"`
+
+	// The OCID of the source block volume.
+	BlockVolumeId *string `mandatory:"true" json:"blockVolumeId"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+}
+
+func (m BlockVolumeReplica) String() string {
+	return common.PointerString(m)
+}
+
+// BlockVolumeReplicaLifecycleStateEnum Enum with underlying type: string
+type BlockVolumeReplicaLifecycleStateEnum string
+
+// Set of constants representing the allowable values for BlockVolumeReplicaLifecycleStateEnum
+const (
+	BlockVolumeReplicaLifecycleStateProvisioning BlockVolumeReplicaLifecycleStateEnum = "PROVISIONING"
+	BlockVolumeReplicaLifecycleStateAvailable    BlockVolumeReplicaLifecycleStateEnum = "AVAILABLE"
+	BlockVolumeReplicaLifecycleStateActivating   BlockVolumeReplicaLifecycleStateEnum = "ACTIVATING"
+	BlockVolumeReplicaLifecycleStateTerminating  BlockVolumeReplicaLifecycleStateEnum = "TERMINATING"
+	BlockVolumeReplicaLifecycleStateTerminated   BlockVolumeReplicaLifecycleStateEnum = "TERMINATED"
+	BlockVolumeReplicaLifecycleStateFaulty       BlockVolumeReplicaLifecycleStateEnum = "FAULTY"
+)
+
+var mappingBlockVolumeReplicaLifecycleState = map[string]BlockVolumeReplicaLifecycleStateEnum{
+	"PROVISIONING": BlockVolumeReplicaLifecycleStateProvisioning,
+	"AVAILABLE":    BlockVolumeReplicaLifecycleStateAvailable,
+	"ACTIVATING":   BlockVolumeReplicaLifecycleStateActivating,
+	"TERMINATING":  BlockVolumeReplicaLifecycleStateTerminating,
+	"TERMINATED":   BlockVolumeReplicaLifecycleStateTerminated,
+	"FAULTY":       BlockVolumeReplicaLifecycleStateFaulty,
+}
+
+// GetBlockVolumeReplicaLifecycleStateEnumValues Enumerates the set of values for BlockVolumeReplicaLifecycleStateEnum
+func GetBlockVolumeReplicaLifecycleStateEnumValues() []BlockVolumeReplicaLifecycleStateEnum {
+	values := make([]BlockVolumeReplicaLifecycleStateEnum, 0)
+	for _, v := range mappingBlockVolumeReplicaLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}

--- a/core/block_volume_replica_details.go
+++ b/core/block_volume_replica_details.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// BlockVolumeReplicaDetails Contains the details for the block volume replica
+type BlockVolumeReplicaDetails struct {
+
+	// The availability domain of the block volume replica.
+	// Example: `Uocm:PHX-AD-1`
+	AvailabilityDomain *string `mandatory:"true" json:"availabilityDomain"`
+
+	// The display name of the block volume replica. You may optionally specify a *display name* for
+	// the block volume replica, otherwise a default is provided.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+}
+
+func (m BlockVolumeReplicaDetails) String() string {
+	return common.PointerString(m)
+}

--- a/core/block_volume_replica_info.go
+++ b/core/block_volume_replica_info.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// BlockVolumeReplicaInfo Information about the block volume replica in the destination availability domain.
+type BlockVolumeReplicaInfo struct {
+
+	// The display name of the block volume replica
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The block volume replica's Oracle ID (OCID).
+	BlockVolumeReplicaId *string `mandatory:"true" json:"blockVolumeReplicaId"`
+
+	// The availability domain of the block volume replica.
+	// Example: `Uocm:PHX-AD-1`
+	AvailabilityDomain *string `mandatory:"true" json:"availabilityDomain"`
+}
+
+func (m BlockVolumeReplicaInfo) String() string {
+	return common.PointerString(m)
+}

--- a/core/boot_volume.go
+++ b/core/boot_volume.go
@@ -97,6 +97,9 @@ type BootVolume struct {
 
 	// The number of Volume Performance Units per GB that this boot volume is effectively tuned to when it's idle.
 	AutoTunedVpusPerGB *int64 `mandatory:"false" json:"autoTunedVpusPerGB"`
+
+	// The list of boot volume replicas of this boot volume
+	BootVolumeReplicas []BootVolumeReplicaInfo `mandatory:"false" json:"bootVolumeReplicas"`
 }
 
 func (m BootVolume) String() string {
@@ -119,6 +122,7 @@ func (m *BootVolume) UnmarshalJSON(data []byte) (e error) {
 		KmsKeyId           *string                           `json:"kmsKeyId"`
 		IsAutoTuneEnabled  *bool                             `json:"isAutoTuneEnabled"`
 		AutoTunedVpusPerGB *int64                            `json:"autoTunedVpusPerGB"`
+		BootVolumeReplicas []BootVolumeReplicaInfo           `json:"bootVolumeReplicas"`
 		AvailabilityDomain *string                           `json:"availabilityDomain"`
 		CompartmentId      *string                           `json:"compartmentId"`
 		Id                 *string                           `json:"id"`
@@ -165,6 +169,11 @@ func (m *BootVolume) UnmarshalJSON(data []byte) (e error) {
 	m.IsAutoTuneEnabled = model.IsAutoTuneEnabled
 
 	m.AutoTunedVpusPerGB = model.AutoTunedVpusPerGB
+
+	m.BootVolumeReplicas = make([]BootVolumeReplicaInfo, len(model.BootVolumeReplicas))
+	for i, n := range model.BootVolumeReplicas {
+		m.BootVolumeReplicas[i] = n
+	}
 
 	m.AvailabilityDomain = model.AvailabilityDomain
 

--- a/core/boot_volume_replica.go
+++ b/core/boot_volume_replica.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// BootVolumeReplica An asynchronous replica of a boot volume that can then be used to create
+// a new boot volume or recover a boot volume. For more information, see Overview
+// of Block Volume Replicas (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/bootvolumereplicas.htm)
+// To use any of the API operations, you must be authorized in an IAM policy.
+// If you're not authorized, talk to an administrator. If you're an administrator
+// who needs to write policies to give users access, see Getting Started with
+// Policies (https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
+// **Warning:** Oracle recommends that you avoid using any confidential information when you
+// supply string values using the API.
+type BootVolumeReplica struct {
+
+	// The availability domain of the boot volume replica.
+	// Example: `Uocm:PHX-AD-1`
+	AvailabilityDomain *string `mandatory:"true" json:"availabilityDomain"`
+
+	// The OCID of the compartment that contains the boot volume replica.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// A user-friendly name. Does not have to be unique, and it's changeable.
+	// Avoid entering confidential information.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The boot volume replica's Oracle ID (OCID).
+	Id *string `mandatory:"true" json:"id"`
+
+	// The current state of a boot volume replica.
+	LifecycleState BootVolumeReplicaLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// The size of the source boot volume, in GBs.
+	SizeInGBs *int64 `mandatory:"true" json:"sizeInGBs"`
+
+	// The date and time the boot volume replica was created. Format defined
+	// by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The date and time the boot volume replica was last synced from the source boot volume.
+	// Format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	TimeLastSynced *common.SDKTime `mandatory:"true" json:"timeLastSynced"`
+
+	// The OCID of the source boot volume.
+	BootVolumeId *string `mandatory:"true" json:"bootVolumeId"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// The image OCID used to create the boot volume the replica is replicated from.
+	ImageId *string `mandatory:"false" json:"imageId"`
+}
+
+func (m BootVolumeReplica) String() string {
+	return common.PointerString(m)
+}
+
+// BootVolumeReplicaLifecycleStateEnum Enum with underlying type: string
+type BootVolumeReplicaLifecycleStateEnum string
+
+// Set of constants representing the allowable values for BootVolumeReplicaLifecycleStateEnum
+const (
+	BootVolumeReplicaLifecycleStateProvisioning BootVolumeReplicaLifecycleStateEnum = "PROVISIONING"
+	BootVolumeReplicaLifecycleStateAvailable    BootVolumeReplicaLifecycleStateEnum = "AVAILABLE"
+	BootVolumeReplicaLifecycleStateActivating   BootVolumeReplicaLifecycleStateEnum = "ACTIVATING"
+	BootVolumeReplicaLifecycleStateTerminating  BootVolumeReplicaLifecycleStateEnum = "TERMINATING"
+	BootVolumeReplicaLifecycleStateTerminated   BootVolumeReplicaLifecycleStateEnum = "TERMINATED"
+	BootVolumeReplicaLifecycleStateFaulty       BootVolumeReplicaLifecycleStateEnum = "FAULTY"
+)
+
+var mappingBootVolumeReplicaLifecycleState = map[string]BootVolumeReplicaLifecycleStateEnum{
+	"PROVISIONING": BootVolumeReplicaLifecycleStateProvisioning,
+	"AVAILABLE":    BootVolumeReplicaLifecycleStateAvailable,
+	"ACTIVATING":   BootVolumeReplicaLifecycleStateActivating,
+	"TERMINATING":  BootVolumeReplicaLifecycleStateTerminating,
+	"TERMINATED":   BootVolumeReplicaLifecycleStateTerminated,
+	"FAULTY":       BootVolumeReplicaLifecycleStateFaulty,
+}
+
+// GetBootVolumeReplicaLifecycleStateEnumValues Enumerates the set of values for BootVolumeReplicaLifecycleStateEnum
+func GetBootVolumeReplicaLifecycleStateEnumValues() []BootVolumeReplicaLifecycleStateEnum {
+	values := make([]BootVolumeReplicaLifecycleStateEnum, 0)
+	for _, v := range mappingBootVolumeReplicaLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}

--- a/core/boot_volume_replica_details.go
+++ b/core/boot_volume_replica_details.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// BootVolumeReplicaDetails Contains the details for the boot volume replica
+type BootVolumeReplicaDetails struct {
+
+	// The availability domain of the boot volume replica.
+	// Example: `Uocm:PHX-AD-1`
+	AvailabilityDomain *string `mandatory:"true" json:"availabilityDomain"`
+
+	// The display name of the boot volume replica. You may optionally specify a *display name* for
+	// the boot volume replica, otherwise a default is provided.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+}
+
+func (m BootVolumeReplicaDetails) String() string {
+	return common.PointerString(m)
+}

--- a/core/boot_volume_replica_info.go
+++ b/core/boot_volume_replica_info.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// BootVolumeReplicaInfo Information about the boot volume replica in the destination availability domain.
+type BootVolumeReplicaInfo struct {
+
+	// The display name of the boot volume replica
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The boot volume replica's Oracle ID (OCID).
+	BootVolumeReplicaId *string `mandatory:"true" json:"bootVolumeReplicaId"`
+
+	// The availability domain of the boot volume replica.
+	// Example: `Uocm:PHX-AD-1`
+	AvailabilityDomain *string `mandatory:"true" json:"availabilityDomain"`
+}
+
+func (m BootVolumeReplicaInfo) String() string {
+	return common.PointerString(m)
+}

--- a/core/boot_volume_source_details.go
+++ b/core/boot_volume_source_details.go
@@ -60,6 +60,10 @@ func (m *bootvolumesourcedetails) UnmarshalPolymorphicJSON(data []byte) (interfa
 		mm := BootVolumeSourceFromBootVolumeDetails{}
 		err = json.Unmarshal(data, &mm)
 		return mm, err
+	case "bootVolumeReplica":
+		mm := BootVolumeSourceFromBootVolumeReplicaDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
 	default:
 		return *m, nil
 	}

--- a/core/boot_volume_source_from_boot_volume_replica_details.go
+++ b/core/boot_volume_source_from_boot_volume_replica_details.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// BootVolumeSourceFromBootVolumeReplicaDetails Specifies the source boot volume replica which the boot volume will be created from.
+// The boot volume replica shoulbe be in the same availability domain as the boot volume.
+// Only one volume can be created from a replica at the same time.
+type BootVolumeSourceFromBootVolumeReplicaDetails struct {
+
+	// The OCID of the boot volume replica.
+	Id *string `mandatory:"true" json:"id"`
+}
+
+func (m BootVolumeSourceFromBootVolumeReplicaDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m BootVolumeSourceFromBootVolumeReplicaDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeBootVolumeSourceFromBootVolumeReplicaDetails BootVolumeSourceFromBootVolumeReplicaDetails
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeBootVolumeSourceFromBootVolumeReplicaDetails
+	}{
+		"bootVolumeReplica",
+		(MarshalTypeBootVolumeSourceFromBootVolumeReplicaDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/core/core_blockstorage_client.go
+++ b/core/core_blockstorage_client.go
@@ -1589,6 +1589,60 @@ func (client BlockstorageClient) deleteVolumeKmsKey(ctx context.Context, request
 	return response, err
 }
 
+// GetBlockVolumeReplica Gets information for the specified block volume replica.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/GetBlockVolumeReplica.go.html to see an example of how to use GetBlockVolumeReplica API.
+func (client BlockstorageClient) GetBlockVolumeReplica(ctx context.Context, request GetBlockVolumeReplicaRequest) (response GetBlockVolumeReplicaResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getBlockVolumeReplica, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetBlockVolumeReplicaResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetBlockVolumeReplicaResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetBlockVolumeReplicaResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetBlockVolumeReplicaResponse")
+	}
+	return
+}
+
+// getBlockVolumeReplica implements the OCIOperation interface (enables retrying operations)
+func (client BlockstorageClient) getBlockVolumeReplica(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/blockVolumeReplicas/{blockVolumeReplicaId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetBlockVolumeReplicaResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // GetBootVolume Gets information for the specified boot volume.
 //
 // See also
@@ -1739,6 +1793,60 @@ func (client BlockstorageClient) getBootVolumeKmsKey(ctx context.Context, reques
 	}
 
 	var response GetBootVolumeKmsKeyResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetBootVolumeReplica Gets information for the specified boot volume replica.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/GetBootVolumeReplica.go.html to see an example of how to use GetBootVolumeReplica API.
+func (client BlockstorageClient) GetBootVolumeReplica(ctx context.Context, request GetBootVolumeReplicaRequest) (response GetBootVolumeReplicaResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getBootVolumeReplica, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetBootVolumeReplicaResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetBootVolumeReplicaResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetBootVolumeReplicaResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetBootVolumeReplicaResponse")
+	}
+	return
+}
+
+// getBootVolumeReplica implements the OCIOperation interface (enables retrying operations)
+func (client BlockstorageClient) getBootVolumeReplica(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/bootVolumeReplicas/{bootVolumeReplicaId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetBootVolumeReplicaResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -2185,6 +2293,60 @@ func (client BlockstorageClient) getVolumeKmsKey(ctx context.Context, request co
 	return response, err
 }
 
+// ListBlockVolumeReplicas Lists the block volume replicas in the specified compartment and availability domain.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/ListBlockVolumeReplicas.go.html to see an example of how to use ListBlockVolumeReplicas API.
+func (client BlockstorageClient) ListBlockVolumeReplicas(ctx context.Context, request ListBlockVolumeReplicasRequest) (response ListBlockVolumeReplicasResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listBlockVolumeReplicas, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListBlockVolumeReplicasResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListBlockVolumeReplicasResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListBlockVolumeReplicasResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListBlockVolumeReplicasResponse")
+	}
+	return
+}
+
+// listBlockVolumeReplicas implements the OCIOperation interface (enables retrying operations)
+func (client BlockstorageClient) listBlockVolumeReplicas(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/blockVolumeReplicas")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListBlockVolumeReplicasResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // ListBootVolumeBackups Lists the boot volume backups in the specified compartment. You can filter the results by boot volume.
 //
 // See also
@@ -2227,6 +2389,60 @@ func (client BlockstorageClient) listBootVolumeBackups(ctx context.Context, requ
 	}
 
 	var response ListBootVolumeBackupsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListBootVolumeReplicas Lists the boot volume replicas in the specified compartment and availability domain.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/ListBootVolumeReplicas.go.html to see an example of how to use ListBootVolumeReplicas API.
+func (client BlockstorageClient) ListBootVolumeReplicas(ctx context.Context, request ListBootVolumeReplicasRequest) (response ListBootVolumeReplicasResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listBootVolumeReplicas, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListBootVolumeReplicasResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListBootVolumeReplicasResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListBootVolumeReplicasResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListBootVolumeReplicasResponse")
+	}
+	return
+}
+
+// listBootVolumeReplicas implements the OCIOperation interface (enables retrying operations)
+func (client BlockstorageClient) listBootVolumeReplicas(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/bootVolumeReplicas")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListBootVolumeReplicasResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)

--- a/core/create_boot_volume_details.go
+++ b/core/create_boot_volume_details.go
@@ -65,6 +65,10 @@ type CreateBootVolumeDetails struct {
 
 	// Specifies whether the auto-tune performance is enabled for this boot volume.
 	IsAutoTuneEnabled *bool `mandatory:"false" json:"isAutoTuneEnabled"`
+
+	// The list of boot volume replicas to be enabled for this boot volume
+	// in the specified destination availability domains.
+	BootVolumeReplicas []BootVolumeReplicaDetails `mandatory:"false" json:"bootVolumeReplicas"`
 }
 
 func (m CreateBootVolumeDetails) String() string {
@@ -82,6 +86,7 @@ func (m *CreateBootVolumeDetails) UnmarshalJSON(data []byte) (e error) {
 		SizeInGBs          *int64                            `json:"sizeInGBs"`
 		VpusPerGB          *int64                            `json:"vpusPerGB"`
 		IsAutoTuneEnabled  *bool                             `json:"isAutoTuneEnabled"`
+		BootVolumeReplicas []BootVolumeReplicaDetails        `json:"bootVolumeReplicas"`
 		AvailabilityDomain *string                           `json:"availabilityDomain"`
 		CompartmentId      *string                           `json:"compartmentId"`
 		SourceDetails      bootvolumesourcedetails           `json:"sourceDetails"`
@@ -107,6 +112,11 @@ func (m *CreateBootVolumeDetails) UnmarshalJSON(data []byte) (e error) {
 	m.VpusPerGB = model.VpusPerGB
 
 	m.IsAutoTuneEnabled = model.IsAutoTuneEnabled
+
+	m.BootVolumeReplicas = make([]BootVolumeReplicaDetails, len(model.BootVolumeReplicas))
+	for i, n := range model.BootVolumeReplicas {
+		m.BootVolumeReplicas[i] = n
+	}
 
 	m.AvailabilityDomain = model.AvailabilityDomain
 

--- a/core/create_virtual_circuit_details.go
+++ b/core/create_virtual_circuit_details.go
@@ -38,6 +38,12 @@ type CreateVirtualCircuitDetails struct {
 	// group this virtual circuit will run on.
 	CrossConnectMappings []CrossConnectMapping `mandatory:"false" json:"crossConnectMappings"`
 
+	// The routing policy sets how routing information about the Oracle cloud is shared over a public virtual circuit.
+	// Policies available are: `ORACLE_SERVICE_NETWORK`, `REGIONAL`, `MARKET_LEVEL`, and `GLOBAL`.
+	// See Route Filtering (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/routingonprem.htm#route_filtering) for details.
+	// By default, routing information is shared for all routes in the same market.
+	RoutingPolicy []CreateVirtualCircuitDetailsRoutingPolicyEnum `mandatory:"false" json:"routingPolicy,omitempty"`
+
 	// Deprecated. Instead use `customerAsn`.
 	// If you specify values for both, the request will be rejected.
 	CustomerBgpAsn *int `mandatory:"false" json:"customerBgpAsn"`
@@ -96,6 +102,33 @@ type CreateVirtualCircuitDetails struct {
 
 func (m CreateVirtualCircuitDetails) String() string {
 	return common.PointerString(m)
+}
+
+// CreateVirtualCircuitDetailsRoutingPolicyEnum Enum with underlying type: string
+type CreateVirtualCircuitDetailsRoutingPolicyEnum string
+
+// Set of constants representing the allowable values for CreateVirtualCircuitDetailsRoutingPolicyEnum
+const (
+	CreateVirtualCircuitDetailsRoutingPolicyOracleServiceNetwork CreateVirtualCircuitDetailsRoutingPolicyEnum = "ORACLE_SERVICE_NETWORK"
+	CreateVirtualCircuitDetailsRoutingPolicyRegional             CreateVirtualCircuitDetailsRoutingPolicyEnum = "REGIONAL"
+	CreateVirtualCircuitDetailsRoutingPolicyMarketLevel          CreateVirtualCircuitDetailsRoutingPolicyEnum = "MARKET_LEVEL"
+	CreateVirtualCircuitDetailsRoutingPolicyGlobal               CreateVirtualCircuitDetailsRoutingPolicyEnum = "GLOBAL"
+)
+
+var mappingCreateVirtualCircuitDetailsRoutingPolicy = map[string]CreateVirtualCircuitDetailsRoutingPolicyEnum{
+	"ORACLE_SERVICE_NETWORK": CreateVirtualCircuitDetailsRoutingPolicyOracleServiceNetwork,
+	"REGIONAL":               CreateVirtualCircuitDetailsRoutingPolicyRegional,
+	"MARKET_LEVEL":           CreateVirtualCircuitDetailsRoutingPolicyMarketLevel,
+	"GLOBAL":                 CreateVirtualCircuitDetailsRoutingPolicyGlobal,
+}
+
+// GetCreateVirtualCircuitDetailsRoutingPolicyEnumValues Enumerates the set of values for CreateVirtualCircuitDetailsRoutingPolicyEnum
+func GetCreateVirtualCircuitDetailsRoutingPolicyEnumValues() []CreateVirtualCircuitDetailsRoutingPolicyEnum {
+	values := make([]CreateVirtualCircuitDetailsRoutingPolicyEnum, 0)
+	for _, v := range mappingCreateVirtualCircuitDetailsRoutingPolicy {
+		values = append(values, v)
+	}
+	return values
 }
 
 // CreateVirtualCircuitDetailsTypeEnum Enum with underlying type: string

--- a/core/create_volume_details.go
+++ b/core/create_volume_details.go
@@ -75,6 +75,10 @@ type CreateVolumeDetails struct {
 
 	// Specifies whether the auto-tune performance is enabled for this volume.
 	IsAutoTuneEnabled *bool `mandatory:"false" json:"isAutoTuneEnabled"`
+
+	// The list of block volume replicas to be enabled for this volume
+	// in the specified destination availability domains.
+	BlockVolumeReplicas []BlockVolumeReplicaDetails `mandatory:"false" json:"blockVolumeReplicas"`
 }
 
 func (m CreateVolumeDetails) String() string {
@@ -84,19 +88,20 @@ func (m CreateVolumeDetails) String() string {
 // UnmarshalJSON unmarshals from json
 func (m *CreateVolumeDetails) UnmarshalJSON(data []byte) (e error) {
 	model := struct {
-		BackupPolicyId     *string                           `json:"backupPolicyId"`
-		DefinedTags        map[string]map[string]interface{} `json:"definedTags"`
-		DisplayName        *string                           `json:"displayName"`
-		FreeformTags       map[string]string                 `json:"freeformTags"`
-		KmsKeyId           *string                           `json:"kmsKeyId"`
-		VpusPerGB          *int64                            `json:"vpusPerGB"`
-		SizeInGBs          *int64                            `json:"sizeInGBs"`
-		SizeInMBs          *int64                            `json:"sizeInMBs"`
-		SourceDetails      volumesourcedetails               `json:"sourceDetails"`
-		VolumeBackupId     *string                           `json:"volumeBackupId"`
-		IsAutoTuneEnabled  *bool                             `json:"isAutoTuneEnabled"`
-		AvailabilityDomain *string                           `json:"availabilityDomain"`
-		CompartmentId      *string                           `json:"compartmentId"`
+		BackupPolicyId      *string                           `json:"backupPolicyId"`
+		DefinedTags         map[string]map[string]interface{} `json:"definedTags"`
+		DisplayName         *string                           `json:"displayName"`
+		FreeformTags        map[string]string                 `json:"freeformTags"`
+		KmsKeyId            *string                           `json:"kmsKeyId"`
+		VpusPerGB           *int64                            `json:"vpusPerGB"`
+		SizeInGBs           *int64                            `json:"sizeInGBs"`
+		SizeInMBs           *int64                            `json:"sizeInMBs"`
+		SourceDetails       volumesourcedetails               `json:"sourceDetails"`
+		VolumeBackupId      *string                           `json:"volumeBackupId"`
+		IsAutoTuneEnabled   *bool                             `json:"isAutoTuneEnabled"`
+		BlockVolumeReplicas []BlockVolumeReplicaDetails       `json:"blockVolumeReplicas"`
+		AvailabilityDomain  *string                           `json:"availabilityDomain"`
+		CompartmentId       *string                           `json:"compartmentId"`
 	}{}
 
 	e = json.Unmarshal(data, &model)
@@ -133,6 +138,11 @@ func (m *CreateVolumeDetails) UnmarshalJSON(data []byte) (e error) {
 	m.VolumeBackupId = model.VolumeBackupId
 
 	m.IsAutoTuneEnabled = model.IsAutoTuneEnabled
+
+	m.BlockVolumeReplicas = make([]BlockVolumeReplicaDetails, len(model.BlockVolumeReplicas))
+	for i, n := range model.BlockVolumeReplicas {
+		m.BlockVolumeReplicas[i] = n
+	}
 
 	m.AvailabilityDomain = model.AvailabilityDomain
 

--- a/core/dedicated_vm_host.go
+++ b/core/dedicated_vm_host.go
@@ -70,6 +70,12 @@ type DedicatedVmHost struct {
 	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// The total memory of the dedicated VM host, in GBs.
+	TotalMemoryInGBs *float32 `mandatory:"false" json:"totalMemoryInGBs"`
+
+	// The remaining memory of the dedicated VM host, in GBs.
+	RemainingMemoryInGBs *float32 `mandatory:"false" json:"remainingMemoryInGBs"`
 }
 
 func (m DedicatedVmHost) String() string {

--- a/core/dedicated_vm_host_summary.go
+++ b/core/dedicated_vm_host_summary.go
@@ -58,6 +58,12 @@ type DedicatedVmHostSummary struct {
 	// To get a list of fault domains, use the ListFaultDomains operation in the Identity and Access Management Service API.
 	// Example: `FAULT-DOMAIN-1`
 	FaultDomain *string `mandatory:"false" json:"faultDomain"`
+
+	// The current total memory of the dedicated VM host, in GBs.
+	TotalMemoryInGBs *float32 `mandatory:"false" json:"totalMemoryInGBs"`
+
+	// The current available memory of the dedicated VM host, in GBs.
+	RemainingMemoryInGBs *float32 `mandatory:"false" json:"remainingMemoryInGBs"`
 }
 
 func (m DedicatedVmHostSummary) String() string {

--- a/core/get_block_volume_replica_request_response.go
+++ b/core/get_block_volume_replica_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+	"net/http"
+)
+
+// GetBlockVolumeReplicaRequest wrapper for the GetBlockVolumeReplica operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/GetBlockVolumeReplica.go.html to see an example of how to use GetBlockVolumeReplicaRequest.
+type GetBlockVolumeReplicaRequest struct {
+
+	// The OCID of the block volume replica.
+	BlockVolumeReplicaId *string `mandatory:"true" contributesTo:"path" name:"blockVolumeReplicaId"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetBlockVolumeReplicaRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetBlockVolumeReplicaRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetBlockVolumeReplicaRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetBlockVolumeReplicaResponse wrapper for the GetBlockVolumeReplica operation
+type GetBlockVolumeReplicaResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The BlockVolumeReplica instance
+	BlockVolumeReplica `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetBlockVolumeReplicaResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetBlockVolumeReplicaResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/core/get_boot_volume_replica_request_response.go
+++ b/core/get_boot_volume_replica_request_response.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+	"net/http"
+)
+
+// GetBootVolumeReplicaRequest wrapper for the GetBootVolumeReplica operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/GetBootVolumeReplica.go.html to see an example of how to use GetBootVolumeReplicaRequest.
+type GetBootVolumeReplicaRequest struct {
+
+	// The OCID of the boot volume replica.
+	BootVolumeReplicaId *string `mandatory:"true" contributesTo:"path" name:"bootVolumeReplicaId"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetBootVolumeReplicaRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetBootVolumeReplicaRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetBootVolumeReplicaRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetBootVolumeReplicaResponse wrapper for the GetBootVolumeReplica operation
+type GetBootVolumeReplicaResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The BootVolumeReplica instance
+	BootVolumeReplica `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetBootVolumeReplicaResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetBootVolumeReplicaResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/core/list_block_volume_replicas_request_response.go
+++ b/core/list_block_volume_replicas_request_response.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+	"net/http"
+)
+
+// ListBlockVolumeReplicasRequest wrapper for the ListBlockVolumeReplicas operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/ListBlockVolumeReplicas.go.html to see an example of how to use ListBlockVolumeReplicasRequest.
+type ListBlockVolumeReplicasRequest struct {
+
+	// The name of the availability domain.
+	// Example: `Uocm:PHX-AD-1`
+	AvailabilityDomain *string `mandatory:"true" contributesTo:"query" name:"availabilityDomain"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated
+	// "List" call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// Example: `50`
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List"
+	// call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// A filter to return only resources that match the given display name exactly.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+	// TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+	// sort order is case sensitive.
+	// **Note:** In general, some "List" operations (for example, `ListInstances`) let you
+	// optionally filter by availability domain if the scope of the resource type is within a
+	// single availability domain. If you call one of these "List" operations without specifying
+	// an availability domain, the resources are grouped by availability domain, then sorted.
+	SortBy ListBlockVolumeReplicasSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+	// is case sensitive.
+	SortOrder ListBlockVolumeReplicasSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// A filter to only return resources that match the given lifecycle state. The state value is case-insensitive.
+	LifecycleState BlockVolumeReplicaLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListBlockVolumeReplicasRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListBlockVolumeReplicasRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListBlockVolumeReplicasRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListBlockVolumeReplicasResponse wrapper for the ListBlockVolumeReplicas operation
+type ListBlockVolumeReplicasResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []BlockVolumeReplica instances
+	Items []BlockVolumeReplica `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListBlockVolumeReplicasResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListBlockVolumeReplicasResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListBlockVolumeReplicasSortByEnum Enum with underlying type: string
+type ListBlockVolumeReplicasSortByEnum string
+
+// Set of constants representing the allowable values for ListBlockVolumeReplicasSortByEnum
+const (
+	ListBlockVolumeReplicasSortByTimecreated ListBlockVolumeReplicasSortByEnum = "TIMECREATED"
+	ListBlockVolumeReplicasSortByDisplayname ListBlockVolumeReplicasSortByEnum = "DISPLAYNAME"
+)
+
+var mappingListBlockVolumeReplicasSortBy = map[string]ListBlockVolumeReplicasSortByEnum{
+	"TIMECREATED": ListBlockVolumeReplicasSortByTimecreated,
+	"DISPLAYNAME": ListBlockVolumeReplicasSortByDisplayname,
+}
+
+// GetListBlockVolumeReplicasSortByEnumValues Enumerates the set of values for ListBlockVolumeReplicasSortByEnum
+func GetListBlockVolumeReplicasSortByEnumValues() []ListBlockVolumeReplicasSortByEnum {
+	values := make([]ListBlockVolumeReplicasSortByEnum, 0)
+	for _, v := range mappingListBlockVolumeReplicasSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListBlockVolumeReplicasSortOrderEnum Enum with underlying type: string
+type ListBlockVolumeReplicasSortOrderEnum string
+
+// Set of constants representing the allowable values for ListBlockVolumeReplicasSortOrderEnum
+const (
+	ListBlockVolumeReplicasSortOrderAsc  ListBlockVolumeReplicasSortOrderEnum = "ASC"
+	ListBlockVolumeReplicasSortOrderDesc ListBlockVolumeReplicasSortOrderEnum = "DESC"
+)
+
+var mappingListBlockVolumeReplicasSortOrder = map[string]ListBlockVolumeReplicasSortOrderEnum{
+	"ASC":  ListBlockVolumeReplicasSortOrderAsc,
+	"DESC": ListBlockVolumeReplicasSortOrderDesc,
+}
+
+// GetListBlockVolumeReplicasSortOrderEnumValues Enumerates the set of values for ListBlockVolumeReplicasSortOrderEnum
+func GetListBlockVolumeReplicasSortOrderEnumValues() []ListBlockVolumeReplicasSortOrderEnum {
+	values := make([]ListBlockVolumeReplicasSortOrderEnum, 0)
+	for _, v := range mappingListBlockVolumeReplicasSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/core/list_boot_volume_replicas_request_response.go
+++ b/core/list_boot_volume_replicas_request_response.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/v38/common"
+	"net/http"
+)
+
+// ListBootVolumeReplicasRequest wrapper for the ListBootVolumeReplicas operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/ListBootVolumeReplicas.go.html to see an example of how to use ListBootVolumeReplicasRequest.
+type ListBootVolumeReplicasRequest struct {
+
+	// The name of the availability domain.
+	// Example: `Uocm:PHX-AD-1`
+	AvailabilityDomain *string `mandatory:"true" contributesTo:"query" name:"availabilityDomain"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated
+	// "List" call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// Example: `50`
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List"
+	// call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// A filter to return only resources that match the given display name exactly.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+	// TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+	// sort order is case sensitive.
+	// **Note:** In general, some "List" operations (for example, `ListInstances`) let you
+	// optionally filter by availability domain if the scope of the resource type is within a
+	// single availability domain. If you call one of these "List" operations without specifying
+	// an availability domain, the resources are grouped by availability domain, then sorted.
+	SortBy ListBootVolumeReplicasSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+	// is case sensitive.
+	SortOrder ListBootVolumeReplicasSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// A filter to only return resources that match the given lifecycle state. The state value is case-insensitive.
+	LifecycleState BootVolumeReplicaLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListBootVolumeReplicasRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListBootVolumeReplicasRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListBootVolumeReplicasRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListBootVolumeReplicasResponse wrapper for the ListBootVolumeReplicas operation
+type ListBootVolumeReplicasResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []BootVolumeReplica instances
+	Items []BootVolumeReplica `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListBootVolumeReplicasResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListBootVolumeReplicasResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListBootVolumeReplicasSortByEnum Enum with underlying type: string
+type ListBootVolumeReplicasSortByEnum string
+
+// Set of constants representing the allowable values for ListBootVolumeReplicasSortByEnum
+const (
+	ListBootVolumeReplicasSortByTimecreated ListBootVolumeReplicasSortByEnum = "TIMECREATED"
+	ListBootVolumeReplicasSortByDisplayname ListBootVolumeReplicasSortByEnum = "DISPLAYNAME"
+)
+
+var mappingListBootVolumeReplicasSortBy = map[string]ListBootVolumeReplicasSortByEnum{
+	"TIMECREATED": ListBootVolumeReplicasSortByTimecreated,
+	"DISPLAYNAME": ListBootVolumeReplicasSortByDisplayname,
+}
+
+// GetListBootVolumeReplicasSortByEnumValues Enumerates the set of values for ListBootVolumeReplicasSortByEnum
+func GetListBootVolumeReplicasSortByEnumValues() []ListBootVolumeReplicasSortByEnum {
+	values := make([]ListBootVolumeReplicasSortByEnum, 0)
+	for _, v := range mappingListBootVolumeReplicasSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListBootVolumeReplicasSortOrderEnum Enum with underlying type: string
+type ListBootVolumeReplicasSortOrderEnum string
+
+// Set of constants representing the allowable values for ListBootVolumeReplicasSortOrderEnum
+const (
+	ListBootVolumeReplicasSortOrderAsc  ListBootVolumeReplicasSortOrderEnum = "ASC"
+	ListBootVolumeReplicasSortOrderDesc ListBootVolumeReplicasSortOrderEnum = "DESC"
+)
+
+var mappingListBootVolumeReplicasSortOrder = map[string]ListBootVolumeReplicasSortOrderEnum{
+	"ASC":  ListBootVolumeReplicasSortOrderAsc,
+	"DESC": ListBootVolumeReplicasSortOrderDesc,
+}
+
+// GetListBootVolumeReplicasSortOrderEnumValues Enumerates the set of values for ListBootVolumeReplicasSortOrderEnum
+func GetListBootVolumeReplicasSortOrderEnumValues() []ListBootVolumeReplicasSortOrderEnum {
+	values := make([]ListBootVolumeReplicasSortOrderEnum, 0)
+	for _, v := range mappingListBootVolumeReplicasSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/core/list_dedicated_vm_hosts_request_response.go
+++ b/core/list_dedicated_vm_hosts_request_response.go
@@ -60,6 +60,12 @@ type ListDedicatedVmHostsRequest struct {
 	// is case sensitive.
 	SortOrder ListDedicatedVmHostsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
 
+	// The remaining memory of the dedicated VM host, in GBs.
+	RemainingMemoryInGBsGreaterThanOrEqualTo *float32 `mandatory:"false" contributesTo:"query" name:"remainingMemoryInGBsGreaterThanOrEqualTo"`
+
+	// The available OCPUs of the dedicated VM host.
+	RemainingOcpusGreaterThanOrEqualTo *float32 `mandatory:"false" contributesTo:"query" name:"remainingOcpusGreaterThanOrEqualTo"`
+
 	// Metadata about the request. This information will not be transmitted to the service, but
 	// represents information that the SDK will consume to drive retry behavior.
 	RequestMetadata common.RequestMetadata

--- a/core/update_boot_volume_details.go
+++ b/core/update_boot_volume_details.go
@@ -47,6 +47,10 @@ type UpdateBootVolumeDetails struct {
 
 	// Specifies whether the auto-tune performance is enabled for this boot volume.
 	IsAutoTuneEnabled *bool `mandatory:"false" json:"isAutoTuneEnabled"`
+
+	// The list of boot volume replicas that this boot volume will be updated to have
+	// in the specified destination availability domains.
+	BootVolumeReplicas []BootVolumeReplicaDetails `mandatory:"false" json:"bootVolumeReplicas"`
 }
 
 func (m UpdateBootVolumeDetails) String() string {

--- a/core/update_virtual_circuit_details.go
+++ b/core/update_virtual_circuit_details.go
@@ -33,6 +33,12 @@ type UpdateVirtualCircuitDetails struct {
 	// CrossConnectMapping.
 	CrossConnectMappings []CrossConnectMapping `mandatory:"false" json:"crossConnectMappings"`
 
+	// The routing policy sets how routing information about the Oracle cloud is shared over a public virtual circuit.
+	// Policies available are: `ORACLE_SERVICE_NETWORK`, `REGIONAL`, `MARKET_LEVEL`, and `GLOBAL`.
+	// See Route Filtering (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/routingonprem.htm#route_filtering) for details.
+	// By default, routing information is shared for all routes in the same market.
+	RoutingPolicy []UpdateVirtualCircuitDetailsRoutingPolicyEnum `mandatory:"false" json:"routingPolicy,omitempty"`
+
 	// Deprecated. Instead use `customerAsn`.
 	// If you specify values for both, the request will be rejected.
 	CustomerBgpAsn *int `mandatory:"false" json:"customerBgpAsn"`
@@ -87,6 +93,33 @@ type UpdateVirtualCircuitDetails struct {
 
 func (m UpdateVirtualCircuitDetails) String() string {
 	return common.PointerString(m)
+}
+
+// UpdateVirtualCircuitDetailsRoutingPolicyEnum Enum with underlying type: string
+type UpdateVirtualCircuitDetailsRoutingPolicyEnum string
+
+// Set of constants representing the allowable values for UpdateVirtualCircuitDetailsRoutingPolicyEnum
+const (
+	UpdateVirtualCircuitDetailsRoutingPolicyOracleServiceNetwork UpdateVirtualCircuitDetailsRoutingPolicyEnum = "ORACLE_SERVICE_NETWORK"
+	UpdateVirtualCircuitDetailsRoutingPolicyRegional             UpdateVirtualCircuitDetailsRoutingPolicyEnum = "REGIONAL"
+	UpdateVirtualCircuitDetailsRoutingPolicyMarketLevel          UpdateVirtualCircuitDetailsRoutingPolicyEnum = "MARKET_LEVEL"
+	UpdateVirtualCircuitDetailsRoutingPolicyGlobal               UpdateVirtualCircuitDetailsRoutingPolicyEnum = "GLOBAL"
+)
+
+var mappingUpdateVirtualCircuitDetailsRoutingPolicy = map[string]UpdateVirtualCircuitDetailsRoutingPolicyEnum{
+	"ORACLE_SERVICE_NETWORK": UpdateVirtualCircuitDetailsRoutingPolicyOracleServiceNetwork,
+	"REGIONAL":               UpdateVirtualCircuitDetailsRoutingPolicyRegional,
+	"MARKET_LEVEL":           UpdateVirtualCircuitDetailsRoutingPolicyMarketLevel,
+	"GLOBAL":                 UpdateVirtualCircuitDetailsRoutingPolicyGlobal,
+}
+
+// GetUpdateVirtualCircuitDetailsRoutingPolicyEnumValues Enumerates the set of values for UpdateVirtualCircuitDetailsRoutingPolicyEnum
+func GetUpdateVirtualCircuitDetailsRoutingPolicyEnumValues() []UpdateVirtualCircuitDetailsRoutingPolicyEnum {
+	values := make([]UpdateVirtualCircuitDetailsRoutingPolicyEnum, 0)
+	for _, v := range mappingUpdateVirtualCircuitDetailsRoutingPolicy {
+		values = append(values, v)
+	}
+	return values
 }
 
 // UpdateVirtualCircuitDetailsProviderStateEnum Enum with underlying type: string

--- a/core/update_volume_details.go
+++ b/core/update_volume_details.go
@@ -48,6 +48,10 @@ type UpdateVolumeDetails struct {
 
 	// Specifies whether the auto-tune performance is enabled for this volume.
 	IsAutoTuneEnabled *bool `mandatory:"false" json:"isAutoTuneEnabled"`
+
+	// The list of block volume replicas that this volume will be updated to have
+	// in the specified destination availability domains.
+	BlockVolumeReplicas []BlockVolumeReplicaDetails `mandatory:"false" json:"blockVolumeReplicas"`
 }
 
 func (m UpdateVolumeDetails) String() string {

--- a/core/virtual_circuit.go
+++ b/core/virtual_circuit.go
@@ -56,6 +56,12 @@ type VirtualCircuit struct {
 	// virtual circuit.
 	CrossConnectMappings []CrossConnectMapping `mandatory:"false" json:"crossConnectMappings"`
 
+	// The routing policy sets how routing information about the Oracle cloud is shared over a public virtual circuit.
+	// Policies available are: `ORACLE_SERVICE_NETWORK`, `REGIONAL`, `MARKET_LEVEL`, and `GLOBAL`.
+	// See Route Filtering (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/routingonprem.htm#route_filtering) for details.
+	// By default, routing information is shared for all routes in the same market.
+	RoutingPolicy []VirtualCircuitRoutingPolicyEnum `mandatory:"false" json:"routingPolicy,omitempty"`
+
 	// Deprecated. Instead use `customerAsn`.
 	// If you specify values for both, the request will be rejected.
 	CustomerBgpAsn *int `mandatory:"false" json:"customerBgpAsn"`
@@ -188,6 +194,33 @@ var mappingVirtualCircuitBgpSessionState = map[string]VirtualCircuitBgpSessionSt
 func GetVirtualCircuitBgpSessionStateEnumValues() []VirtualCircuitBgpSessionStateEnum {
 	values := make([]VirtualCircuitBgpSessionStateEnum, 0)
 	for _, v := range mappingVirtualCircuitBgpSessionState {
+		values = append(values, v)
+	}
+	return values
+}
+
+// VirtualCircuitRoutingPolicyEnum Enum with underlying type: string
+type VirtualCircuitRoutingPolicyEnum string
+
+// Set of constants representing the allowable values for VirtualCircuitRoutingPolicyEnum
+const (
+	VirtualCircuitRoutingPolicyOracleServiceNetwork VirtualCircuitRoutingPolicyEnum = "ORACLE_SERVICE_NETWORK"
+	VirtualCircuitRoutingPolicyRegional             VirtualCircuitRoutingPolicyEnum = "REGIONAL"
+	VirtualCircuitRoutingPolicyMarketLevel          VirtualCircuitRoutingPolicyEnum = "MARKET_LEVEL"
+	VirtualCircuitRoutingPolicyGlobal               VirtualCircuitRoutingPolicyEnum = "GLOBAL"
+)
+
+var mappingVirtualCircuitRoutingPolicy = map[string]VirtualCircuitRoutingPolicyEnum{
+	"ORACLE_SERVICE_NETWORK": VirtualCircuitRoutingPolicyOracleServiceNetwork,
+	"REGIONAL":               VirtualCircuitRoutingPolicyRegional,
+	"MARKET_LEVEL":           VirtualCircuitRoutingPolicyMarketLevel,
+	"GLOBAL":                 VirtualCircuitRoutingPolicyGlobal,
+}
+
+// GetVirtualCircuitRoutingPolicyEnumValues Enumerates the set of values for VirtualCircuitRoutingPolicyEnum
+func GetVirtualCircuitRoutingPolicyEnumValues() []VirtualCircuitRoutingPolicyEnum {
+	values := make([]VirtualCircuitRoutingPolicyEnum, 0)
+	for _, v := range mappingVirtualCircuitRoutingPolicy {
 		values = append(values, v)
 	}
 	return values

--- a/core/volume.go
+++ b/core/volume.go
@@ -94,6 +94,9 @@ type Volume struct {
 
 	// The number of Volume Performance Units per GB that this volume is effectively tuned to when it's idle.
 	AutoTunedVpusPerGB *int64 `mandatory:"false" json:"autoTunedVpusPerGB"`
+
+	// The list of block volume replicas of this volume.
+	BlockVolumeReplicas []BlockVolumeReplicaInfo `mandatory:"false" json:"blockVolumeReplicas"`
 }
 
 func (m Volume) String() string {
@@ -103,24 +106,25 @@ func (m Volume) String() string {
 // UnmarshalJSON unmarshals from json
 func (m *Volume) UnmarshalJSON(data []byte) (e error) {
 	model := struct {
-		DefinedTags        map[string]map[string]interface{} `json:"definedTags"`
-		FreeformTags       map[string]string                 `json:"freeformTags"`
-		SystemTags         map[string]map[string]interface{} `json:"systemTags"`
-		IsHydrated         *bool                             `json:"isHydrated"`
-		KmsKeyId           *string                           `json:"kmsKeyId"`
-		VpusPerGB          *int64                            `json:"vpusPerGB"`
-		SizeInGBs          *int64                            `json:"sizeInGBs"`
-		SourceDetails      volumesourcedetails               `json:"sourceDetails"`
-		VolumeGroupId      *string                           `json:"volumeGroupId"`
-		IsAutoTuneEnabled  *bool                             `json:"isAutoTuneEnabled"`
-		AutoTunedVpusPerGB *int64                            `json:"autoTunedVpusPerGB"`
-		AvailabilityDomain *string                           `json:"availabilityDomain"`
-		CompartmentId      *string                           `json:"compartmentId"`
-		DisplayName        *string                           `json:"displayName"`
-		Id                 *string                           `json:"id"`
-		LifecycleState     VolumeLifecycleStateEnum          `json:"lifecycleState"`
-		SizeInMBs          *int64                            `json:"sizeInMBs"`
-		TimeCreated        *common.SDKTime                   `json:"timeCreated"`
+		DefinedTags         map[string]map[string]interface{} `json:"definedTags"`
+		FreeformTags        map[string]string                 `json:"freeformTags"`
+		SystemTags          map[string]map[string]interface{} `json:"systemTags"`
+		IsHydrated          *bool                             `json:"isHydrated"`
+		KmsKeyId            *string                           `json:"kmsKeyId"`
+		VpusPerGB           *int64                            `json:"vpusPerGB"`
+		SizeInGBs           *int64                            `json:"sizeInGBs"`
+		SourceDetails       volumesourcedetails               `json:"sourceDetails"`
+		VolumeGroupId       *string                           `json:"volumeGroupId"`
+		IsAutoTuneEnabled   *bool                             `json:"isAutoTuneEnabled"`
+		AutoTunedVpusPerGB  *int64                            `json:"autoTunedVpusPerGB"`
+		BlockVolumeReplicas []BlockVolumeReplicaInfo          `json:"blockVolumeReplicas"`
+		AvailabilityDomain  *string                           `json:"availabilityDomain"`
+		CompartmentId       *string                           `json:"compartmentId"`
+		DisplayName         *string                           `json:"displayName"`
+		Id                  *string                           `json:"id"`
+		LifecycleState      VolumeLifecycleStateEnum          `json:"lifecycleState"`
+		SizeInMBs           *int64                            `json:"sizeInMBs"`
+		TimeCreated         *common.SDKTime                   `json:"timeCreated"`
 	}{}
 
 	e = json.Unmarshal(data, &model)
@@ -157,6 +161,11 @@ func (m *Volume) UnmarshalJSON(data []byte) (e error) {
 	m.IsAutoTuneEnabled = model.IsAutoTuneEnabled
 
 	m.AutoTunedVpusPerGB = model.AutoTunedVpusPerGB
+
+	m.BlockVolumeReplicas = make([]BlockVolumeReplicaInfo, len(model.BlockVolumeReplicas))
+	for i, n := range model.BlockVolumeReplicas {
+		m.BlockVolumeReplicas[i] = n
+	}
 
 	m.AvailabilityDomain = model.AvailabilityDomain
 

--- a/core/volume_source_details.go
+++ b/core/volume_source_details.go
@@ -54,6 +54,10 @@ func (m *volumesourcedetails) UnmarshalPolymorphicJSON(data []byte) (interface{}
 
 	var err error
 	switch m.Type {
+	case "blockVolumeReplica":
+		mm := VolumeSourceFromBlockVolumeReplicaDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
 	case "volume":
 		mm := VolumeSourceFromVolumeDetails{}
 		err = json.Unmarshal(data, &mm)

--- a/core/volume_source_from_block_volume_replica_details.go
+++ b/core/volume_source_from_block_volume_replica_details.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/v38/common"
+)
+
+// VolumeSourceFromBlockVolumeReplicaDetails Specifies the source block volume replica which the block volume will be created from.
+// The block volume replica shoulbe be in the same availability domain as the block volume.
+// Only one volume can be created from a replica at the same time.
+type VolumeSourceFromBlockVolumeReplicaDetails struct {
+
+	// The OCID of the block volume replica.
+	Id *string `mandatory:"true" json:"id"`
+}
+
+func (m VolumeSourceFromBlockVolumeReplicaDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m VolumeSourceFromBlockVolumeReplicaDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeVolumeSourceFromBlockVolumeReplicaDetails VolumeSourceFromBlockVolumeReplicaDetails
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeVolumeSourceFromBlockVolumeReplicaDetails
+	}{
+		"blockVolumeReplica",
+		(MarshalTypeVolumeSourceFromBlockVolumeReplicaDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/database/create_database_software_image_details.go
+++ b/database/create_database_software_image_details.go
@@ -62,11 +62,13 @@ type CreateDatabaseSoftwareImageDetailsImageShapeFamilyEnum string
 const (
 	CreateDatabaseSoftwareImageDetailsImageShapeFamilyVmBmShape    CreateDatabaseSoftwareImageDetailsImageShapeFamilyEnum = "VM_BM_SHAPE"
 	CreateDatabaseSoftwareImageDetailsImageShapeFamilyExadataShape CreateDatabaseSoftwareImageDetailsImageShapeFamilyEnum = "EXADATA_SHAPE"
+	CreateDatabaseSoftwareImageDetailsImageShapeFamilyExaccShape   CreateDatabaseSoftwareImageDetailsImageShapeFamilyEnum = "EXACC_SHAPE"
 )
 
 var mappingCreateDatabaseSoftwareImageDetailsImageShapeFamily = map[string]CreateDatabaseSoftwareImageDetailsImageShapeFamilyEnum{
 	"VM_BM_SHAPE":   CreateDatabaseSoftwareImageDetailsImageShapeFamilyVmBmShape,
 	"EXADATA_SHAPE": CreateDatabaseSoftwareImageDetailsImageShapeFamilyExadataShape,
+	"EXACC_SHAPE":   CreateDatabaseSoftwareImageDetailsImageShapeFamilyExaccShape,
 }
 
 // GetCreateDatabaseSoftwareImageDetailsImageShapeFamilyEnumValues Enumerates the set of values for CreateDatabaseSoftwareImageDetailsImageShapeFamilyEnum

--- a/database/database_software_image.go
+++ b/database/database_software_image.go
@@ -140,11 +140,13 @@ type DatabaseSoftwareImageImageShapeFamilyEnum string
 const (
 	DatabaseSoftwareImageImageShapeFamilyVmBmShape    DatabaseSoftwareImageImageShapeFamilyEnum = "VM_BM_SHAPE"
 	DatabaseSoftwareImageImageShapeFamilyExadataShape DatabaseSoftwareImageImageShapeFamilyEnum = "EXADATA_SHAPE"
+	DatabaseSoftwareImageImageShapeFamilyExaccShape   DatabaseSoftwareImageImageShapeFamilyEnum = "EXACC_SHAPE"
 )
 
 var mappingDatabaseSoftwareImageImageShapeFamily = map[string]DatabaseSoftwareImageImageShapeFamilyEnum{
 	"VM_BM_SHAPE":   DatabaseSoftwareImageImageShapeFamilyVmBmShape,
 	"EXADATA_SHAPE": DatabaseSoftwareImageImageShapeFamilyExadataShape,
+	"EXACC_SHAPE":   DatabaseSoftwareImageImageShapeFamilyExaccShape,
 }
 
 // GetDatabaseSoftwareImageImageShapeFamilyEnumValues Enumerates the set of values for DatabaseSoftwareImageImageShapeFamilyEnum

--- a/database/database_software_image_summary.go
+++ b/database/database_software_image_summary.go
@@ -143,11 +143,13 @@ type DatabaseSoftwareImageSummaryImageShapeFamilyEnum string
 const (
 	DatabaseSoftwareImageSummaryImageShapeFamilyVmBmShape    DatabaseSoftwareImageSummaryImageShapeFamilyEnum = "VM_BM_SHAPE"
 	DatabaseSoftwareImageSummaryImageShapeFamilyExadataShape DatabaseSoftwareImageSummaryImageShapeFamilyEnum = "EXADATA_SHAPE"
+	DatabaseSoftwareImageSummaryImageShapeFamilyExaccShape   DatabaseSoftwareImageSummaryImageShapeFamilyEnum = "EXACC_SHAPE"
 )
 
 var mappingDatabaseSoftwareImageSummaryImageShapeFamily = map[string]DatabaseSoftwareImageSummaryImageShapeFamilyEnum{
 	"VM_BM_SHAPE":   DatabaseSoftwareImageSummaryImageShapeFamilyVmBmShape,
 	"EXADATA_SHAPE": DatabaseSoftwareImageSummaryImageShapeFamilyExadataShape,
+	"EXACC_SHAPE":   DatabaseSoftwareImageSummaryImageShapeFamilyExaccShape,
 }
 
 // GetDatabaseSoftwareImageSummaryImageShapeFamilyEnumValues Enumerates the set of values for DatabaseSoftwareImageSummaryImageShapeFamilyEnum

--- a/example/container_image_signing/example.go
+++ b/example/container_image_signing/example.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+package example
+
+import (
+	"context"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v38/artifacts"
+	"github.com/oracle/oci-go-sdk/v38/common"
+	"github.com/oracle/oci-go-sdk/v38/example/helpers"
+)
+
+func main() {
+	configProvider := common.DefaultConfigProvider()
+	ctx := context.Background()
+
+	// Create artifact client
+	artifactClient, artifactError := artifacts.NewArtifactsClientWithConfigurationProvider(configProvider)
+	helpers.FatalIfError(artifactError)
+
+	// Upload Image and Signature Flow
+	kmsKeyId := "ocid1.key.oc1..exampleuniqueID"
+	kmsKeyVersionId := "ocid1.keyversion.oc1..exampleuniqueID"
+	signingAlgo := "SHA_512_RSA_PKCS_PSS"
+	compartmentId := "ocid1.compartment.oc1..exampleuniqueID"
+	imageId := "ocid1.containerimage.oc1..exampleuniqueID"
+	description := "Image built by TC"
+	metadata := "{\"buildNumber\":\"123\"}"
+
+	signature, err := SignAndUploadContainerImageSignatureMetadata(ctx, artifactClient, configProvider, kmsKeyId, kmsKeyVersionId, signingAlgo, compartmentId, imageId, description, metadata)
+	helpers.FatalIfError(err)
+	common.Logf(fmt.Sprintf("A signature has been successfully uploaded: %s", *signature))
+
+	// Pull Image and Verify Signature Flow
+	repoName := "repo-name"
+	imageDigest := "sha256:12345"
+	trustedKeys := []string{"ocid1.key.oc1..keyId1", "ocid1.key.oc1..keyId2"}
+
+	verified, err := GetAndVerifyImageSignatureMetadata(ctx, artifactClient, configProvider, compartmentId, false, repoName, imageDigest, trustedKeys)
+	helpers.FatalIfError(err)
+	if verified {
+		common.Logf("At least one of the signatures is verified")
+	} else {
+		common.Logf("None of the signatures is verified")
+	}
+}

--- a/example/container_image_signing/utils.go
+++ b/example/container_image_signing/utils.go
@@ -1,0 +1,385 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+package example
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v38/artifacts"
+	"github.com/oracle/oci-go-sdk/v38/common"
+	"github.com/oracle/oci-go-sdk/v38/keymanagement"
+	"regexp"
+	"strings"
+)
+
+/*
+SignAndUploadContainerImageSignatureMetadata calls KMS to sign the message then calls OCIR to upload the returned signature
+  Description: Sign a container image and upload the signature to the image
+  Response: The signed container image signature metadata.
+  Parameters:
+   - kmsKeyId:
+  	  description: The OCID of the kmsKeyId used to sign the container image. eg) ocid1.key.oc1..exampleuniqueID
+  	  maxLength: 255
+  	  minLength: 1
+   - kmsKeyVersionId:
+  	  description: The OCID of the kmsKeyVersionId used to sign the container image. eg) ocid1.keyversion.oc1..exampleuniqueID
+  	  maxLength: 255
+  	  minLength: 1
+   - signingAlgorithm:
+  	  - description: The algorithm to be used for signing. These are the only supported signing algorithms for container images.
+  	  	 - SHA_224_RSA_PKCS_PSS
+  	  	 - SHA_256_RSA_PKCS_PSS
+  	  	 - SHA_384_RSA_PKCS_PSS
+  	  	 - SHA_512_RSA_PKCS_PSS
+   - compartmentId:
+  	  description: The OCID of the compartment in which the container repository exists. eg) ocid1.compartment.oc1..exampleuniqueID
+  	  maxLength: 100
+  	  minLength: 1
+   - imageId:
+  	  description: The OCID of the container image. eg) ocid1.containerimage.oc1..exampleuniqueID
+  	  maxLength: 255
+  	  minLength: 1
+   - repoPath:
+  	  description The docker repository path. eg) odx-registry/busybox
+   - imageDigest:
+  	  description: The sha256 digest of the docker image. eg) sha256:12345
+   - description:
+  	  description: An user inputted message.
+   - metadata:
+  	  description: An user defined information about the container image in JSON format eg) {"buildNumber":"123"}
+  	  restriction:
+  	   - should only contains alphanumeric key strings.
+  	   - should be alphabetically sorted.
+  	   - should not have whitespaces or escape characters.
+*/
+func SignAndUploadContainerImageSignatureMetadata(ctx context.Context, artifactClient artifacts.ArtifactsClient, configProvider common.ConfigurationProvider, kmsKeyId string, kmsKeyVersionId string, signingAlgorithm string, compartmentId string, imageId string, description string, metadata string) (*artifacts.ContainerImageSignature, error) {
+	signingAlgoKms := mappingSignDataDetailsSigningAlgorithm[signingAlgorithm]
+	signingAlgoOcir := mappingCreateContainerImageSignatureDetailsSigningAlgorithm[signingAlgorithm]
+
+	region, err := configProvider.Region()
+	if err != nil {
+		return nil, err
+	}
+
+	// Create KMS client
+	vaultCryptoClient, cryptoClientError := buildVaultCryptoClient(configProvider, kmsKeyId, region)
+	if cryptoClientError != nil {
+		return nil, cryptoClientError
+	}
+
+	// Get container image metadata
+	common.Debugf("Obtaining container image metadata by the image ID")
+	containerImageMetadata, err := getContainerImageMetadata(ctx, artifactClient, imageId)
+	if err != nil {
+		return nil, err
+	}
+	common.Debugf(fmt.Sprintf("Container image metadata: %s", *containerImageMetadata))
+
+	// Generate message
+	message := Message{
+		Description:      description,
+		ImageDigest:      *containerImageMetadata.Digest,
+		KmsKeyId:         kmsKeyId,
+		KmsKeyVersionId:  kmsKeyVersionId,
+		Metadata:         metadata,
+		Region:           region,
+		RepositoryName:   *containerImageMetadata.RepositoryName,
+		SigningAlgorithm: signingAlgorithm,
+	}
+
+	jsonByte, err := json.Marshal(message)
+	if err != nil {
+		return nil, err
+	}
+	encodedJson := base64.StdEncoding.EncodeToString(jsonByte)
+
+	// Sign image digest
+	common.Debugf("Generating signature")
+	signedData, err := signContainerImage(ctx, vaultCryptoClient, encodedJson, kmsKeyId, kmsKeyVersionId, signingAlgoKms)
+	if err != nil {
+		return nil, err
+	}
+	common.Debugf(fmt.Sprintf("Signature: %s", *signedData.Signature))
+
+	// Upload signature metadata
+	common.Debugf("Uploading signature")
+	containerImageSignatureUploaded, err := uploadSignatureMetadata(ctx, artifactClient, compartmentId, imageId, kmsKeyId, kmsKeyVersionId, signingAlgoOcir, encodedJson, *signedData.Signature)
+	if err != nil {
+		return nil, err
+	}
+	common.Debugf(fmt.Sprintf("Uploaded signature: %s\nMessage: %s\nID: %s\n", *containerImageSignatureUploaded.Signature, *containerImageSignatureUploaded.Message, *containerImageSignatureUploaded.Id))
+
+	return containerImageSignatureUploaded, err
+}
+
+/*
+GetAndVerifyImageSignatureMetadata calls OCIR to list all the signatures satisfying the user provided criterion then calls KMS to verify the returned signatures
+  Description: Fetch a container image signature metadata and verity the signature
+  Response: Boolean to indicate if any of the signatures of the container image is verified
+  Parameters:
+   - compartmentId:
+	  description: The OCID of the compartment in which the container repository exists. eg) ocid1.compartment.oc1..exampleuniqueID
+	  maxLength: 100
+	  minLength: 1
+   - compartmentIdInSubtree:
+	  description: When set to true, the hierarchy of compartments is traversed
+   - repositoryName:
+	  description: The repository name in which the container image exists eg) busybox
+   - imageDigest:
+	  description: The sha256 digest of the docker image. eg) sha256:12345
+   - trustedKeys:
+	  description: List of OCIDs of the kmsKeyId used to sign the container image.
+*/
+func GetAndVerifyImageSignatureMetadata(ctx context.Context, artifactClient artifacts.ArtifactsClient, configProvider common.ConfigurationProvider, compartmentId string, compartmentIdInSubtree bool, repositoryName string, imageDigest string, trustedKeys []string) (bool, error) {
+	return getAndVerifyImageSignatureMetadataHelper(ctx, artifactClient, configProvider, compartmentId, compartmentIdInSubtree, repositoryName, imageDigest, trustedKeys, "")
+}
+
+// getAndVerifyImageSignatureMetadataHelper is a helper function of GetAndVerifyImageSignatureMetadata
+func getAndVerifyImageSignatureMetadataHelper(ctx context.Context, artifactClient artifacts.ArtifactsClient, configProvider common.ConfigurationProvider, compartmentId string, compartmentIdInSubtree bool, repositoryName string, imageDigest string, trustedKeys []string, page string) (bool, error) {
+	// Fetch signature metadata
+	common.Debugf("Fetching signatures")
+	signatureCollection, nextPage, listErr := listContainerImageSignaturesWithRepoPath(ctx, artifactClient, compartmentId, compartmentIdInSubtree, repositoryName, imageDigest, page)
+	if listErr != nil {
+		return false, listErr
+	}
+	common.Debugf(fmt.Sprintf("Fetched signature: %d signatures in compartment %s with image URL: %s:%s. Remaining count %d", len(signatureCollection.Items), compartmentId, repositoryName, imageDigest, *signatureCollection.RemainingItemsCount))
+
+	// filter out the keys
+	ContainerImageSignatureSummaries := filterItemByTrustedKeys(signatureCollection.Items, trustedKeys)
+	common.Debugf(fmt.Sprintf("Filtered out %d signatures by the trusted keys", len(signatureCollection.Items)-len(ContainerImageSignatureSummaries)))
+
+	// Verify signature
+	common.Debugf("Verifying signature")
+	verified, verifyErr := verifySignatures(ctx, configProvider, ContainerImageSignatureSummaries)
+
+	if verifyErr != nil {
+		return false, verifyErr
+	} else if !verified && nextPage != "" {
+		return getAndVerifyImageSignatureMetadataHelper(ctx, artifactClient, configProvider, compartmentId, compartmentIdInSubtree, repositoryName, imageDigest, trustedKeys, nextPage)
+	} else {
+		return verified, nil
+	}
+}
+
+// signContainerImage returns the signature of the provided message signed with the provided keyId, keyVersionId, and signingAlgorithm
+func signContainerImage(ctx context.Context, client keymanagement.KmsCryptoClient, message string, keyId string, keyVersionId string, signingAlgorithm keymanagement.SignDataDetailsSigningAlgorithmEnum) (*keymanagement.SignedData, error) {
+	signDataDetails := keymanagement.SignDataDetails{
+		Message:          &message,
+		KeyId:            &keyId,
+		KeyVersionId:     &keyVersionId,
+		SigningAlgorithm: signingAlgorithm,
+		MessageType:      keymanagement.SignDataDetailsMessageTypeRaw,
+	}
+
+	request := keymanagement.SignRequest{
+		SignDataDetails: signDataDetails,
+	}
+
+	response, err := client.Sign(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.SignedData, err
+}
+
+// getContainerImageMetadata returns ...
+func getContainerImageMetadata(ctx context.Context, artifactClient artifacts.ArtifactsClient, imageId string) (*artifacts.ContainerImage, error) {
+	request := artifacts.GetContainerImageRequest{
+		ImageId: &imageId,
+	}
+
+	response, err := artifactClient.GetContainerImage(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.ContainerImage, err
+}
+
+// uploadSignatureMetadata uploads the signature and signed message to the container image with the imageId
+func uploadSignatureMetadata(ctx context.Context, artifactClient artifacts.ArtifactsClient, compartmentId string, imageId string, keyId string, keyVersionId string, signingAlgorithm artifacts.CreateContainerImageSignatureDetailsSigningAlgorithmEnum, message string, signature string) (*artifacts.ContainerImageSignature, error) {
+	signatureDetails := artifacts.CreateContainerImageSignatureDetails{
+		CompartmentId:    &compartmentId,
+		ImageId:          &imageId,
+		KmsKeyId:         &keyId,
+		KmsKeyVersionId:  &keyVersionId,
+		SigningAlgorithm: signingAlgorithm,
+		Message:          &message,
+		Signature:        &signature,
+	}
+
+	request := artifacts.CreateContainerImageSignatureRequest{
+		CreateContainerImageSignatureDetails: signatureDetails,
+	}
+
+	response, err := artifactClient.CreateContainerImageSignature(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.RawResponse.StatusCode != 200 {
+		err := fmt.Sprintf("failed to upload the signature to OCI Registry. Status Code: %d", response.RawResponse.StatusCode)
+		return nil, errors.New(err)
+	}
+
+	return &response.ContainerImageSignature, err
+}
+
+// listContainerImageSignaturesWithRepoPath lists all the container image signatures uploaded to the image referenced with the repositoryName and imageDigest
+func listContainerImageSignaturesWithRepoPath(ctx context.Context, artifactClient artifacts.ArtifactsClient, compartmentId string, compartmentIdInSubtree bool, repositoryName string, imageDigest string, page string) (*artifacts.ContainerImageSignatureCollection, string, error) {
+	var request artifacts.ListContainerImageSignaturesRequest
+
+	if page != "" {
+		request = artifacts.ListContainerImageSignaturesRequest{
+			CompartmentId:          &compartmentId,
+			CompartmentIdInSubtree: &compartmentIdInSubtree,
+			RepositoryName:         &repositoryName,
+			ImageDigest:            &imageDigest,
+			Page:                   &page,
+		}
+	} else {
+		request = artifacts.ListContainerImageSignaturesRequest{
+			CompartmentId:          &compartmentId,
+			CompartmentIdInSubtree: &compartmentIdInSubtree,
+			RepositoryName:         &repositoryName,
+			ImageDigest:            &imageDigest,
+		}
+	}
+
+	response, err := artifactClient.ListContainerImageSignatures(ctx, request)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if response.RawResponse.StatusCode != 200 {
+		err := fmt.Sprintf("failed to list the signatures of repositoryName %s, imageDigest %s. Status Code: %d", repositoryName, imageDigest, response.RawResponse.StatusCode)
+		return nil, "", errors.New(err)
+	}
+
+	var nextPage string
+	if response.OpcNextPage == nil {
+		nextPage = ""
+	} else {
+		nextPage = *response.OpcNextPage
+	}
+
+	return &response.ContainerImageSignatureCollection, nextPage, err
+}
+
+// verifySignatures returns true if any of the provided container image signatures in the ContainerImageSignatureSummary items is valid
+func verifySignatures(ctx context.Context, configProvider common.ConfigurationProvider, containerImageSignatureSummary []artifacts.ContainerImageSignatureSummary) (bool, error) {
+	region, err := configProvider.Region()
+	if err != nil {
+		return false, err
+	}
+
+	for _, signatureSummary := range containerImageSignatureSummary {
+		vaultCryptoClient, cryptoClientError := buildVaultCryptoClient(configProvider, *signatureSummary.KmsKeyId, region)
+		if cryptoClientError != nil {
+			return false, cryptoClientError
+		}
+
+		algo := mappingVerifyDataDetailsSigningAlgorithm[string(signatureSummary.SigningAlgorithm)]
+		verifiedData, verifyErr := verifySignature(ctx, vaultCryptoClient, *signatureSummary.Message, *signatureSummary.Signature, *signatureSummary.KmsKeyId, *signatureSummary.KmsKeyVersionId, algo)
+		if verifyErr != nil {
+			return false, verifyErr
+		} else if *verifiedData.IsSignatureValid {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// verifySignature verifies if the provided signature is valid given signed message, keyId, keyVersionId, and signingAlgorithm
+func verifySignature(ctx context.Context, client keymanagement.KmsCryptoClient, message string, signature string, keyId string, keyVersionId string, signingAlgorithm keymanagement.VerifyDataDetailsSigningAlgorithmEnum) (*keymanagement.VerifiedData, error) {
+	verifyDataDetails := keymanagement.VerifyDataDetails{
+		KeyId:            &keyId,
+		KeyVersionId:     &keyVersionId,
+		SigningAlgorithm: signingAlgorithm,
+		Message:          &message,
+		Signature:        &signature,
+	}
+
+	request := keymanagement.VerifyRequest{
+		VerifyDataDetails: verifyDataDetails,
+	}
+
+	response, err := client.Verify(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.VerifiedData, err
+}
+
+// buildVaultCryptoClient builds the KmsCryptoClient based on the vault extension OCID in the keyId
+func buildVaultCryptoClient(configProvider common.ConfigurationProvider, keyId string, region string) (client keymanagement.KmsCryptoClient, err error) {
+	re := regexp.MustCompile("ocid1\\.key\\.([\\w-]+)\\.([\\w-]+)\\.([\\w-]+)\\.([\\w]{60})")
+	vaultExt := re.FindStringSubmatch(keyId)[3]
+	cryptoEndpointTemplate := common.StringToRegion(region).EndpointForTemplate("kms", "https://{vaultExt}-crypto.kms.{region}.{secondLevelDomain}")
+	cryptoEndpoint := strings.Replace(cryptoEndpointTemplate, "{vaultExt}", vaultExt, 1)
+	common.Debugf(fmt.Sprintf("Built vault crypto client with endpoint: %s", cryptoEndpoint))
+
+	return keymanagement.NewKmsCryptoClientWithConfigurationProvider(configProvider, cryptoEndpoint)
+}
+
+// filterItemByTrustedKeys filters out ContainerImageSignatureSummary items if its key is not in the trustedKeys list
+func filterItemByTrustedKeys(items []artifacts.ContainerImageSignatureSummary, trustedKeys []string) (ret []artifacts.ContainerImageSignatureSummary) {
+	for _, item := range items {
+		if isTrustedKey(*item.KmsKeyId, trustedKeys) {
+			ret = append(ret, item)
+		}
+	}
+	return
+}
+
+// isTrustedKey returns true if a key is in the trustedKeys key list
+func isTrustedKey(key string, trustedKeys []string) bool {
+	for _, k := range trustedKeys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+// Message defines the struct of container image signature payload
+type Message struct {
+	Description      string `mandatory:"true" json:"description"`
+	ImageDigest      string `mandatory:"true" json:"imageDigest"`
+	KmsKeyId         string `mandatory:"true" json:"kmsKeyId"`
+	KmsKeyVersionId  string `mandatory:"true" json:"kmsKeyVersionId"`
+	Metadata         string `mandatory:"true" json:"metadata"`
+	Region           string `mandatory:"true" json:"region"`
+	RepositoryName   string `mandatory:"true" json:"repositoryName"`
+	SigningAlgorithm string `mandatory:"true" json:"signingAlgorithm"`
+}
+
+// mappingCreateContainerImageSignatureDetailsSigningAlgorithm duplicated from the artifacts package since they're not exported
+var mappingCreateContainerImageSignatureDetailsSigningAlgorithm = map[string]artifacts.CreateContainerImageSignatureDetailsSigningAlgorithmEnum{
+	"SHA_224_RSA_PKCS_PSS": artifacts.CreateContainerImageSignatureDetailsSigningAlgorithm224RsaPkcsPss,
+	"SHA_256_RSA_PKCS_PSS": artifacts.CreateContainerImageSignatureDetailsSigningAlgorithm256RsaPkcsPss,
+	"SHA_384_RSA_PKCS_PSS": artifacts.CreateContainerImageSignatureDetailsSigningAlgorithm384RsaPkcsPss,
+	"SHA_512_RSA_PKCS_PSS": artifacts.CreateContainerImageSignatureDetailsSigningAlgorithm512RsaPkcsPss,
+}
+
+// mappingSignDataDetailsSigningAlgorithm duplicated from the keymanagement package since they're not exported
+var mappingSignDataDetailsSigningAlgorithm = map[string]keymanagement.SignDataDetailsSigningAlgorithmEnum{
+	"SHA_224_RSA_PKCS_PSS": keymanagement.SignDataDetailsSigningAlgorithmSha224RsaPkcsPss,
+	"SHA_256_RSA_PKCS_PSS": keymanagement.SignDataDetailsSigningAlgorithmSha256RsaPkcsPss,
+	"SHA_384_RSA_PKCS_PSS": keymanagement.SignDataDetailsSigningAlgorithmSha384RsaPkcsPss,
+	"SHA_512_RSA_PKCS_PSS": keymanagement.SignDataDetailsSigningAlgorithmSha512RsaPkcsPss,
+}
+
+// mappingVerifyDataDetailsSigningAlgorithm duplicated from the keymanagement package since they're not exported
+var mappingVerifyDataDetailsSigningAlgorithm = map[string]keymanagement.VerifyDataDetailsSigningAlgorithmEnum{
+	"SHA_224_RSA_PKCS_PSS": keymanagement.VerifyDataDetailsSigningAlgorithmSha224RsaPkcsPss,
+	"SHA_256_RSA_PKCS_PSS": keymanagement.VerifyDataDetailsSigningAlgorithmSha256RsaPkcsPss,
+	"SHA_384_RSA_PKCS_PSS": keymanagement.VerifyDataDetailsSigningAlgorithmSha384RsaPkcsPss,
+	"SHA_512_RSA_PKCS_PSS": keymanagement.VerifyDataDetailsSigningAlgorithmSha512RsaPkcsPss,
+}

--- a/objectstorage/create_preauthenticated_request_details.go
+++ b/objectstorage/create_preauthenticated_request_details.go
@@ -29,8 +29,15 @@ type CreatePreauthenticatedRequestDetails struct {
 	// After this date the pre-authenticated request will no longer be valid.
 	TimeExpires *common.SDKTime `mandatory:"true" json:"timeExpires"`
 
+	// Specifies whether a list operation is allowed on a PAR with accessType "AnyObjectRead" or "AnyObjectReadWrite".
+	// Deny: Prevents the user from performing a list operation.
+	// ListObjects: Authorizes the user to perform a list operation.
+	BucketListingAction PreauthenticatedRequestBucketListingActionEnum `mandatory:"false" json:"bucketListingAction,omitempty"`
+
 	// The name of the object that is being granted access to by the pre-authenticated request. Avoid entering confidential
-	// information. The object name can be null and if so, the pre-authenticated request grants access to the entire bucket.
+	// information. The object name can be null and if so, the pre-authenticated request grants access to the entire bucket
+	// if the access type allows that. The object name can be a prefix as well, in that case pre-authenticated request
+	// grants access to all the objects within the bucket starting with that prefix provided that we have the correct access type.
 	ObjectName *string `mandatory:"false" json:"objectName"`
 }
 
@@ -43,17 +50,21 @@ type CreatePreauthenticatedRequestDetailsAccessTypeEnum string
 
 // Set of constants representing the allowable values for CreatePreauthenticatedRequestDetailsAccessTypeEnum
 const (
-	CreatePreauthenticatedRequestDetailsAccessTypeObjectread      CreatePreauthenticatedRequestDetailsAccessTypeEnum = "ObjectRead"
-	CreatePreauthenticatedRequestDetailsAccessTypeObjectwrite     CreatePreauthenticatedRequestDetailsAccessTypeEnum = "ObjectWrite"
-	CreatePreauthenticatedRequestDetailsAccessTypeObjectreadwrite CreatePreauthenticatedRequestDetailsAccessTypeEnum = "ObjectReadWrite"
-	CreatePreauthenticatedRequestDetailsAccessTypeAnyobjectwrite  CreatePreauthenticatedRequestDetailsAccessTypeEnum = "AnyObjectWrite"
+	CreatePreauthenticatedRequestDetailsAccessTypeObjectread         CreatePreauthenticatedRequestDetailsAccessTypeEnum = "ObjectRead"
+	CreatePreauthenticatedRequestDetailsAccessTypeObjectwrite        CreatePreauthenticatedRequestDetailsAccessTypeEnum = "ObjectWrite"
+	CreatePreauthenticatedRequestDetailsAccessTypeObjectreadwrite    CreatePreauthenticatedRequestDetailsAccessTypeEnum = "ObjectReadWrite"
+	CreatePreauthenticatedRequestDetailsAccessTypeAnyobjectwrite     CreatePreauthenticatedRequestDetailsAccessTypeEnum = "AnyObjectWrite"
+	CreatePreauthenticatedRequestDetailsAccessTypeAnyobjectread      CreatePreauthenticatedRequestDetailsAccessTypeEnum = "AnyObjectRead"
+	CreatePreauthenticatedRequestDetailsAccessTypeAnyobjectreadwrite CreatePreauthenticatedRequestDetailsAccessTypeEnum = "AnyObjectReadWrite"
 )
 
 var mappingCreatePreauthenticatedRequestDetailsAccessType = map[string]CreatePreauthenticatedRequestDetailsAccessTypeEnum{
-	"ObjectRead":      CreatePreauthenticatedRequestDetailsAccessTypeObjectread,
-	"ObjectWrite":     CreatePreauthenticatedRequestDetailsAccessTypeObjectwrite,
-	"ObjectReadWrite": CreatePreauthenticatedRequestDetailsAccessTypeObjectreadwrite,
-	"AnyObjectWrite":  CreatePreauthenticatedRequestDetailsAccessTypeAnyobjectwrite,
+	"ObjectRead":         CreatePreauthenticatedRequestDetailsAccessTypeObjectread,
+	"ObjectWrite":        CreatePreauthenticatedRequestDetailsAccessTypeObjectwrite,
+	"ObjectReadWrite":    CreatePreauthenticatedRequestDetailsAccessTypeObjectreadwrite,
+	"AnyObjectWrite":     CreatePreauthenticatedRequestDetailsAccessTypeAnyobjectwrite,
+	"AnyObjectRead":      CreatePreauthenticatedRequestDetailsAccessTypeAnyobjectread,
+	"AnyObjectReadWrite": CreatePreauthenticatedRequestDetailsAccessTypeAnyobjectreadwrite,
 }
 
 // GetCreatePreauthenticatedRequestDetailsAccessTypeEnumValues Enumerates the set of values for CreatePreauthenticatedRequestDetailsAccessTypeEnum

--- a/objectstorage/preauthenticated_request.go
+++ b/objectstorage/preauthenticated_request.go
@@ -48,10 +48,38 @@ type PreauthenticatedRequest struct {
 	// information. The object name can be null and if so, the pre-authenticated request grants access to the entire bucket.
 	// Example: test/object1.log
 	ObjectName *string `mandatory:"false" json:"objectName"`
+
+	// Specifies whether a list operation is allowed on a PAR with accessType "AnyObjectRead" or "AnyObjectReadWrite".
+	// Deny: Prevents the user from performing a list operation.
+	// ListObjects: Authorizes the user to perform a list operation.
+	BucketListingAction PreauthenticatedRequestBucketListingActionEnum `mandatory:"false" json:"bucketListingAction,omitempty"`
 }
 
 func (m PreauthenticatedRequest) String() string {
 	return common.PointerString(m)
+}
+
+// PreauthenticatedRequestBucketListingActionEnum Enum with underlying type: string
+type PreauthenticatedRequestBucketListingActionEnum string
+
+// Set of constants representing the allowable values for PreauthenticatedRequestBucketListingActionEnum
+const (
+	PreauthenticatedRequestBucketListingActionDeny        PreauthenticatedRequestBucketListingActionEnum = "Deny"
+	PreauthenticatedRequestBucketListingActionListobjects PreauthenticatedRequestBucketListingActionEnum = "ListObjects"
+)
+
+var mappingPreauthenticatedRequestBucketListingAction = map[string]PreauthenticatedRequestBucketListingActionEnum{
+	"Deny":        PreauthenticatedRequestBucketListingActionDeny,
+	"ListObjects": PreauthenticatedRequestBucketListingActionListobjects,
+}
+
+// GetPreauthenticatedRequestBucketListingActionEnumValues Enumerates the set of values for PreauthenticatedRequestBucketListingActionEnum
+func GetPreauthenticatedRequestBucketListingActionEnumValues() []PreauthenticatedRequestBucketListingActionEnum {
+	values := make([]PreauthenticatedRequestBucketListingActionEnum, 0)
+	for _, v := range mappingPreauthenticatedRequestBucketListingAction {
+		values = append(values, v)
+	}
+	return values
 }
 
 // PreauthenticatedRequestAccessTypeEnum Enum with underlying type: string
@@ -59,17 +87,21 @@ type PreauthenticatedRequestAccessTypeEnum string
 
 // Set of constants representing the allowable values for PreauthenticatedRequestAccessTypeEnum
 const (
-	PreauthenticatedRequestAccessTypeObjectread      PreauthenticatedRequestAccessTypeEnum = "ObjectRead"
-	PreauthenticatedRequestAccessTypeObjectwrite     PreauthenticatedRequestAccessTypeEnum = "ObjectWrite"
-	PreauthenticatedRequestAccessTypeObjectreadwrite PreauthenticatedRequestAccessTypeEnum = "ObjectReadWrite"
-	PreauthenticatedRequestAccessTypeAnyobjectwrite  PreauthenticatedRequestAccessTypeEnum = "AnyObjectWrite"
+	PreauthenticatedRequestAccessTypeObjectread         PreauthenticatedRequestAccessTypeEnum = "ObjectRead"
+	PreauthenticatedRequestAccessTypeObjectwrite        PreauthenticatedRequestAccessTypeEnum = "ObjectWrite"
+	PreauthenticatedRequestAccessTypeObjectreadwrite    PreauthenticatedRequestAccessTypeEnum = "ObjectReadWrite"
+	PreauthenticatedRequestAccessTypeAnyobjectwrite     PreauthenticatedRequestAccessTypeEnum = "AnyObjectWrite"
+	PreauthenticatedRequestAccessTypeAnyobjectread      PreauthenticatedRequestAccessTypeEnum = "AnyObjectRead"
+	PreauthenticatedRequestAccessTypeAnyobjectreadwrite PreauthenticatedRequestAccessTypeEnum = "AnyObjectReadWrite"
 )
 
 var mappingPreauthenticatedRequestAccessType = map[string]PreauthenticatedRequestAccessTypeEnum{
-	"ObjectRead":      PreauthenticatedRequestAccessTypeObjectread,
-	"ObjectWrite":     PreauthenticatedRequestAccessTypeObjectwrite,
-	"ObjectReadWrite": PreauthenticatedRequestAccessTypeObjectreadwrite,
-	"AnyObjectWrite":  PreauthenticatedRequestAccessTypeAnyobjectwrite,
+	"ObjectRead":         PreauthenticatedRequestAccessTypeObjectread,
+	"ObjectWrite":        PreauthenticatedRequestAccessTypeObjectwrite,
+	"ObjectReadWrite":    PreauthenticatedRequestAccessTypeObjectreadwrite,
+	"AnyObjectWrite":     PreauthenticatedRequestAccessTypeAnyobjectwrite,
+	"AnyObjectRead":      PreauthenticatedRequestAccessTypeAnyobjectread,
+	"AnyObjectReadWrite": PreauthenticatedRequestAccessTypeAnyobjectreadwrite,
 }
 
 // GetPreauthenticatedRequestAccessTypeEnumValues Enumerates the set of values for PreauthenticatedRequestAccessTypeEnum

--- a/objectstorage/preauthenticated_request_summary.go
+++ b/objectstorage/preauthenticated_request_summary.go
@@ -36,6 +36,11 @@ type PreauthenticatedRequestSummary struct {
 	// The name of object that is being granted access to by the pre-authenticated request. This can be null and if it is,
 	// the pre-authenticated request grants access to the entire bucket.
 	ObjectName *string `mandatory:"false" json:"objectName"`
+
+	// Specifies whether a list operation is allowed on a PAR with accessType "AnyObjectRead" or "AnyObjectReadWrite".
+	// Deny: Prevents the user from performing a list operation.
+	// ListObjects: Authorizes the user to perform a list operation.
+	BucketListingAction PreauthenticatedRequestBucketListingActionEnum `mandatory:"false" json:"bucketListingAction,omitempty"`
 }
 
 func (m PreauthenticatedRequestSummary) String() string {
@@ -47,17 +52,21 @@ type PreauthenticatedRequestSummaryAccessTypeEnum string
 
 // Set of constants representing the allowable values for PreauthenticatedRequestSummaryAccessTypeEnum
 const (
-	PreauthenticatedRequestSummaryAccessTypeObjectread      PreauthenticatedRequestSummaryAccessTypeEnum = "ObjectRead"
-	PreauthenticatedRequestSummaryAccessTypeObjectwrite     PreauthenticatedRequestSummaryAccessTypeEnum = "ObjectWrite"
-	PreauthenticatedRequestSummaryAccessTypeObjectreadwrite PreauthenticatedRequestSummaryAccessTypeEnum = "ObjectReadWrite"
-	PreauthenticatedRequestSummaryAccessTypeAnyobjectwrite  PreauthenticatedRequestSummaryAccessTypeEnum = "AnyObjectWrite"
+	PreauthenticatedRequestSummaryAccessTypeObjectread         PreauthenticatedRequestSummaryAccessTypeEnum = "ObjectRead"
+	PreauthenticatedRequestSummaryAccessTypeObjectwrite        PreauthenticatedRequestSummaryAccessTypeEnum = "ObjectWrite"
+	PreauthenticatedRequestSummaryAccessTypeObjectreadwrite    PreauthenticatedRequestSummaryAccessTypeEnum = "ObjectReadWrite"
+	PreauthenticatedRequestSummaryAccessTypeAnyobjectwrite     PreauthenticatedRequestSummaryAccessTypeEnum = "AnyObjectWrite"
+	PreauthenticatedRequestSummaryAccessTypeAnyobjectread      PreauthenticatedRequestSummaryAccessTypeEnum = "AnyObjectRead"
+	PreauthenticatedRequestSummaryAccessTypeAnyobjectreadwrite PreauthenticatedRequestSummaryAccessTypeEnum = "AnyObjectReadWrite"
 )
 
 var mappingPreauthenticatedRequestSummaryAccessType = map[string]PreauthenticatedRequestSummaryAccessTypeEnum{
-	"ObjectRead":      PreauthenticatedRequestSummaryAccessTypeObjectread,
-	"ObjectWrite":     PreauthenticatedRequestSummaryAccessTypeObjectwrite,
-	"ObjectReadWrite": PreauthenticatedRequestSummaryAccessTypeObjectreadwrite,
-	"AnyObjectWrite":  PreauthenticatedRequestSummaryAccessTypeAnyobjectwrite,
+	"ObjectRead":         PreauthenticatedRequestSummaryAccessTypeObjectread,
+	"ObjectWrite":        PreauthenticatedRequestSummaryAccessTypeObjectwrite,
+	"ObjectReadWrite":    PreauthenticatedRequestSummaryAccessTypeObjectreadwrite,
+	"AnyObjectWrite":     PreauthenticatedRequestSummaryAccessTypeAnyobjectwrite,
+	"AnyObjectRead":      PreauthenticatedRequestSummaryAccessTypeAnyobjectread,
+	"AnyObjectReadWrite": PreauthenticatedRequestSummaryAccessTypeAnyobjectreadwrite,
 }
 
 // GetPreauthenticatedRequestSummaryAccessTypeEnumValues Enumerates the set of values for PreauthenticatedRequestSummaryAccessTypeEnum


### PR DESCRIPTION
### Added

- Support for scheduling the suspension and resumption of compute instance pools based on predefined schedules in the Autoscaling service

- Support for database software images for Cloud@Customer in the Database service

- Support for OCIC IDCS authorization details in the Application Migration service

- Support for cross-region asynchronous volume replication in the Block Storage service

- Support for SDK generation in the API Gateway service

- Support for container image signing in the Registry service

- Support for cluster features as a part of the Container Engine for Kubernetes service

- Support for filtering dedicated virtual machine hosts by remaining memory and OCPUs in the Compute service

- Support for read/write-any object from buckets using pre-authenticated requests in the Object Storage service

- Support for restricting pre-authenticated requests by prefix in the Object Storage service

- Support for route filtering on public virtual circuits in the Virtual Networking service