### PR TITLE
Releasing version 40.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## 40.1.0 - 2021-04-27
+### Added
+- VCN id parameters were moved from being required to being optional on all list operations in the Networking service
+- Support for RACs (real application clusters) for external container, non-container, and pluggable databases in the Database service
+- Support for data masking in the Cloud Guard service
+- Support for opting out of DNS records during instance launch, as well as attaching secondary VNICs, in the Compute service
+- Support for mutable sizes on cluster networks in the Autoscaling service
+- Support for auto-tiering on buckets in the Object Storage service
+
+
+
+
 ## 40.0.0 - 2021-04-20
 ### Added
 - Support for opting in/out of live migration on instances in the Compute service

--- a/cloudguard/all_targets_selected.go
+++ b/cloudguard/all_targets_selected.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Cloud Guard APIs
+//
+// A description of the Cloud Guard APIs
+//
+
+package cloudguard
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/v40/common"
+)
+
+// AllTargetsSelected All Targets selected.
+type AllTargetsSelected struct {
+}
+
+func (m AllTargetsSelected) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m AllTargetsSelected) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeAllTargetsSelected AllTargetsSelected
+	s := struct {
+		DiscriminatorParam string `json:"kind"`
+		MarshalTypeAllTargetsSelected
+	}{
+		"ALL",
+		(MarshalTypeAllTargetsSelected)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/cloudguard/cloudguard_client.go
+++ b/cloudguard/cloudguard_client.go
@@ -256,6 +256,65 @@ func (client CloudGuardClient) changeResponderRecipeCompartment(ctx context.Cont
 	return response, err
 }
 
+// CreateDataMaskRule Creates a new Data Mask Rule Definition
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/cloudguard/CreateDataMaskRule.go.html to see an example of how to use CreateDataMaskRule API.
+func (client CloudGuardClient) CreateDataMaskRule(ctx context.Context, request CreateDataMaskRuleRequest) (response CreateDataMaskRuleResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createDataMaskRule, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateDataMaskRuleResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateDataMaskRuleResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateDataMaskRuleResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateDataMaskRuleResponse")
+	}
+	return
+}
+
+// createDataMaskRule implements the OCIOperation interface (enables retrying operations)
+func (client CloudGuardClient) createDataMaskRule(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/dataMaskRules", binaryReqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateDataMaskRuleResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // CreateDetectorRecipe Creates a DetectorRecipe
 //
 // See also
@@ -598,6 +657,60 @@ func (client CloudGuardClient) createTargetResponderRecipe(ctx context.Context, 
 	}
 
 	var response CreateTargetResponderRecipeResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteDataMaskRule Deletes a DataMaskRule identified by dataMaskRuleId
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/cloudguard/DeleteDataMaskRule.go.html to see an example of how to use DeleteDataMaskRule API.
+func (client CloudGuardClient) DeleteDataMaskRule(ctx context.Context, request DeleteDataMaskRuleRequest) (response DeleteDataMaskRuleResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteDataMaskRule, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteDataMaskRuleResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteDataMaskRuleResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteDataMaskRuleResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteDataMaskRuleResponse")
+	}
+	return
+}
+
+// deleteDataMaskRule implements the OCIOperation interface (enables retrying operations)
+func (client CloudGuardClient) deleteDataMaskRule(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/dataMaskRules/{dataMaskRuleId}", binaryReqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteDataMaskRuleResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -1099,6 +1212,60 @@ func (client CloudGuardClient) getConfiguration(ctx context.Context, request com
 	}
 
 	var response GetConfigurationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetDataMaskRule Returns a DataMaskRule identified by DataMaskRuleId
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/cloudguard/GetDataMaskRule.go.html to see an example of how to use GetDataMaskRule API.
+func (client CloudGuardClient) GetDataMaskRule(ctx context.Context, request GetDataMaskRuleRequest) (response GetDataMaskRuleResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getDataMaskRule, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetDataMaskRuleResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetDataMaskRuleResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetDataMaskRuleResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetDataMaskRuleResponse")
+	}
+	return
+}
+
+// getDataMaskRule implements the OCIOperation interface (enables retrying operations)
+func (client CloudGuardClient) getDataMaskRule(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/dataMaskRules/{dataMaskRuleId}", binaryReqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetDataMaskRuleResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -1975,6 +2142,60 @@ func (client CloudGuardClient) listConditionMetadataTypes(ctx context.Context, r
 	return response, err
 }
 
+// ListDataMaskRules Returns a list of all Data Mask Rules in the root 'compartmentId' passed.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/cloudguard/ListDataMaskRules.go.html to see an example of how to use ListDataMaskRules API.
+func (client CloudGuardClient) ListDataMaskRules(ctx context.Context, request ListDataMaskRulesRequest) (response ListDataMaskRulesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listDataMaskRules, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListDataMaskRulesResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListDataMaskRulesResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListDataMaskRulesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListDataMaskRulesResponse")
+	}
+	return
+}
+
+// listDataMaskRules implements the OCIOperation interface (enables retrying operations)
+func (client CloudGuardClient) listDataMaskRules(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/dataMaskRules", binaryReqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListDataMaskRulesResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // ListDetectorRecipeDetectorRules Returns a list of DetectorRule associated with DetectorRecipe.
 //
 // See also
@@ -2363,6 +2584,60 @@ func (client CloudGuardClient) listManagedLists(ctx context.Context, request com
 	}
 
 	var response ListManagedListsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListPolicies Returns the list of global policy statements needed by Cloud Guard when enabling
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/cloudguard/ListPolicies.go.html to see an example of how to use ListPolicies API.
+func (client CloudGuardClient) ListPolicies(ctx context.Context, request ListPoliciesRequest) (response ListPoliciesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listPolicies, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListPoliciesResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListPoliciesResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListPoliciesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListPoliciesResponse")
+	}
+	return
+}
+
+// listPolicies implements the OCIOperation interface (enables retrying operations)
+func (client CloudGuardClient) listPolicies(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/policies", binaryReqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListPoliciesResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -4081,6 +4356,60 @@ func (client CloudGuardClient) updateConfiguration(ctx context.Context, request 
 	}
 
 	var response UpdateConfigurationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateDataMaskRule Updates a DataMaskRule identified by dataMaskRuleId
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/cloudguard/UpdateDataMaskRule.go.html to see an example of how to use UpdateDataMaskRule API.
+func (client CloudGuardClient) UpdateDataMaskRule(ctx context.Context, request UpdateDataMaskRuleRequest) (response UpdateDataMaskRuleResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateDataMaskRule, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateDataMaskRuleResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateDataMaskRuleResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateDataMaskRuleResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateDataMaskRuleResponse")
+	}
+	return
+}
+
+// updateDataMaskRule implements the OCIOperation interface (enables retrying operations)
+func (client CloudGuardClient) updateDataMaskRule(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/dataMaskRules/{dataMaskRuleId}", binaryReqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateDataMaskRuleResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)

--- a/cloudguard/create_data_mask_rule_details.go
+++ b/cloudguard/create_data_mask_rule_details.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Cloud Guard APIs
+//
+// A description of the Cloud Guard APIs
+//
+
+package cloudguard
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/v40/common"
+)
+
+// CreateDataMaskRuleDetails The information about new Data Mask Rule.
+type CreateDataMaskRuleDetails struct {
+
+	// Data Mask Rule name
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// Compartment Identifier where the resource is created
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// IAM Group id associated with the data mask rule
+	IamGroupId *string `mandatory:"true" json:"iamGroupId"`
+
+	TargetSelected TargetSelected `mandatory:"true" json:"targetSelected"`
+
+	// Data Mask Categories
+	DataMaskCategories []DataMaskCategoryEnum `mandatory:"true" json:"dataMaskCategories"`
+
+	// The Data Mask Rule description.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The status of the dataMaskRule.
+	DataMaskRuleStatus DataMaskRuleStatusEnum `mandatory:"false" json:"dataMaskRuleStatus,omitempty"`
+
+	// The current state of the DataMaskRule.
+	LifecycleState LifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m CreateDataMaskRuleDetails) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *CreateDataMaskRuleDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Description        *string                           `json:"description"`
+		DataMaskRuleStatus DataMaskRuleStatusEnum            `json:"dataMaskRuleStatus"`
+		LifecycleState     LifecycleStateEnum                `json:"lifecycleState"`
+		FreeformTags       map[string]string                 `json:"freeformTags"`
+		DefinedTags        map[string]map[string]interface{} `json:"definedTags"`
+		DisplayName        *string                           `json:"displayName"`
+		CompartmentId      *string                           `json:"compartmentId"`
+		IamGroupId         *string                           `json:"iamGroupId"`
+		TargetSelected     targetselected                    `json:"targetSelected"`
+		DataMaskCategories []DataMaskCategoryEnum            `json:"dataMaskCategories"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Description = model.Description
+
+	m.DataMaskRuleStatus = model.DataMaskRuleStatus
+
+	m.LifecycleState = model.LifecycleState
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.DisplayName = model.DisplayName
+
+	m.CompartmentId = model.CompartmentId
+
+	m.IamGroupId = model.IamGroupId
+
+	nn, e = model.TargetSelected.UnmarshalPolymorphicJSON(model.TargetSelected.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.TargetSelected = nn.(TargetSelected)
+	} else {
+		m.TargetSelected = nil
+	}
+
+	m.DataMaskCategories = make([]DataMaskCategoryEnum, len(model.DataMaskCategories))
+	for i, n := range model.DataMaskCategories {
+		m.DataMaskCategories[i] = n
+	}
+
+	return
+}

--- a/cloudguard/create_data_mask_rule_request_response.go
+++ b/cloudguard/create_data_mask_rule_request_response.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package cloudguard
+
+import (
+	"github.com/oracle/oci-go-sdk/v40/common"
+	"net/http"
+)
+
+// CreateDataMaskRuleRequest wrapper for the CreateDataMaskRule operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/cloudguard/CreateDataMaskRule.go.html to see an example of how to use CreateDataMaskRuleRequest.
+type CreateDataMaskRuleRequest struct {
+
+	// Definition for the new Data Mask Rule.
+	CreateDataMaskRuleDetails `contributesTo:"body"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// might be rejected.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateDataMaskRuleRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateDataMaskRuleRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request CreateDataMaskRuleRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateDataMaskRuleRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateDataMaskRuleResponse wrapper for the CreateDataMaskRule operation
+type CreateDataMaskRuleResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The DataMaskRule instance
+	DataMaskRule `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateDataMaskRuleResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateDataMaskRuleResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/cloudguard/data_mask_category.go
+++ b/cloudguard/data_mask_category.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Cloud Guard APIs
+//
+// A description of the Cloud Guard APIs
+//
+
+package cloudguard
+
+// DataMaskCategoryEnum Enum with underlying type: string
+type DataMaskCategoryEnum string
+
+// Set of constants representing the allowable values for DataMaskCategoryEnum
+const (
+	DataMaskCategoryActor     DataMaskCategoryEnum = "ACTOR"
+	DataMaskCategoryPii       DataMaskCategoryEnum = "PII"
+	DataMaskCategoryPhi       DataMaskCategoryEnum = "PHI"
+	DataMaskCategoryFinancial DataMaskCategoryEnum = "FINANCIAL"
+	DataMaskCategoryLocation  DataMaskCategoryEnum = "LOCATION"
+	DataMaskCategoryCustom    DataMaskCategoryEnum = "CUSTOM"
+)
+
+var mappingDataMaskCategory = map[string]DataMaskCategoryEnum{
+	"ACTOR":     DataMaskCategoryActor,
+	"PII":       DataMaskCategoryPii,
+	"PHI":       DataMaskCategoryPhi,
+	"FINANCIAL": DataMaskCategoryFinancial,
+	"LOCATION":  DataMaskCategoryLocation,
+	"CUSTOM":    DataMaskCategoryCustom,
+}
+
+// GetDataMaskCategoryEnumValues Enumerates the set of values for DataMaskCategoryEnum
+func GetDataMaskCategoryEnumValues() []DataMaskCategoryEnum {
+	values := make([]DataMaskCategoryEnum, 0)
+	for _, v := range mappingDataMaskCategory {
+		values = append(values, v)
+	}
+	return values
+}

--- a/cloudguard/data_mask_rule.go
+++ b/cloudguard/data_mask_rule.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Cloud Guard APIs
+//
+// A description of the Cloud Guard APIs
+//
+
+package cloudguard
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/v40/common"
+)
+
+// DataMaskRule Description of DataMaskRule.
+type DataMaskRule struct {
+
+	// Unique identifier that is immutable on creation
+	Id *string `mandatory:"true" json:"id"`
+
+	// Compartment Identifier where the resource is created
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// IAM Group id associated with the data mask rule
+	IamGroupId *string `mandatory:"true" json:"iamGroupId"`
+
+	TargetSelected TargetSelected `mandatory:"true" json:"targetSelected"`
+
+	// Data Mask Rule Identifier, can be renamed
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// The data mask rule description.
+	Description *string `mandatory:"false" json:"description"`
+
+	// Data Mask Categories
+	DataMaskCategories []DataMaskCategoryEnum `mandatory:"false" json:"dataMaskCategories,omitempty"`
+
+	// The date and time the target was created. Format defined by RFC3339.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The date and time the target was updated. Format defined by RFC3339.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// The status of the dataMaskRule.
+	DataMaskRuleStatus DataMaskRuleStatusEnum `mandatory:"false" json:"dataMaskRuleStatus,omitempty"`
+
+	// The current state of the DataMaskRule.
+	LifecycleState LifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// A message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+	LifecyleDetails *string `mandatory:"false" json:"lifecyleDetails"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// System tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// System tags can be viewed by users, but can only be created by the system.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+}
+
+func (m DataMaskRule) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *DataMaskRule) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		DisplayName        *string                           `json:"displayName"`
+		Description        *string                           `json:"description"`
+		DataMaskCategories []DataMaskCategoryEnum            `json:"dataMaskCategories"`
+		TimeCreated        *common.SDKTime                   `json:"timeCreated"`
+		TimeUpdated        *common.SDKTime                   `json:"timeUpdated"`
+		DataMaskRuleStatus DataMaskRuleStatusEnum            `json:"dataMaskRuleStatus"`
+		LifecycleState     LifecycleStateEnum                `json:"lifecycleState"`
+		LifecyleDetails    *string                           `json:"lifecyleDetails"`
+		FreeformTags       map[string]string                 `json:"freeformTags"`
+		DefinedTags        map[string]map[string]interface{} `json:"definedTags"`
+		SystemTags         map[string]map[string]interface{} `json:"systemTags"`
+		Id                 *string                           `json:"id"`
+		CompartmentId      *string                           `json:"compartmentId"`
+		IamGroupId         *string                           `json:"iamGroupId"`
+		TargetSelected     targetselected                    `json:"targetSelected"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.DisplayName = model.DisplayName
+
+	m.Description = model.Description
+
+	m.DataMaskCategories = make([]DataMaskCategoryEnum, len(model.DataMaskCategories))
+	for i, n := range model.DataMaskCategories {
+		m.DataMaskCategories[i] = n
+	}
+
+	m.TimeCreated = model.TimeCreated
+
+	m.TimeUpdated = model.TimeUpdated
+
+	m.DataMaskRuleStatus = model.DataMaskRuleStatus
+
+	m.LifecycleState = model.LifecycleState
+
+	m.LifecyleDetails = model.LifecyleDetails
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.SystemTags = model.SystemTags
+
+	m.Id = model.Id
+
+	m.CompartmentId = model.CompartmentId
+
+	m.IamGroupId = model.IamGroupId
+
+	nn, e = model.TargetSelected.UnmarshalPolymorphicJSON(model.TargetSelected.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.TargetSelected = nn.(TargetSelected)
+	} else {
+		m.TargetSelected = nil
+	}
+
+	return
+}

--- a/cloudguard/data_mask_rule_collection.go
+++ b/cloudguard/data_mask_rule_collection.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Cloud Guard APIs
+//
+// A description of the Cloud Guard APIs
+//
+
+package cloudguard
+
+import (
+	"github.com/oracle/oci-go-sdk/v40/common"
+)
+
+// DataMaskRuleCollection Collection of Data Mask Rule
+type DataMaskRuleCollection struct {
+
+	// List of Data Mask Rule Summary
+	Items []DataMaskRuleSummary `mandatory:"true" json:"items"`
+}
+
+func (m DataMaskRuleCollection) String() string {
+	return common.PointerString(m)
+}

--- a/cloudguard/data_mask_rule_status.go
+++ b/cloudguard/data_mask_rule_status.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Cloud Guard APIs
+//
+// A description of the Cloud Guard APIs
+//
+
+package cloudguard
+
+// DataMaskRuleStatusEnum Enum with underlying type: string
+type DataMaskRuleStatusEnum string
+
+// Set of constants representing the allowable values for DataMaskRuleStatusEnum
+const (
+	DataMaskRuleStatusEnabled  DataMaskRuleStatusEnum = "ENABLED"
+	DataMaskRuleStatusDisabled DataMaskRuleStatusEnum = "DISABLED"
+)
+
+var mappingDataMaskRuleStatus = map[string]DataMaskRuleStatusEnum{
+	"ENABLED":  DataMaskRuleStatusEnabled,
+	"DISABLED": DataMaskRuleStatusDisabled,
+}
+
+// GetDataMaskRuleStatusEnumValues Enumerates the set of values for DataMaskRuleStatusEnum
+func GetDataMaskRuleStatusEnumValues() []DataMaskRuleStatusEnum {
+	values := make([]DataMaskRuleStatusEnum, 0)
+	for _, v := range mappingDataMaskRuleStatus {
+		values = append(values, v)
+	}
+	return values
+}

--- a/cloudguard/data_mask_rule_summary.go
+++ b/cloudguard/data_mask_rule_summary.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Cloud Guard APIs
+//
+// A description of the Cloud Guard APIs
+//
+
+package cloudguard
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/v40/common"
+)
+
+// DataMaskRuleSummary Summary of DataMaskRule.
+type DataMaskRuleSummary struct {
+
+	// Unique identifier that is immutable on creation
+	Id *string `mandatory:"true" json:"id"`
+
+	// Compartment Identifier where the resource is created
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// IAM Group id associated with the data mask rule
+	IamGroupId *string `mandatory:"true" json:"iamGroupId"`
+
+	TargetSelected TargetSelected `mandatory:"true" json:"targetSelected"`
+
+	// Data Mask Rule Name.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// The data mask rule description.
+	Description *string `mandatory:"false" json:"description"`
+
+	// Data Mask Categories
+	DataMaskCategories []DataMaskCategoryEnum `mandatory:"false" json:"dataMaskCategories,omitempty"`
+
+	// The date and time the target was created. Format defined by RFC3339.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The date and time the target was updated. Format defined by RFC3339.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// The status of the dataMaskRule.
+	DataMaskRuleStatus DataMaskRuleStatusEnum `mandatory:"false" json:"dataMaskRuleStatus,omitempty"`
+
+	// The current state of the DataMaskRule.
+	LifecycleState LifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// A message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+	LifecyleDetails *string `mandatory:"false" json:"lifecyleDetails"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// System tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// System tags can be viewed by users, but can only be created by the system.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+}
+
+func (m DataMaskRuleSummary) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *DataMaskRuleSummary) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		DisplayName        *string                           `json:"displayName"`
+		Description        *string                           `json:"description"`
+		DataMaskCategories []DataMaskCategoryEnum            `json:"dataMaskCategories"`
+		TimeCreated        *common.SDKTime                   `json:"timeCreated"`
+		TimeUpdated        *common.SDKTime                   `json:"timeUpdated"`
+		DataMaskRuleStatus DataMaskRuleStatusEnum            `json:"dataMaskRuleStatus"`
+		LifecycleState     LifecycleStateEnum                `json:"lifecycleState"`
+		LifecyleDetails    *string                           `json:"lifecyleDetails"`
+		FreeformTags       map[string]string                 `json:"freeformTags"`
+		DefinedTags        map[string]map[string]interface{} `json:"definedTags"`
+		SystemTags         map[string]map[string]interface{} `json:"systemTags"`
+		Id                 *string                           `json:"id"`
+		CompartmentId      *string                           `json:"compartmentId"`
+		IamGroupId         *string                           `json:"iamGroupId"`
+		TargetSelected     targetselected                    `json:"targetSelected"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.DisplayName = model.DisplayName
+
+	m.Description = model.Description
+
+	m.DataMaskCategories = make([]DataMaskCategoryEnum, len(model.DataMaskCategories))
+	for i, n := range model.DataMaskCategories {
+		m.DataMaskCategories[i] = n
+	}
+
+	m.TimeCreated = model.TimeCreated
+
+	m.TimeUpdated = model.TimeUpdated
+
+	m.DataMaskRuleStatus = model.DataMaskRuleStatus
+
+	m.LifecycleState = model.LifecycleState
+
+	m.LifecyleDetails = model.LifecyleDetails
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.SystemTags = model.SystemTags
+
+	m.Id = model.Id
+
+	m.CompartmentId = model.CompartmentId
+
+	m.IamGroupId = model.IamGroupId
+
+	nn, e = model.TargetSelected.UnmarshalPolymorphicJSON(model.TargetSelected.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.TargetSelected = nn.(TargetSelected)
+	} else {
+		m.TargetSelected = nil
+	}
+
+	return
+}

--- a/cloudguard/delete_data_mask_rule_request_response.go
+++ b/cloudguard/delete_data_mask_rule_request_response.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package cloudguard
+
+import (
+	"github.com/oracle/oci-go-sdk/v40/common"
+	"net/http"
+)
+
+// DeleteDataMaskRuleRequest wrapper for the DeleteDataMaskRule operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/cloudguard/DeleteDataMaskRule.go.html to see an example of how to use DeleteDataMaskRuleRequest.
+type DeleteDataMaskRuleRequest struct {
+
+	// OCID of dataMaskRule
+	DataMaskRuleId *string `mandatory:"true" contributesTo:"path" name:"dataMaskRuleId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call
+	// for a resource, set the `if-match` parameter to the value of the
+	// etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you
+	// provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteDataMaskRuleRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteDataMaskRuleRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request DeleteDataMaskRuleRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteDataMaskRuleRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteDataMaskRuleResponse wrapper for the DeleteDataMaskRule operation
+type DeleteDataMaskRuleResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteDataMaskRuleResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteDataMaskRuleResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/cloudguard/detector_recipe.go
+++ b/cloudguard/detector_recipe.go
@@ -37,10 +37,10 @@ type DetectorRecipe struct {
 	// Detector recipe description
 	Description *string `mandatory:"false" json:"description"`
 
-	// List of detetor rules for the detector type for recipe
+	// List of detector rules for the detector type for recipe - user input
 	DetectorRules []DetectorRecipeDetectorRule `mandatory:"false" json:"detectorRules"`
 
-	// List of detetor rules for the detector type for recipe
+	// List of effective detector rules for the detector type for recipe after applying defaults
 	EffectiveDetectorRules []DetectorRecipeDetectorRule `mandatory:"false" json:"effectiveDetectorRules"`
 
 	// The date and time the detector recipe was created. Format defined by RFC3339.

--- a/cloudguard/detector_recipe_detector_rule.go
+++ b/cloudguard/detector_recipe_detector_rule.go
@@ -78,6 +78,7 @@ const (
 	DetectorRecipeDetectorRuleManagedListTypesState        DetectorRecipeDetectorRuleManagedListTypesEnum = "STATE"
 	DetectorRecipeDetectorRuleManagedListTypesCity         DetectorRecipeDetectorRuleManagedListTypesEnum = "CITY"
 	DetectorRecipeDetectorRuleManagedListTypesTags         DetectorRecipeDetectorRuleManagedListTypesEnum = "TAGS"
+	DetectorRecipeDetectorRuleManagedListTypesGeneric      DetectorRecipeDetectorRuleManagedListTypesEnum = "GENERIC"
 )
 
 var mappingDetectorRecipeDetectorRuleManagedListTypes = map[string]DetectorRecipeDetectorRuleManagedListTypesEnum{
@@ -92,6 +93,7 @@ var mappingDetectorRecipeDetectorRuleManagedListTypes = map[string]DetectorRecip
 	"STATE":         DetectorRecipeDetectorRuleManagedListTypesState,
 	"CITY":          DetectorRecipeDetectorRuleManagedListTypesCity,
 	"TAGS":          DetectorRecipeDetectorRuleManagedListTypesTags,
+	"GENERIC":       DetectorRecipeDetectorRuleManagedListTypesGeneric,
 }
 
 // GetDetectorRecipeDetectorRuleManagedListTypesEnumValues Enumerates the set of values for DetectorRecipeDetectorRuleManagedListTypesEnum

--- a/cloudguard/detector_recipe_detector_rule_summary.go
+++ b/cloudguard/detector_recipe_detector_rule_summary.go
@@ -78,6 +78,7 @@ const (
 	DetectorRecipeDetectorRuleSummaryManagedListTypesState        DetectorRecipeDetectorRuleSummaryManagedListTypesEnum = "STATE"
 	DetectorRecipeDetectorRuleSummaryManagedListTypesCity         DetectorRecipeDetectorRuleSummaryManagedListTypesEnum = "CITY"
 	DetectorRecipeDetectorRuleSummaryManagedListTypesTags         DetectorRecipeDetectorRuleSummaryManagedListTypesEnum = "TAGS"
+	DetectorRecipeDetectorRuleSummaryManagedListTypesGeneric      DetectorRecipeDetectorRuleSummaryManagedListTypesEnum = "GENERIC"
 )
 
 var mappingDetectorRecipeDetectorRuleSummaryManagedListTypes = map[string]DetectorRecipeDetectorRuleSummaryManagedListTypesEnum{
@@ -92,6 +93,7 @@ var mappingDetectorRecipeDetectorRuleSummaryManagedListTypes = map[string]Detect
 	"STATE":         DetectorRecipeDetectorRuleSummaryManagedListTypesState,
 	"CITY":          DetectorRecipeDetectorRuleSummaryManagedListTypesCity,
 	"TAGS":          DetectorRecipeDetectorRuleSummaryManagedListTypesTags,
+	"GENERIC":       DetectorRecipeDetectorRuleSummaryManagedListTypesGeneric,
 }
 
 // GetDetectorRecipeDetectorRuleSummaryManagedListTypesEnumValues Enumerates the set of values for DetectorRecipeDetectorRuleSummaryManagedListTypesEnum

--- a/cloudguard/detector_rule.go
+++ b/cloudguard/detector_rule.go
@@ -78,6 +78,7 @@ const (
 	DetectorRuleManagedListTypesState        DetectorRuleManagedListTypesEnum = "STATE"
 	DetectorRuleManagedListTypesCity         DetectorRuleManagedListTypesEnum = "CITY"
 	DetectorRuleManagedListTypesTags         DetectorRuleManagedListTypesEnum = "TAGS"
+	DetectorRuleManagedListTypesGeneric      DetectorRuleManagedListTypesEnum = "GENERIC"
 )
 
 var mappingDetectorRuleManagedListTypes = map[string]DetectorRuleManagedListTypesEnum{
@@ -92,6 +93,7 @@ var mappingDetectorRuleManagedListTypes = map[string]DetectorRuleManagedListType
 	"STATE":         DetectorRuleManagedListTypesState,
 	"CITY":          DetectorRuleManagedListTypesCity,
 	"TAGS":          DetectorRuleManagedListTypesTags,
+	"GENERIC":       DetectorRuleManagedListTypesGeneric,
 }
 
 // GetDetectorRuleManagedListTypesEnumValues Enumerates the set of values for DetectorRuleManagedListTypesEnum

--- a/cloudguard/detector_rule_summary.go
+++ b/cloudguard/detector_rule_summary.go
@@ -78,6 +78,7 @@ const (
 	DetectorRuleSummaryManagedListTypesState        DetectorRuleSummaryManagedListTypesEnum = "STATE"
 	DetectorRuleSummaryManagedListTypesCity         DetectorRuleSummaryManagedListTypesEnum = "CITY"
 	DetectorRuleSummaryManagedListTypesTags         DetectorRuleSummaryManagedListTypesEnum = "TAGS"
+	DetectorRuleSummaryManagedListTypesGeneric      DetectorRuleSummaryManagedListTypesEnum = "GENERIC"
 )
 
 var mappingDetectorRuleSummaryManagedListTypes = map[string]DetectorRuleSummaryManagedListTypesEnum{
@@ -92,6 +93,7 @@ var mappingDetectorRuleSummaryManagedListTypes = map[string]DetectorRuleSummaryM
 	"STATE":         DetectorRuleSummaryManagedListTypesState,
 	"CITY":          DetectorRuleSummaryManagedListTypesCity,
 	"TAGS":          DetectorRuleSummaryManagedListTypesTags,
+	"GENERIC":       DetectorRuleSummaryManagedListTypesGeneric,
 }
 
 // GetDetectorRuleSummaryManagedListTypesEnumValues Enumerates the set of values for DetectorRuleSummaryManagedListTypesEnum

--- a/cloudguard/get_data_mask_rule_request_response.go
+++ b/cloudguard/get_data_mask_rule_request_response.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package cloudguard
+
+import (
+	"github.com/oracle/oci-go-sdk/v40/common"
+	"net/http"
+)
+
+// GetDataMaskRuleRequest wrapper for the GetDataMaskRule operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/cloudguard/GetDataMaskRule.go.html to see an example of how to use GetDataMaskRuleRequest.
+type GetDataMaskRuleRequest struct {
+
+	// OCID of dataMaskRule
+	DataMaskRuleId *string `mandatory:"true" contributesTo:"path" name:"dataMaskRuleId"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetDataMaskRuleRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetDataMaskRuleRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetDataMaskRuleRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetDataMaskRuleRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetDataMaskRuleResponse wrapper for the GetDataMaskRule operation
+type GetDataMaskRuleResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The DataMaskRule instance
+	DataMaskRule `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetDataMaskRuleResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetDataMaskRuleResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/cloudguard/list_data_mask_rules_request_response.go
+++ b/cloudguard/list_data_mask_rules_request_response.go
@@ -1,0 +1,240 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package cloudguard
+
+import (
+	"github.com/oracle/oci-go-sdk/v40/common"
+	"net/http"
+)
+
+// ListDataMaskRulesRequest wrapper for the ListDataMaskRules operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/cloudguard/ListDataMaskRules.go.html to see an example of how to use ListDataMaskRulesRequest.
+type ListDataMaskRulesRequest struct {
+
+	// The ID of the compartment in which to list resources.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// A filter to return only resources that match the entire display name given.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// The field life cycle state. Only one state can be provided. Default value for state is active. If no value is specified state is active.
+	LifecycleState ListDataMaskRulesLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+
+	// Valid values are `RESTRICTED` and `ACCESSIBLE`. Default is `RESTRICTED`.
+	// Setting this to `ACCESSIBLE` returns only those compartments for which the
+	// user has INSPECT permissions directly or indirectly (permissions can be on a
+	// resource in a subcompartment).
+	// When set to `RESTRICTED` permissions are checked and no partial results are displayed.
+	AccessLevel ListDataMaskRulesAccessLevelEnum `mandatory:"false" contributesTo:"query" name:"accessLevel" omitEmpty:"true"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The sort order to use, either 'asc' or 'desc'.
+	SortOrder ListDataMaskRulesSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending. Default order for displayName is ascending. If no value is specified timeCreated is default.
+	SortBy ListDataMaskRulesSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The status of the dataMaskRule.
+	DataMaskRuleStatus ListDataMaskRulesDataMaskRuleStatusEnum `mandatory:"false" contributesTo:"query" name:"dataMaskRuleStatus" omitEmpty:"true"`
+
+	// OCID of target
+	TargetId *string `mandatory:"false" contributesTo:"query" name:"targetId"`
+
+	// OCID of iamGroup
+	IamGroupId *string `mandatory:"false" contributesTo:"query" name:"iamGroupId"`
+
+	// Type of target
+	TargetType *string `mandatory:"false" contributesTo:"query" name:"targetType"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListDataMaskRulesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListDataMaskRulesRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListDataMaskRulesRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListDataMaskRulesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListDataMaskRulesResponse wrapper for the ListDataMaskRules operation
+type ListDataMaskRulesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of DataMaskRuleCollection instances
+	DataMaskRuleCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then a partial list might have been returned. Include this value as the `page` parameter for the
+	// subsequent GET request to get the next batch of items.
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListDataMaskRulesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListDataMaskRulesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListDataMaskRulesLifecycleStateEnum Enum with underlying type: string
+type ListDataMaskRulesLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ListDataMaskRulesLifecycleStateEnum
+const (
+	ListDataMaskRulesLifecycleStateCreating ListDataMaskRulesLifecycleStateEnum = "CREATING"
+	ListDataMaskRulesLifecycleStateUpdating ListDataMaskRulesLifecycleStateEnum = "UPDATING"
+	ListDataMaskRulesLifecycleStateActive   ListDataMaskRulesLifecycleStateEnum = "ACTIVE"
+	ListDataMaskRulesLifecycleStateInactive ListDataMaskRulesLifecycleStateEnum = "INACTIVE"
+	ListDataMaskRulesLifecycleStateDeleting ListDataMaskRulesLifecycleStateEnum = "DELETING"
+	ListDataMaskRulesLifecycleStateDeleted  ListDataMaskRulesLifecycleStateEnum = "DELETED"
+	ListDataMaskRulesLifecycleStateFailed   ListDataMaskRulesLifecycleStateEnum = "FAILED"
+)
+
+var mappingListDataMaskRulesLifecycleState = map[string]ListDataMaskRulesLifecycleStateEnum{
+	"CREATING": ListDataMaskRulesLifecycleStateCreating,
+	"UPDATING": ListDataMaskRulesLifecycleStateUpdating,
+	"ACTIVE":   ListDataMaskRulesLifecycleStateActive,
+	"INACTIVE": ListDataMaskRulesLifecycleStateInactive,
+	"DELETING": ListDataMaskRulesLifecycleStateDeleting,
+	"DELETED":  ListDataMaskRulesLifecycleStateDeleted,
+	"FAILED":   ListDataMaskRulesLifecycleStateFailed,
+}
+
+// GetListDataMaskRulesLifecycleStateEnumValues Enumerates the set of values for ListDataMaskRulesLifecycleStateEnum
+func GetListDataMaskRulesLifecycleStateEnumValues() []ListDataMaskRulesLifecycleStateEnum {
+	values := make([]ListDataMaskRulesLifecycleStateEnum, 0)
+	for _, v := range mappingListDataMaskRulesLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListDataMaskRulesAccessLevelEnum Enum with underlying type: string
+type ListDataMaskRulesAccessLevelEnum string
+
+// Set of constants representing the allowable values for ListDataMaskRulesAccessLevelEnum
+const (
+	ListDataMaskRulesAccessLevelRestricted ListDataMaskRulesAccessLevelEnum = "RESTRICTED"
+	ListDataMaskRulesAccessLevelAccessible ListDataMaskRulesAccessLevelEnum = "ACCESSIBLE"
+)
+
+var mappingListDataMaskRulesAccessLevel = map[string]ListDataMaskRulesAccessLevelEnum{
+	"RESTRICTED": ListDataMaskRulesAccessLevelRestricted,
+	"ACCESSIBLE": ListDataMaskRulesAccessLevelAccessible,
+}
+
+// GetListDataMaskRulesAccessLevelEnumValues Enumerates the set of values for ListDataMaskRulesAccessLevelEnum
+func GetListDataMaskRulesAccessLevelEnumValues() []ListDataMaskRulesAccessLevelEnum {
+	values := make([]ListDataMaskRulesAccessLevelEnum, 0)
+	for _, v := range mappingListDataMaskRulesAccessLevel {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListDataMaskRulesSortOrderEnum Enum with underlying type: string
+type ListDataMaskRulesSortOrderEnum string
+
+// Set of constants representing the allowable values for ListDataMaskRulesSortOrderEnum
+const (
+	ListDataMaskRulesSortOrderAsc  ListDataMaskRulesSortOrderEnum = "ASC"
+	ListDataMaskRulesSortOrderDesc ListDataMaskRulesSortOrderEnum = "DESC"
+)
+
+var mappingListDataMaskRulesSortOrder = map[string]ListDataMaskRulesSortOrderEnum{
+	"ASC":  ListDataMaskRulesSortOrderAsc,
+	"DESC": ListDataMaskRulesSortOrderDesc,
+}
+
+// GetListDataMaskRulesSortOrderEnumValues Enumerates the set of values for ListDataMaskRulesSortOrderEnum
+func GetListDataMaskRulesSortOrderEnumValues() []ListDataMaskRulesSortOrderEnum {
+	values := make([]ListDataMaskRulesSortOrderEnum, 0)
+	for _, v := range mappingListDataMaskRulesSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListDataMaskRulesSortByEnum Enum with underlying type: string
+type ListDataMaskRulesSortByEnum string
+
+// Set of constants representing the allowable values for ListDataMaskRulesSortByEnum
+const (
+	ListDataMaskRulesSortByTimecreated ListDataMaskRulesSortByEnum = "timeCreated"
+	ListDataMaskRulesSortByDisplayname ListDataMaskRulesSortByEnum = "displayName"
+)
+
+var mappingListDataMaskRulesSortBy = map[string]ListDataMaskRulesSortByEnum{
+	"timeCreated": ListDataMaskRulesSortByTimecreated,
+	"displayName": ListDataMaskRulesSortByDisplayname,
+}
+
+// GetListDataMaskRulesSortByEnumValues Enumerates the set of values for ListDataMaskRulesSortByEnum
+func GetListDataMaskRulesSortByEnumValues() []ListDataMaskRulesSortByEnum {
+	values := make([]ListDataMaskRulesSortByEnum, 0)
+	for _, v := range mappingListDataMaskRulesSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListDataMaskRulesDataMaskRuleStatusEnum Enum with underlying type: string
+type ListDataMaskRulesDataMaskRuleStatusEnum string
+
+// Set of constants representing the allowable values for ListDataMaskRulesDataMaskRuleStatusEnum
+const (
+	ListDataMaskRulesDataMaskRuleStatusEnabled  ListDataMaskRulesDataMaskRuleStatusEnum = "ENABLED"
+	ListDataMaskRulesDataMaskRuleStatusDisabled ListDataMaskRulesDataMaskRuleStatusEnum = "DISABLED"
+)
+
+var mappingListDataMaskRulesDataMaskRuleStatus = map[string]ListDataMaskRulesDataMaskRuleStatusEnum{
+	"ENABLED":  ListDataMaskRulesDataMaskRuleStatusEnabled,
+	"DISABLED": ListDataMaskRulesDataMaskRuleStatusDisabled,
+}
+
+// GetListDataMaskRulesDataMaskRuleStatusEnumValues Enumerates the set of values for ListDataMaskRulesDataMaskRuleStatusEnum
+func GetListDataMaskRulesDataMaskRuleStatusEnumValues() []ListDataMaskRulesDataMaskRuleStatusEnum {
+	values := make([]ListDataMaskRulesDataMaskRuleStatusEnum, 0)
+	for _, v := range mappingListDataMaskRulesDataMaskRuleStatus {
+		values = append(values, v)
+	}
+	return values
+}

--- a/cloudguard/list_detector_recipes_request_response.go
+++ b/cloudguard/list_detector_recipes_request_response.go
@@ -24,7 +24,7 @@ type ListDetectorRecipesRequest struct {
 
 	// Default is false.
 	// When set to true, the list of all Oracle Managed Resources
-	// Metadata supported by Cloud Guard is returned.
+	// Metadata supported by Cloud Guard are returned.
 	ResourceMetadataOnly *bool `mandatory:"false" contributesTo:"query" name:"resourceMetadataOnly"`
 
 	// The field life cycle state. Only one state can be provided. Default value for state is active. If no value is specified state is active.

--- a/cloudguard/list_managed_lists_request_response.go
+++ b/cloudguard/list_managed_lists_request_response.go
@@ -24,7 +24,7 @@ type ListManagedListsRequest struct {
 
 	// Default is false.
 	// When set to true, the list of all Oracle Managed Resources
-	// Metadata supported by Cloud Guard is returned.
+	// Metadata supported by Cloud Guard are returned.
 	ResourceMetadataOnly *bool `mandatory:"false" contributesTo:"query" name:"resourceMetadataOnly"`
 
 	// The field life cycle state. Only one state can be provided. Default value for state is active. If no value is specified state is active.
@@ -165,6 +165,7 @@ const (
 	ListManagedListsListTypeState        ListManagedListsListTypeEnum = "STATE"
 	ListManagedListsListTypeCity         ListManagedListsListTypeEnum = "CITY"
 	ListManagedListsListTypeTags         ListManagedListsListTypeEnum = "TAGS"
+	ListManagedListsListTypeGeneric      ListManagedListsListTypeEnum = "GENERIC"
 )
 
 var mappingListManagedListsListType = map[string]ListManagedListsListTypeEnum{
@@ -179,6 +180,7 @@ var mappingListManagedListsListType = map[string]ListManagedListsListTypeEnum{
 	"STATE":         ListManagedListsListTypeState,
 	"CITY":          ListManagedListsListTypeCity,
 	"TAGS":          ListManagedListsListTypeTags,
+	"GENERIC":       ListManagedListsListTypeGeneric,
 }
 
 // GetListManagedListsListTypeEnumValues Enumerates the set of values for ListManagedListsListTypeEnum

--- a/cloudguard/list_policies_request_response.go
+++ b/cloudguard/list_policies_request_response.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package cloudguard
+
+import (
+	"github.com/oracle/oci-go-sdk/v40/common"
+	"net/http"
+)
+
+// ListPoliciesRequest wrapper for the ListPolicies operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/cloudguard/ListPolicies.go.html to see an example of how to use ListPoliciesRequest.
+type ListPoliciesRequest struct {
+
+	// The ID of the compartment in which to list resources.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The sort order to use, either 'asc' or 'desc'.
+	SortOrder ListPoliciesSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending. Default order for displayName is ascending. If no value is specified timeCreated is default.
+	SortBy ListPoliciesSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListPoliciesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListPoliciesRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListPoliciesRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListPoliciesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListPoliciesResponse wrapper for the ListPolicies operation
+type ListPoliciesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of PolicyCollection instances
+	PolicyCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then a partial list might have been returned. Include this value as the `page` parameter for the
+	// subsequent GET request to get the next batch of items.
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListPoliciesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListPoliciesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListPoliciesSortOrderEnum Enum with underlying type: string
+type ListPoliciesSortOrderEnum string
+
+// Set of constants representing the allowable values for ListPoliciesSortOrderEnum
+const (
+	ListPoliciesSortOrderAsc  ListPoliciesSortOrderEnum = "ASC"
+	ListPoliciesSortOrderDesc ListPoliciesSortOrderEnum = "DESC"
+)
+
+var mappingListPoliciesSortOrder = map[string]ListPoliciesSortOrderEnum{
+	"ASC":  ListPoliciesSortOrderAsc,
+	"DESC": ListPoliciesSortOrderDesc,
+}
+
+// GetListPoliciesSortOrderEnumValues Enumerates the set of values for ListPoliciesSortOrderEnum
+func GetListPoliciesSortOrderEnumValues() []ListPoliciesSortOrderEnum {
+	values := make([]ListPoliciesSortOrderEnum, 0)
+	for _, v := range mappingListPoliciesSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListPoliciesSortByEnum Enum with underlying type: string
+type ListPoliciesSortByEnum string
+
+// Set of constants representing the allowable values for ListPoliciesSortByEnum
+const (
+	ListPoliciesSortByTimecreated ListPoliciesSortByEnum = "timeCreated"
+	ListPoliciesSortByDisplayname ListPoliciesSortByEnum = "displayName"
+)
+
+var mappingListPoliciesSortBy = map[string]ListPoliciesSortByEnum{
+	"timeCreated": ListPoliciesSortByTimecreated,
+	"displayName": ListPoliciesSortByDisplayname,
+}
+
+// GetListPoliciesSortByEnumValues Enumerates the set of values for ListPoliciesSortByEnum
+func GetListPoliciesSortByEnumValues() []ListPoliciesSortByEnum {
+	values := make([]ListPoliciesSortByEnum, 0)
+	for _, v := range mappingListPoliciesSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/cloudguard/list_problems_request_response.go
+++ b/cloudguard/list_problems_request_response.go
@@ -19,16 +19,16 @@ type ListProblemsRequest struct {
 	// The ID of the compartment in which to list resources.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
-	// Start time for a filter. If start time is not specified, start time will be set to today's current time - 30 days.
+	// Start time for a filter. If start time is not specified, start time will be set to current time - 30 days.
 	TimeLastDetectedGreaterThanOrEqualTo *common.SDKTime `mandatory:"false" contributesTo:"query" name:"timeLastDetectedGreaterThanOrEqualTo"`
 
-	// End time for a filter. If end time is not specified, end time will be set to today's current time.
+	// End time for a filter. If end time is not specified, end time will be set to current time.
 	TimeLastDetectedLessThanOrEqualTo *common.SDKTime `mandatory:"false" contributesTo:"query" name:"timeLastDetectedLessThanOrEqualTo"`
 
-	// Start time for a filter. If start time is not specified, start time will be set to today's current time - 30 days.
+	// Start time for a filter. If start time is not specified, start time will be set to current time - 30 days.
 	TimeFirstDetectedGreaterThanOrEqualTo *common.SDKTime `mandatory:"false" contributesTo:"query" name:"timeFirstDetectedGreaterThanOrEqualTo"`
 
-	// End time for a filter. If end time is not specified, end time will be set to today's current time.
+	// End time for a filter. If end time is not specified, end time will be set to current time.
 	TimeFirstDetectedLessThanOrEqualTo *common.SDKTime `mandatory:"false" contributesTo:"query" name:"timeFirstDetectedLessThanOrEqualTo"`
 
 	// The field life cycle state. Only one state can be provided. Default value for state is active. If no value is specified state is active.

--- a/cloudguard/list_responder_recipes_request_response.go
+++ b/cloudguard/list_responder_recipes_request_response.go
@@ -21,7 +21,7 @@ type ListResponderRecipesRequest struct {
 
 	// Default is false.
 	// When set to true, the list of all Oracle Managed Resources
-	// Metadata supported by Cloud Guard is returned.
+	// Metadata supported by Cloud Guard are returned.
 	ResourceMetadataOnly *bool `mandatory:"false" contributesTo:"query" name:"resourceMetadataOnly"`
 
 	// A filter to return only resources that match the entire display name given.

--- a/cloudguard/managed_list_type.go
+++ b/cloudguard/managed_list_type.go
@@ -25,6 +25,7 @@ const (
 	ManagedListTypeState        ManagedListTypeEnum = "STATE"
 	ManagedListTypeCity         ManagedListTypeEnum = "CITY"
 	ManagedListTypeTags         ManagedListTypeEnum = "TAGS"
+	ManagedListTypeGeneric      ManagedListTypeEnum = "GENERIC"
 )
 
 var mappingManagedListType = map[string]ManagedListTypeEnum{
@@ -39,6 +40,7 @@ var mappingManagedListType = map[string]ManagedListTypeEnum{
 	"STATE":         ManagedListTypeState,
 	"CITY":          ManagedListTypeCity,
 	"TAGS":          ManagedListTypeTags,
+	"GENERIC":       ManagedListTypeGeneric,
 }
 
 // GetManagedListTypeEnumValues Enumerates the set of values for ManagedListTypeEnum

--- a/cloudguard/policy_collection.go
+++ b/cloudguard/policy_collection.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Cloud Guard APIs
+//
+// A description of the Cloud Guard APIs
+//
+
+package cloudguard
+
+import (
+	"github.com/oracle/oci-go-sdk/v40/common"
+)
+
+// PolicyCollection Collection of policy statements required by cloud guard
+type PolicyCollection struct {
+
+	// List of global policy statements
+	Items []PolicySummary `mandatory:"true" json:"items"`
+}
+
+func (m PolicyCollection) String() string {
+	return common.PointerString(m)
+}

--- a/cloudguard/policy_summary.go
+++ b/cloudguard/policy_summary.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Cloud Guard APIs
+//
+// A description of the Cloud Guard APIs
+//
+
+package cloudguard
+
+import (
+	"github.com/oracle/oci-go-sdk/v40/common"
+)
+
+// PolicySummary Global policy statement
+type PolicySummary struct {
+
+	// Global policy statement
+	Policy *string `mandatory:"true" json:"policy"`
+}
+
+func (m PolicySummary) String() string {
+	return common.PointerString(m)
+}

--- a/cloudguard/problem.go
+++ b/cloudguard/problem.go
@@ -64,6 +64,15 @@ type Problem struct {
 	// targetId of the problem
 	TargetId *string `mandatory:"false" json:"targetId"`
 
+	// The additional details of the Problem
+	AdditionalDetails map[string]string `mandatory:"false" json:"additionalDetails"`
+
+	// Description of the problem
+	Description *string `mandatory:"false" json:"description"`
+
+	// Recommendation for the problem
+	Recommendation *string `mandatory:"false" json:"recommendation"`
+
 	// User Comments
 	Comment *string `mandatory:"false" json:"comment"`
 }

--- a/cloudguard/request_summarized_trend_problems_request_response.go
+++ b/cloudguard/request_summarized_trend_problems_request_response.go
@@ -19,10 +19,10 @@ type RequestSummarizedTrendProblemsRequest struct {
 	// The ID of the compartment in which to list resources.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
-	// Start time for a filter. If start time is not specified, start time will be set to today's current time - 30 days.
+	// Start time for a filter. If start time is not specified, start time will be set to current time - 30 days.
 	TimeFirstDetectedGreaterThanOrEqualTo *common.SDKTime `mandatory:"false" contributesTo:"query" name:"timeFirstDetectedGreaterThanOrEqualTo"`
 
-	// End time for a filter. If end time is not specified, end time will be set to today's current time.
+	// End time for a filter. If end time is not specified, end time will be set to current time.
 	TimeFirstDetectedLessThanOrEqualTo *common.SDKTime `mandatory:"false" contributesTo:"query" name:"timeFirstDetectedLessThanOrEqualTo"`
 
 	// Default is false.

--- a/cloudguard/security_rating.go
+++ b/cloudguard/security_rating.go
@@ -18,6 +18,7 @@ const (
 	SecurityRatingGood      SecurityRatingEnum = "GOOD"
 	SecurityRatingFair      SecurityRatingEnum = "FAIR"
 	SecurityRatingPoor      SecurityRatingEnum = "POOR"
+	SecurityRatingNa        SecurityRatingEnum = "NA"
 )
 
 var mappingSecurityRating = map[string]SecurityRatingEnum{
@@ -25,6 +26,7 @@ var mappingSecurityRating = map[string]SecurityRatingEnum{
 	"GOOD":      SecurityRatingGood,
 	"FAIR":      SecurityRatingFair,
 	"POOR":      SecurityRatingPoor,
+	"NA":        SecurityRatingNa,
 }
 
 // GetSecurityRatingEnumValues Enumerates the set of values for SecurityRatingEnum

--- a/cloudguard/target_detector_recipe_detector_rule.go
+++ b/cloudguard/target_detector_recipe_detector_rule.go
@@ -75,6 +75,7 @@ const (
 	TargetDetectorRecipeDetectorRuleManagedListTypesState        TargetDetectorRecipeDetectorRuleManagedListTypesEnum = "STATE"
 	TargetDetectorRecipeDetectorRuleManagedListTypesCity         TargetDetectorRecipeDetectorRuleManagedListTypesEnum = "CITY"
 	TargetDetectorRecipeDetectorRuleManagedListTypesTags         TargetDetectorRecipeDetectorRuleManagedListTypesEnum = "TAGS"
+	TargetDetectorRecipeDetectorRuleManagedListTypesGeneric      TargetDetectorRecipeDetectorRuleManagedListTypesEnum = "GENERIC"
 )
 
 var mappingTargetDetectorRecipeDetectorRuleManagedListTypes = map[string]TargetDetectorRecipeDetectorRuleManagedListTypesEnum{
@@ -89,6 +90,7 @@ var mappingTargetDetectorRecipeDetectorRuleManagedListTypes = map[string]TargetD
 	"STATE":         TargetDetectorRecipeDetectorRuleManagedListTypesState,
 	"CITY":          TargetDetectorRecipeDetectorRuleManagedListTypesCity,
 	"TAGS":          TargetDetectorRecipeDetectorRuleManagedListTypesTags,
+	"GENERIC":       TargetDetectorRecipeDetectorRuleManagedListTypesGeneric,
 }
 
 // GetTargetDetectorRecipeDetectorRuleManagedListTypesEnumValues Enumerates the set of values for TargetDetectorRecipeDetectorRuleManagedListTypesEnum

--- a/cloudguard/target_detector_recipe_detector_rule_summary.go
+++ b/cloudguard/target_detector_recipe_detector_rule_summary.go
@@ -75,6 +75,7 @@ const (
 	TargetDetectorRecipeDetectorRuleSummaryManagedListTypesState        TargetDetectorRecipeDetectorRuleSummaryManagedListTypesEnum = "STATE"
 	TargetDetectorRecipeDetectorRuleSummaryManagedListTypesCity         TargetDetectorRecipeDetectorRuleSummaryManagedListTypesEnum = "CITY"
 	TargetDetectorRecipeDetectorRuleSummaryManagedListTypesTags         TargetDetectorRecipeDetectorRuleSummaryManagedListTypesEnum = "TAGS"
+	TargetDetectorRecipeDetectorRuleSummaryManagedListTypesGeneric      TargetDetectorRecipeDetectorRuleSummaryManagedListTypesEnum = "GENERIC"
 )
 
 var mappingTargetDetectorRecipeDetectorRuleSummaryManagedListTypes = map[string]TargetDetectorRecipeDetectorRuleSummaryManagedListTypesEnum{
@@ -89,6 +90,7 @@ var mappingTargetDetectorRecipeDetectorRuleSummaryManagedListTypes = map[string]
 	"STATE":         TargetDetectorRecipeDetectorRuleSummaryManagedListTypesState,
 	"CITY":          TargetDetectorRecipeDetectorRuleSummaryManagedListTypesCity,
 	"TAGS":          TargetDetectorRecipeDetectorRuleSummaryManagedListTypesTags,
+	"GENERIC":       TargetDetectorRecipeDetectorRuleSummaryManagedListTypesGeneric,
 }
 
 // GetTargetDetectorRecipeDetectorRuleSummaryManagedListTypesEnumValues Enumerates the set of values for TargetDetectorRecipeDetectorRuleSummaryManagedListTypesEnum

--- a/cloudguard/target_ids_selected.go
+++ b/cloudguard/target_ids_selected.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Cloud Guard APIs
+//
+// A description of the Cloud Guard APIs
+//
+
+package cloudguard
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/v40/common"
+)
+
+// TargetIdsSelected Target selection on basis of TargetIds.
+type TargetIdsSelected struct {
+
+	// Ids of Target
+	Values []string `mandatory:"false" json:"values"`
+}
+
+func (m TargetIdsSelected) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m TargetIdsSelected) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeTargetIdsSelected TargetIdsSelected
+	s := struct {
+		DiscriminatorParam string `json:"kind"`
+		MarshalTypeTargetIdsSelected
+	}{
+		"TARGETIDS",
+		(MarshalTypeTargetIdsSelected)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/cloudguard/target_resource_types_selected.go
+++ b/cloudguard/target_resource_types_selected.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Cloud Guard APIs
+//
+// A description of the Cloud Guard APIs
+//
+
+package cloudguard
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/v40/common"
+)
+
+// TargetResourceTypesSelected Target selection on basis of TargetResourceTypes.
+type TargetResourceTypesSelected struct {
+
+	// Types of Targets
+	Values []TargetResourceTypeEnum `mandatory:"false" json:"values,omitempty"`
+}
+
+func (m TargetResourceTypesSelected) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m TargetResourceTypesSelected) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeTargetResourceTypesSelected TargetResourceTypesSelected
+	s := struct {
+		DiscriminatorParam string `json:"kind"`
+		MarshalTypeTargetResourceTypesSelected
+	}{
+		"TARGETTYPES",
+		(MarshalTypeTargetResourceTypesSelected)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/cloudguard/target_selected.go
+++ b/cloudguard/target_selected.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Cloud Guard APIs
+//
+// A description of the Cloud Guard APIs
+//
+
+package cloudguard
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/v40/common"
+)
+
+// TargetSelected Target Selection eg select ALL or select on basis of TargetResourceTypes or TargetIds.
+type TargetSelected interface {
+}
+
+type targetselected struct {
+	JsonData []byte
+	Kind     string `json:"kind"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *targetselected) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalertargetselected targetselected
+	s := struct {
+		Model Unmarshalertargetselected
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Kind = s.Model.Kind
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *targetselected) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.Kind {
+	case "ALL":
+		mm := AllTargetsSelected{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "TARGETTYPES":
+		mm := TargetResourceTypesSelected{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "TARGETIDS":
+		mm := TargetIdsSelected{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m targetselected) String() string {
+	return common.PointerString(m)
+}
+
+// TargetSelectedKindEnum Enum with underlying type: string
+type TargetSelectedKindEnum string
+
+// Set of constants representing the allowable values for TargetSelectedKindEnum
+const (
+	TargetSelectedKindAll         TargetSelectedKindEnum = "ALL"
+	TargetSelectedKindTargettypes TargetSelectedKindEnum = "TARGETTYPES"
+	TargetSelectedKindTargetids   TargetSelectedKindEnum = "TARGETIDS"
+)
+
+var mappingTargetSelectedKind = map[string]TargetSelectedKindEnum{
+	"ALL":         TargetSelectedKindAll,
+	"TARGETTYPES": TargetSelectedKindTargettypes,
+	"TARGETIDS":   TargetSelectedKindTargetids,
+}
+
+// GetTargetSelectedKindEnumValues Enumerates the set of values for TargetSelectedKindEnum
+func GetTargetSelectedKindEnumValues() []TargetSelectedKindEnum {
+	values := make([]TargetSelectedKindEnum, 0)
+	for _, v := range mappingTargetSelectedKind {
+		values = append(values, v)
+	}
+	return values
+}

--- a/cloudguard/update_bulk_problem_status_details.go
+++ b/cloudguard/update_bulk_problem_status_details.go
@@ -21,6 +21,9 @@ type UpdateBulkProblemStatusDetails struct {
 
 	// List of ProblemIds to be passed in to update the Problem status.
 	ProblemIds []string `mandatory:"true" json:"problemIds"`
+
+	// User defined comment to be passed in to update the problem.
+	Comment *string `mandatory:"false" json:"comment"`
 }
 
 func (m UpdateBulkProblemStatusDetails) String() string {

--- a/cloudguard/update_data_mask_rule_details.go
+++ b/cloudguard/update_data_mask_rule_details.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Cloud Guard APIs
+//
+// A description of the Cloud Guard APIs
+//
+
+package cloudguard
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/v40/common"
+)
+
+// UpdateDataMaskRuleDetails The information to be updated.
+type UpdateDataMaskRuleDetails struct {
+
+	// Data Mask Rule Name
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Compartment Identifier where the resource is created
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// IAM Group id associated with the data mask rule
+	IamGroupId *string `mandatory:"false" json:"iamGroupId"`
+
+	TargetSelected TargetSelected `mandatory:"false" json:"targetSelected"`
+
+	// Data Mask Categories
+	DataMaskCategories []DataMaskCategoryEnum `mandatory:"false" json:"dataMaskCategories,omitempty"`
+
+	// The status of the dataMaskRule.
+	DataMaskRuleStatus DataMaskRuleStatusEnum `mandatory:"false" json:"dataMaskRuleStatus,omitempty"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m UpdateDataMaskRuleDetails) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *UpdateDataMaskRuleDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		DisplayName        *string                           `json:"displayName"`
+		CompartmentId      *string                           `json:"compartmentId"`
+		IamGroupId         *string                           `json:"iamGroupId"`
+		TargetSelected     targetselected                    `json:"targetSelected"`
+		DataMaskCategories []DataMaskCategoryEnum            `json:"dataMaskCategories"`
+		DataMaskRuleStatus DataMaskRuleStatusEnum            `json:"dataMaskRuleStatus"`
+		FreeformTags       map[string]string                 `json:"freeformTags"`
+		DefinedTags        map[string]map[string]interface{} `json:"definedTags"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.DisplayName = model.DisplayName
+
+	m.CompartmentId = model.CompartmentId
+
+	m.IamGroupId = model.IamGroupId
+
+	nn, e = model.TargetSelected.UnmarshalPolymorphicJSON(model.TargetSelected.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.TargetSelected = nn.(TargetSelected)
+	} else {
+		m.TargetSelected = nil
+	}
+
+	m.DataMaskCategories = make([]DataMaskCategoryEnum, len(model.DataMaskCategories))
+	for i, n := range model.DataMaskCategories {
+		m.DataMaskCategories[i] = n
+	}
+
+	m.DataMaskRuleStatus = model.DataMaskRuleStatus
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	return
+}

--- a/cloudguard/update_data_mask_rule_request_response.go
+++ b/cloudguard/update_data_mask_rule_request_response.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package cloudguard
+
+import (
+	"github.com/oracle/oci-go-sdk/v40/common"
+	"net/http"
+)
+
+// UpdateDataMaskRuleRequest wrapper for the UpdateDataMaskRule operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/cloudguard/UpdateDataMaskRule.go.html to see an example of how to use UpdateDataMaskRuleRequest.
+type UpdateDataMaskRuleRequest struct {
+
+	// OCID of dataMaskRule
+	DataMaskRuleId *string `mandatory:"true" contributesTo:"path" name:"dataMaskRuleId"`
+
+	// The information to be updated.
+	UpdateDataMaskRuleDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call
+	// for a resource, set the `if-match` parameter to the value of the
+	// etag from a previous GET or POST response for that resource.
+	// The resource will be updated or deleted only if the etag you
+	// provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateDataMaskRuleRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateDataMaskRuleRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request UpdateDataMaskRuleRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateDataMaskRuleRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateDataMaskRuleResponse wrapper for the UpdateDataMaskRule operation
+type UpdateDataMaskRuleResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The DataMaskRule instance
+	DataMaskRule `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateDataMaskRuleResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateDataMaskRuleResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/common/version.go
+++ b/common/version.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	major = "40"
-	minor = "0"
+	minor = "1"
 	patch = "0"
 	tag   = ""
 )

--- a/core/create_vnic_details.go
+++ b/core/create_vnic_details.go
@@ -44,6 +44,12 @@ type CreateVnicDetails struct {
 	// Vlan.
 	AssignPublicIp *bool `mandatory:"false" json:"assignPublicIp"`
 
+	// Whether the VNIC should be assigned a DNS record. If set to false, there will be no DNS record
+	// registration for the VNIC. If set to true, the DNS record will be registered. The default
+	// value is true.
+	// If you specify a `hostnameLabel`, then `assignPrivateDnsRecord` must be set to true.
+	AssignPrivateDnsRecord *bool `mandatory:"false" json:"assignPrivateDnsRecord"`
+
 	// Defined tags for this resource. Each key is predefined and scoped to a
 	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`

--- a/core/instance_configuration_create_vnic_details.go
+++ b/core/instance_configuration_create_vnic_details.go
@@ -25,6 +25,10 @@ type InstanceConfigurationCreateVnicDetails struct {
 	// for more information.
 	AssignPublicIp *bool `mandatory:"false" json:"assignPublicIp"`
 
+	// Whether the VNIC should be assigned a private DNS record. See the `assignPrivateDnsRecord` attribute of CreateVnicDetails
+	// for more information.
+	AssignPrivateDnsRecord *bool `mandatory:"false" json:"assignPrivateDnsRecord"`
+
 	// Defined tags for this resource. Each key is predefined and scoped to a
 	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`

--- a/core/list_vlans_request_response.go
+++ b/core/list_vlans_request_response.go
@@ -19,9 +19,6 @@ type ListVlansRequest struct {
 	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
-	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
-	VcnId *string `mandatory:"true" contributesTo:"query" name:"vcnId"`
-
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
 	// "List" call. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
@@ -32,6 +29,9 @@ type ListVlansRequest struct {
 	// call. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
+	VcnId *string `mandatory:"false" contributesTo:"query" name:"vcnId"`
 
 	// A filter to return only resources that match the given display name exactly.
 	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`

--- a/core/update_cluster_network_details.go
+++ b/core/update_cluster_network_details.go
@@ -33,6 +33,9 @@ type UpdateClusterNetworkDetails struct {
 	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// The instance pools in the cluster network to update.
+	InstancePools []UpdateClusterNetworkInstancePoolDetails `mandatory:"false" json:"instancePools"`
 }
 
 func (m UpdateClusterNetworkDetails) String() string {

--- a/core/update_cluster_network_instance_pool_details.go
+++ b/core/update_cluster_network_instance_pool_details.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/v40/common"
+)
+
+// UpdateClusterNetworkInstancePoolDetails The data to update an instance pool within a cluster network.
+type UpdateClusterNetworkInstancePoolDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the instance pool.
+	Id *string `mandatory:"true" json:"id"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// A user-friendly name for the instance pool. Does not have to be unique, and it's
+	// changeable. Avoid entering confidential information.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// The number of instances that should be in the instance pool.
+	Size *int `mandatory:"false" json:"size"`
+}
+
+func (m UpdateClusterNetworkInstancePoolDetails) String() string {
+	return common.PointerString(m)
+}

--- a/database/external_container_database.go
+++ b/database/external_container_database.go
@@ -69,6 +69,9 @@ type ExternalContainerDatabase struct {
 	// The database packs licensed for the external Oracle Database.
 	DbPacks *string `mandatory:"false" json:"dbPacks"`
 
+	// The Oracle Database configuration
+	DatabaseConfiguration ExternalContainerDatabaseDatabaseConfigurationEnum `mandatory:"false" json:"databaseConfiguration,omitempty"`
+
 	DatabaseManagementConfig *DatabaseManagementConfig `mandatory:"false" json:"databaseManagementConfig"`
 }
 
@@ -131,6 +134,29 @@ var mappingExternalContainerDatabaseDatabaseEdition = map[string]ExternalContain
 func GetExternalContainerDatabaseDatabaseEditionEnumValues() []ExternalContainerDatabaseDatabaseEditionEnum {
 	values := make([]ExternalContainerDatabaseDatabaseEditionEnum, 0)
 	for _, v := range mappingExternalContainerDatabaseDatabaseEdition {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ExternalContainerDatabaseDatabaseConfigurationEnum Enum with underlying type: string
+type ExternalContainerDatabaseDatabaseConfigurationEnum string
+
+// Set of constants representing the allowable values for ExternalContainerDatabaseDatabaseConfigurationEnum
+const (
+	ExternalContainerDatabaseDatabaseConfigurationRac            ExternalContainerDatabaseDatabaseConfigurationEnum = "RAC"
+	ExternalContainerDatabaseDatabaseConfigurationSingleInstance ExternalContainerDatabaseDatabaseConfigurationEnum = "SINGLE_INSTANCE"
+)
+
+var mappingExternalContainerDatabaseDatabaseConfiguration = map[string]ExternalContainerDatabaseDatabaseConfigurationEnum{
+	"RAC":             ExternalContainerDatabaseDatabaseConfigurationRac,
+	"SINGLE_INSTANCE": ExternalContainerDatabaseDatabaseConfigurationSingleInstance,
+}
+
+// GetExternalContainerDatabaseDatabaseConfigurationEnumValues Enumerates the set of values for ExternalContainerDatabaseDatabaseConfigurationEnum
+func GetExternalContainerDatabaseDatabaseConfigurationEnumValues() []ExternalContainerDatabaseDatabaseConfigurationEnum {
+	values := make([]ExternalContainerDatabaseDatabaseConfigurationEnum, 0)
+	for _, v := range mappingExternalContainerDatabaseDatabaseConfiguration {
 		values = append(values, v)
 	}
 	return values

--- a/database/external_container_database_summary.go
+++ b/database/external_container_database_summary.go
@@ -69,6 +69,9 @@ type ExternalContainerDatabaseSummary struct {
 	// The database packs licensed for the external Oracle Database.
 	DbPacks *string `mandatory:"false" json:"dbPacks"`
 
+	// The Oracle Database configuration
+	DatabaseConfiguration ExternalContainerDatabaseSummaryDatabaseConfigurationEnum `mandatory:"false" json:"databaseConfiguration,omitempty"`
+
 	DatabaseManagementConfig *DatabaseManagementConfig `mandatory:"false" json:"databaseManagementConfig"`
 }
 
@@ -131,6 +134,29 @@ var mappingExternalContainerDatabaseSummaryDatabaseEdition = map[string]External
 func GetExternalContainerDatabaseSummaryDatabaseEditionEnumValues() []ExternalContainerDatabaseSummaryDatabaseEditionEnum {
 	values := make([]ExternalContainerDatabaseSummaryDatabaseEditionEnum, 0)
 	for _, v := range mappingExternalContainerDatabaseSummaryDatabaseEdition {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ExternalContainerDatabaseSummaryDatabaseConfigurationEnum Enum with underlying type: string
+type ExternalContainerDatabaseSummaryDatabaseConfigurationEnum string
+
+// Set of constants representing the allowable values for ExternalContainerDatabaseSummaryDatabaseConfigurationEnum
+const (
+	ExternalContainerDatabaseSummaryDatabaseConfigurationRac            ExternalContainerDatabaseSummaryDatabaseConfigurationEnum = "RAC"
+	ExternalContainerDatabaseSummaryDatabaseConfigurationSingleInstance ExternalContainerDatabaseSummaryDatabaseConfigurationEnum = "SINGLE_INSTANCE"
+)
+
+var mappingExternalContainerDatabaseSummaryDatabaseConfiguration = map[string]ExternalContainerDatabaseSummaryDatabaseConfigurationEnum{
+	"RAC":             ExternalContainerDatabaseSummaryDatabaseConfigurationRac,
+	"SINGLE_INSTANCE": ExternalContainerDatabaseSummaryDatabaseConfigurationSingleInstance,
+}
+
+// GetExternalContainerDatabaseSummaryDatabaseConfigurationEnumValues Enumerates the set of values for ExternalContainerDatabaseSummaryDatabaseConfigurationEnum
+func GetExternalContainerDatabaseSummaryDatabaseConfigurationEnumValues() []ExternalContainerDatabaseSummaryDatabaseConfigurationEnum {
+	values := make([]ExternalContainerDatabaseSummaryDatabaseConfigurationEnum, 0)
+	for _, v := range mappingExternalContainerDatabaseSummaryDatabaseConfiguration {
 		values = append(values, v)
 	}
 	return values

--- a/database/external_database_base.go
+++ b/database/external_database_base.go
@@ -69,6 +69,9 @@ type ExternalDatabaseBase struct {
 	// The database packs licensed for the external Oracle Database.
 	DbPacks *string `mandatory:"false" json:"dbPacks"`
 
+	// The Oracle Database configuration
+	DatabaseConfiguration ExternalDatabaseBaseDatabaseConfigurationEnum `mandatory:"false" json:"databaseConfiguration,omitempty"`
+
 	DatabaseManagementConfig *DatabaseManagementConfig `mandatory:"false" json:"databaseManagementConfig"`
 }
 
@@ -131,6 +134,29 @@ var mappingExternalDatabaseBaseDatabaseEdition = map[string]ExternalDatabaseBase
 func GetExternalDatabaseBaseDatabaseEditionEnumValues() []ExternalDatabaseBaseDatabaseEditionEnum {
 	values := make([]ExternalDatabaseBaseDatabaseEditionEnum, 0)
 	for _, v := range mappingExternalDatabaseBaseDatabaseEdition {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ExternalDatabaseBaseDatabaseConfigurationEnum Enum with underlying type: string
+type ExternalDatabaseBaseDatabaseConfigurationEnum string
+
+// Set of constants representing the allowable values for ExternalDatabaseBaseDatabaseConfigurationEnum
+const (
+	ExternalDatabaseBaseDatabaseConfigurationRac            ExternalDatabaseBaseDatabaseConfigurationEnum = "RAC"
+	ExternalDatabaseBaseDatabaseConfigurationSingleInstance ExternalDatabaseBaseDatabaseConfigurationEnum = "SINGLE_INSTANCE"
+)
+
+var mappingExternalDatabaseBaseDatabaseConfiguration = map[string]ExternalDatabaseBaseDatabaseConfigurationEnum{
+	"RAC":             ExternalDatabaseBaseDatabaseConfigurationRac,
+	"SINGLE_INSTANCE": ExternalDatabaseBaseDatabaseConfigurationSingleInstance,
+}
+
+// GetExternalDatabaseBaseDatabaseConfigurationEnumValues Enumerates the set of values for ExternalDatabaseBaseDatabaseConfigurationEnum
+func GetExternalDatabaseBaseDatabaseConfigurationEnumValues() []ExternalDatabaseBaseDatabaseConfigurationEnum {
+	values := make([]ExternalDatabaseBaseDatabaseConfigurationEnum, 0)
+	for _, v := range mappingExternalDatabaseBaseDatabaseConfiguration {
 		values = append(values, v)
 	}
 	return values

--- a/database/external_non_container_database.go
+++ b/database/external_non_container_database.go
@@ -69,6 +69,9 @@ type ExternalNonContainerDatabase struct {
 	// The database packs licensed for the external Oracle Database.
 	DbPacks *string `mandatory:"false" json:"dbPacks"`
 
+	// The Oracle Database configuration
+	DatabaseConfiguration ExternalNonContainerDatabaseDatabaseConfigurationEnum `mandatory:"false" json:"databaseConfiguration,omitempty"`
+
 	DatabaseManagementConfig *DatabaseManagementConfig `mandatory:"false" json:"databaseManagementConfig"`
 
 	OperationsInsightsConfig *OperationsInsightsConfig `mandatory:"false" json:"operationsInsightsConfig"`
@@ -133,6 +136,29 @@ var mappingExternalNonContainerDatabaseDatabaseEdition = map[string]ExternalNonC
 func GetExternalNonContainerDatabaseDatabaseEditionEnumValues() []ExternalNonContainerDatabaseDatabaseEditionEnum {
 	values := make([]ExternalNonContainerDatabaseDatabaseEditionEnum, 0)
 	for _, v := range mappingExternalNonContainerDatabaseDatabaseEdition {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ExternalNonContainerDatabaseDatabaseConfigurationEnum Enum with underlying type: string
+type ExternalNonContainerDatabaseDatabaseConfigurationEnum string
+
+// Set of constants representing the allowable values for ExternalNonContainerDatabaseDatabaseConfigurationEnum
+const (
+	ExternalNonContainerDatabaseDatabaseConfigurationRac            ExternalNonContainerDatabaseDatabaseConfigurationEnum = "RAC"
+	ExternalNonContainerDatabaseDatabaseConfigurationSingleInstance ExternalNonContainerDatabaseDatabaseConfigurationEnum = "SINGLE_INSTANCE"
+)
+
+var mappingExternalNonContainerDatabaseDatabaseConfiguration = map[string]ExternalNonContainerDatabaseDatabaseConfigurationEnum{
+	"RAC":             ExternalNonContainerDatabaseDatabaseConfigurationRac,
+	"SINGLE_INSTANCE": ExternalNonContainerDatabaseDatabaseConfigurationSingleInstance,
+}
+
+// GetExternalNonContainerDatabaseDatabaseConfigurationEnumValues Enumerates the set of values for ExternalNonContainerDatabaseDatabaseConfigurationEnum
+func GetExternalNonContainerDatabaseDatabaseConfigurationEnumValues() []ExternalNonContainerDatabaseDatabaseConfigurationEnum {
+	values := make([]ExternalNonContainerDatabaseDatabaseConfigurationEnum, 0)
+	for _, v := range mappingExternalNonContainerDatabaseDatabaseConfiguration {
 		values = append(values, v)
 	}
 	return values

--- a/database/external_non_container_database_summary.go
+++ b/database/external_non_container_database_summary.go
@@ -70,6 +70,9 @@ type ExternalNonContainerDatabaseSummary struct {
 	// The database packs licensed for the external Oracle Database.
 	DbPacks *string `mandatory:"false" json:"dbPacks"`
 
+	// The Oracle Database configuration
+	DatabaseConfiguration ExternalNonContainerDatabaseSummaryDatabaseConfigurationEnum `mandatory:"false" json:"databaseConfiguration,omitempty"`
+
 	DatabaseManagementConfig *DatabaseManagementConfig `mandatory:"false" json:"databaseManagementConfig"`
 
 	OperationsInsightsConfig *OperationsInsightsConfig `mandatory:"false" json:"operationsInsightsConfig"`
@@ -134,6 +137,29 @@ var mappingExternalNonContainerDatabaseSummaryDatabaseEdition = map[string]Exter
 func GetExternalNonContainerDatabaseSummaryDatabaseEditionEnumValues() []ExternalNonContainerDatabaseSummaryDatabaseEditionEnum {
 	values := make([]ExternalNonContainerDatabaseSummaryDatabaseEditionEnum, 0)
 	for _, v := range mappingExternalNonContainerDatabaseSummaryDatabaseEdition {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ExternalNonContainerDatabaseSummaryDatabaseConfigurationEnum Enum with underlying type: string
+type ExternalNonContainerDatabaseSummaryDatabaseConfigurationEnum string
+
+// Set of constants representing the allowable values for ExternalNonContainerDatabaseSummaryDatabaseConfigurationEnum
+const (
+	ExternalNonContainerDatabaseSummaryDatabaseConfigurationRac            ExternalNonContainerDatabaseSummaryDatabaseConfigurationEnum = "RAC"
+	ExternalNonContainerDatabaseSummaryDatabaseConfigurationSingleInstance ExternalNonContainerDatabaseSummaryDatabaseConfigurationEnum = "SINGLE_INSTANCE"
+)
+
+var mappingExternalNonContainerDatabaseSummaryDatabaseConfiguration = map[string]ExternalNonContainerDatabaseSummaryDatabaseConfigurationEnum{
+	"RAC":             ExternalNonContainerDatabaseSummaryDatabaseConfigurationRac,
+	"SINGLE_INSTANCE": ExternalNonContainerDatabaseSummaryDatabaseConfigurationSingleInstance,
+}
+
+// GetExternalNonContainerDatabaseSummaryDatabaseConfigurationEnumValues Enumerates the set of values for ExternalNonContainerDatabaseSummaryDatabaseConfigurationEnum
+func GetExternalNonContainerDatabaseSummaryDatabaseConfigurationEnumValues() []ExternalNonContainerDatabaseSummaryDatabaseConfigurationEnum {
+	values := make([]ExternalNonContainerDatabaseSummaryDatabaseConfigurationEnum, 0)
+	for _, v := range mappingExternalNonContainerDatabaseSummaryDatabaseConfiguration {
 		values = append(values, v)
 	}
 	return values

--- a/database/external_pluggable_database.go
+++ b/database/external_pluggable_database.go
@@ -74,6 +74,9 @@ type ExternalPluggableDatabase struct {
 	// The database packs licensed for the external Oracle Database.
 	DbPacks *string `mandatory:"false" json:"dbPacks"`
 
+	// The Oracle Database configuration
+	DatabaseConfiguration ExternalPluggableDatabaseDatabaseConfigurationEnum `mandatory:"false" json:"databaseConfiguration,omitempty"`
+
 	DatabaseManagementConfig *DatabaseManagementConfig `mandatory:"false" json:"databaseManagementConfig"`
 
 	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the the non-container database that was converted
@@ -142,6 +145,29 @@ var mappingExternalPluggableDatabaseDatabaseEdition = map[string]ExternalPluggab
 func GetExternalPluggableDatabaseDatabaseEditionEnumValues() []ExternalPluggableDatabaseDatabaseEditionEnum {
 	values := make([]ExternalPluggableDatabaseDatabaseEditionEnum, 0)
 	for _, v := range mappingExternalPluggableDatabaseDatabaseEdition {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ExternalPluggableDatabaseDatabaseConfigurationEnum Enum with underlying type: string
+type ExternalPluggableDatabaseDatabaseConfigurationEnum string
+
+// Set of constants representing the allowable values for ExternalPluggableDatabaseDatabaseConfigurationEnum
+const (
+	ExternalPluggableDatabaseDatabaseConfigurationRac            ExternalPluggableDatabaseDatabaseConfigurationEnum = "RAC"
+	ExternalPluggableDatabaseDatabaseConfigurationSingleInstance ExternalPluggableDatabaseDatabaseConfigurationEnum = "SINGLE_INSTANCE"
+)
+
+var mappingExternalPluggableDatabaseDatabaseConfiguration = map[string]ExternalPluggableDatabaseDatabaseConfigurationEnum{
+	"RAC":             ExternalPluggableDatabaseDatabaseConfigurationRac,
+	"SINGLE_INSTANCE": ExternalPluggableDatabaseDatabaseConfigurationSingleInstance,
+}
+
+// GetExternalPluggableDatabaseDatabaseConfigurationEnumValues Enumerates the set of values for ExternalPluggableDatabaseDatabaseConfigurationEnum
+func GetExternalPluggableDatabaseDatabaseConfigurationEnumValues() []ExternalPluggableDatabaseDatabaseConfigurationEnum {
+	values := make([]ExternalPluggableDatabaseDatabaseConfigurationEnum, 0)
+	for _, v := range mappingExternalPluggableDatabaseDatabaseConfiguration {
 		values = append(values, v)
 	}
 	return values

--- a/database/external_pluggable_database_summary.go
+++ b/database/external_pluggable_database_summary.go
@@ -74,6 +74,9 @@ type ExternalPluggableDatabaseSummary struct {
 	// The database packs licensed for the external Oracle Database.
 	DbPacks *string `mandatory:"false" json:"dbPacks"`
 
+	// The Oracle Database configuration
+	DatabaseConfiguration ExternalPluggableDatabaseSummaryDatabaseConfigurationEnum `mandatory:"false" json:"databaseConfiguration,omitempty"`
+
 	DatabaseManagementConfig *DatabaseManagementConfig `mandatory:"false" json:"databaseManagementConfig"`
 
 	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the the non-container database that was converted
@@ -142,6 +145,29 @@ var mappingExternalPluggableDatabaseSummaryDatabaseEdition = map[string]External
 func GetExternalPluggableDatabaseSummaryDatabaseEditionEnumValues() []ExternalPluggableDatabaseSummaryDatabaseEditionEnum {
 	values := make([]ExternalPluggableDatabaseSummaryDatabaseEditionEnum, 0)
 	for _, v := range mappingExternalPluggableDatabaseSummaryDatabaseEdition {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ExternalPluggableDatabaseSummaryDatabaseConfigurationEnum Enum with underlying type: string
+type ExternalPluggableDatabaseSummaryDatabaseConfigurationEnum string
+
+// Set of constants representing the allowable values for ExternalPluggableDatabaseSummaryDatabaseConfigurationEnum
+const (
+	ExternalPluggableDatabaseSummaryDatabaseConfigurationRac            ExternalPluggableDatabaseSummaryDatabaseConfigurationEnum = "RAC"
+	ExternalPluggableDatabaseSummaryDatabaseConfigurationSingleInstance ExternalPluggableDatabaseSummaryDatabaseConfigurationEnum = "SINGLE_INSTANCE"
+)
+
+var mappingExternalPluggableDatabaseSummaryDatabaseConfiguration = map[string]ExternalPluggableDatabaseSummaryDatabaseConfigurationEnum{
+	"RAC":             ExternalPluggableDatabaseSummaryDatabaseConfigurationRac,
+	"SINGLE_INSTANCE": ExternalPluggableDatabaseSummaryDatabaseConfigurationSingleInstance,
+}
+
+// GetExternalPluggableDatabaseSummaryDatabaseConfigurationEnumValues Enumerates the set of values for ExternalPluggableDatabaseSummaryDatabaseConfigurationEnum
+func GetExternalPluggableDatabaseSummaryDatabaseConfigurationEnumValues() []ExternalPluggableDatabaseSummaryDatabaseConfigurationEnum {
+	values := make([]ExternalPluggableDatabaseSummaryDatabaseConfigurationEnum, 0)
+	for _, v := range mappingExternalPluggableDatabaseSummaryDatabaseConfiguration {
 		values = append(values, v)
 	}
 	return values

--- a/databasemigration/admin_credentials.go
+++ b/databasemigration/admin_credentials.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,10 +13,10 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// AdminCredentials Database Admin Credentials details.
+// AdminCredentials Database Administrator Credentials details.
 type AdminCredentials struct {
 
-	// Admin username
+	// Administrator username
 	Username *string `mandatory:"true" json:"username"`
 }
 

--- a/databasemigration/agent.go
+++ b/databasemigration/agent.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -37,7 +37,7 @@ type Agent struct {
 	// The time of the last Agent details update. An RFC3339 formatted datetime string.
 	TimeUpdated *common.SDKTime `mandatory:"true" json:"timeUpdated"`
 
-	// The current state of the ODMS On Prem Agent.
+	// The current state of the ODMS on-premises Agent.
 	LifecycleState LifecycleStatesEnum `mandatory:"true" json:"lifecycleState"`
 
 	// ODMS Agent public key.

--- a/databasemigration/agent_collection.go
+++ b/databasemigration/agent_collection.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,7 +13,7 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// AgentCollection Results of a Agent search. Contains AgentSummary items.
+// AgentCollection Results of an Agent search. Contains AgentSummary items.
 type AgentCollection struct {
 
 	// Items in collection.

--- a/databasemigration/agent_image_collection.go
+++ b/databasemigration/agent_image_collection.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,7 +13,7 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// AgentImageCollection Results of a ODMS Agent Image search. Contains AgentImageSummary items.
+// AgentImageCollection Results of an ODMS Agent Image search. Contains AgentImageSummary items.
 type AgentImageCollection struct {
 
 	// Items in collection.

--- a/databasemigration/agent_image_summary.go
+++ b/databasemigration/agent_image_summary.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/agent_summary.go
+++ b/databasemigration/agent_summary.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -31,7 +31,7 @@ type AgentSummary struct {
 	// The time the Agent was created. An RFC3339 formatted datetime string.
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
-	// The current state of the ODMS On Prem Agent.
+	// The current state of the ODMS on-premises Agent.
 	LifecycleState LifecycleStatesEnum `mandatory:"true" json:"lifecycleState"`
 
 	// The OCID of the Stream

--- a/databasemigration/change_agent_compartment_details.go
+++ b/databasemigration/change_agent_compartment_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,7 +13,7 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// ChangeAgentCompartmentDetails ChangeAgentCompartmentDetails description
+// ChangeAgentCompartmentDetails Change Agent compartment details
 type ChangeAgentCompartmentDetails struct {
 
 	// The OCID of the compartment to move the resource to.

--- a/databasemigration/change_connection_compartment_details.go
+++ b/databasemigration/change_connection_compartment_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/change_connection_compartment_request_response.go
+++ b/databasemigration/change_connection_compartment_request_response.go
@@ -16,7 +16,7 @@ import (
 // Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/databasemigration/ChangeConnectionCompartment.go.html to see an example of how to use ChangeConnectionCompartmentRequest.
 type ChangeConnectionCompartmentRequest struct {
 
-	// The OCID of the job
+	// The OCID of the database connection
 	ConnectionId *string `mandatory:"true" contributesTo:"path" name:"connectionId"`
 
 	// Details to change the compartment.

--- a/databasemigration/change_migration_compartment_details.go
+++ b/databasemigration/change_migration_compartment_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/change_migration_compartment_request_response.go
+++ b/databasemigration/change_migration_compartment_request_response.go
@@ -16,7 +16,7 @@ import (
 // Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/databasemigration/ChangeMigrationCompartment.go.html to see an example of how to use ChangeMigrationCompartmentRequest.
 type ChangeMigrationCompartmentRequest struct {
 
-	// The OCID of the job
+	// The OCID of the migration
 	MigrationId *string `mandatory:"true" contributesTo:"path" name:"migrationId"`
 
 	// Details to change the compartment.

--- a/databasemigration/clone_migration_details.go
+++ b/databasemigration/clone_migration_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,7 +13,7 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// CloneMigrationDetails Details to specify that will override an existing Migration configuration that will be cloned.
+// CloneMigrationDetails Details that will override an existing Migration configuration that will be cloned.
 type CloneMigrationDetails struct {
 
 	// The OCID of the Source Database Connection.
@@ -28,10 +28,10 @@ type CloneMigrationDetails struct {
 	// OCID of the compartment
 	CompartmentId *string `mandatory:"false" json:"compartmentId"`
 
-	// The OCID of the registered On-Prem ODMS Agent. Required for OFFLINE Migrations.
+	// The OCID of the registered on-premises ODMS Agent. Only valid for Offline Logical Migrations.
 	AgentId *string `mandatory:"false" json:"agentId"`
 
-	// The OCID of the Source Container Database Connection. Only used for ONLINE migrations.
+	// The OCID of the Source Container Database Connection. Only used for Online migrations.
 	// Only Connections of type Non-Autonomous can be used as source container databases.
 	SourceContainerDatabaseConnectionId *string `mandatory:"false" json:"sourceContainerDatabaseConnectionId"`
 

--- a/databasemigration/clone_migration_request_response.go
+++ b/databasemigration/clone_migration_request_response.go
@@ -16,7 +16,7 @@ import (
 // Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/databasemigration/CloneMigration.go.html to see an example of how to use CloneMigrationRequest.
 type CloneMigrationRequest struct {
 
-	// The OCID of the job
+	// The OCID of the migration
 	MigrationId *string `mandatory:"true" contributesTo:"path" name:"migrationId"`
 
 	// Clone Migration properties.

--- a/databasemigration/connect_descriptor.go
+++ b/databasemigration/connect_descriptor.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/connection.go
+++ b/databasemigration/connection.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/connection_collection.go
+++ b/databasemigration/connection_collection.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/connection_summary.go
+++ b/databasemigration/connection_summary.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/create_admin_credentials.go
+++ b/databasemigration/create_admin_credentials.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,13 +13,13 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// CreateAdminCredentials Database Admin Credentials details.
+// CreateAdminCredentials Database Administrator Credentials details.
 type CreateAdminCredentials struct {
 
-	// Admin username
+	// Administrator username
 	Username *string `mandatory:"true" json:"username"`
 
-	// Admin password
+	// Administrator password
 	Password *string `mandatory:"true" json:"password"`
 }
 

--- a/databasemigration/create_agent_details.go
+++ b/databasemigration/create_agent_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/create_connect_descriptor.go
+++ b/databasemigration/create_connect_descriptor.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/create_connection_details.go
+++ b/databasemigration/create_connection_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/create_data_pump_parameters.go
+++ b/databasemigration/create_data_pump_parameters.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,10 +13,10 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// CreateDataPumpParameters Optional parameters for Datapump Export and Import. Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-62324358-2F26-4A94-B69F-1075D53FA96D__BABDECJE
+// CreateDataPumpParameters Optional parameters for Data Pump Export and Import. Refer to Configuring Optional Initial Load Advanced Settings (https://docs.us.oracle.com/en/cloud/paas/database-migration/dmsus/working-migration-resources.html#GUID-24BD3054-FDF8-48FF-8492-636C1D4B71ED)
 type CreateDataPumpParameters struct {
 
-	// False to force datapump worker process to run on one instance.
+	// Set to false to force Data Pump worker process to run on one instance.
 	IsCluster *bool `mandatory:"false" json:"isCluster"`
 
 	// Estimate size of dumps that will be generated.
@@ -25,14 +25,14 @@ type CreateDataPumpParameters struct {
 	// IMPORT: Specifies the action to be performed when data is loaded into a preexisting table.
 	TableExistsAction DataPumpTableExistsActionEnum `mandatory:"false" json:"tableExistsAction,omitempty"`
 
-	// Exclude paratemers for export and import.
+	// Exclude paratemers for Export and Import.
 	ExcludeParameters []DataPumpExcludeParametersEnum `mandatory:"false" json:"excludeParameters"`
 
-	// Maximum number of worker processes that can be used for a Datapump Import job.
+	// Maximum number of worker processes that can be used for a Data Pump Import job.
 	// For an Autonomous Database, ODMS will automatically query its CPU core count and set this property.
 	ImportParallelismDegree *int `mandatory:"false" json:"importParallelismDegree"`
 
-	// Maximum number of worker processes that can be used for a Datapump Export job.
+	// Maximum number of worker processes that can be used for a Data Pump Export job.
 	ExportParallelismDegree *int `mandatory:"false" json:"exportParallelismDegree"`
 }
 

--- a/databasemigration/create_data_pump_settings.go
+++ b/databasemigration/create_data_pump_settings.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,17 +13,17 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// CreateDataPumpSettings Optional settings for Datapump Export and Import jobs
+// CreateDataPumpSettings Optional settings for Data Pump Export and Import jobs
 type CreateDataPumpSettings struct {
 
-	// DataPump job mode.
-	// Refer to docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-92C2CB46-8BC9-414D-B62E-79CD788C1E62__BABBDEHD
+	// Data Pump job mode.
+	// Refer to link text (https://docs.oracle.com/en/database/oracle/oracle-database/19/sutil/oracle-data-pump-export-utility.html#GUID-8E497131-6B9B-4CC8-AA50-35F480CAC2C4)
 	JobMode DataPumpJobModeEnum `mandatory:"false" json:"jobMode,omitempty"`
 
 	DataPumpParameters *CreateDataPumpParameters `mandatory:"false" json:"dataPumpParameters"`
 
 	// Defines remapping to be applied to objects as they are processed.
-	// Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D.
+	// Refer to DATA_REMAP (https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-E75AAE6F-4EA6-4737-A752-6B62F5E9D460)
 	MetadataRemaps []MetadataRemap `mandatory:"false" json:"metadataRemaps"`
 
 	ExportDirectoryObject *CreateDirectoryObject `mandatory:"false" json:"exportDirectoryObject"`

--- a/databasemigration/create_data_transfer_medium_details.go
+++ b/databasemigration/create_data_transfer_medium_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -14,7 +14,7 @@ import (
 )
 
 // CreateDataTransferMediumDetails Data Transfer Medium details for the Migration. If not specified, it will default to Database Link. Only one type
-// of medium details can be specified.
+// of data transfer medium can be specified.
 type CreateDataTransferMediumDetails struct {
 	DatabaseLinkDetails *CreateDatabaseLinkDetails `mandatory:"false" json:"databaseLinkDetails"`
 

--- a/databasemigration/create_database_link_details.go
+++ b/databasemigration/create_database_link_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/create_directory_object.go
+++ b/databasemigration/create_directory_object.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/create_extract.go
+++ b/databasemigration/create_extract.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,7 +13,7 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// CreateExtract Parameters for Extract processes.
+// CreateExtract Parameters for GoldenGate Extract processes.
 type CreateExtract struct {
 
 	// Extract performance.

--- a/databasemigration/create_golden_gate_details.go
+++ b/databasemigration/create_golden_gate_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/create_golden_gate_hub.go
+++ b/databasemigration/create_golden_gate_hub.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -21,19 +21,19 @@ type CreateGoldenGateHub struct {
 
 	TargetDbAdminCredentials *CreateAdminCredentials `mandatory:"true" json:"targetDbAdminCredentials"`
 
-	// Oracle GoldenGate hub's REST endpoint.
+	// Oracle GoldenGate Microservices hub's REST endpoint.
 	// Refer to https://docs.oracle.com/en/middleware/goldengate/core/19.1/securing/network.html#GUID-A709DA55-111D-455E-8942-C9BDD1E38CAA
 	Url *string `mandatory:"true" json:"url"`
 
-	// Name of Microservices deployment to operate on source DB
+	// Name of GoldenGate Microservices deployment to operate on source database
 	SourceMicroservicesDeploymentName *string `mandatory:"true" json:"sourceMicroservicesDeploymentName"`
 
-	// Name of Microservices deployment to operate on target DB
+	// Name of GoldenGate Microservices deployment to operate on target database
 	TargetMicroservicesDeploymentName *string `mandatory:"true" json:"targetMicroservicesDeploymentName"`
 
 	SourceContainerDbAdminCredentials *CreateAdminCredentials `mandatory:"false" json:"sourceContainerDbAdminCredentials"`
 
-	// OCID of Golden Gate compute instance.
+	// OCID of GoldenGate Microservices compute instance.
 	ComputeId *string `mandatory:"false" json:"computeId"`
 }
 

--- a/databasemigration/create_golden_gate_settings.go
+++ b/databasemigration/create_golden_gate_settings.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,7 +13,7 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// CreateGoldenGateSettings Optional settings for Oracle GoldenGate processes
+// CreateGoldenGateSettings Optional settings for GoldenGate Microservices processes
 type CreateGoldenGateSettings struct {
 	Extract *CreateExtract `mandatory:"false" json:"extract"`
 

--- a/databasemigration/create_migration_details.go
+++ b/databasemigration/create_migration_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -31,10 +31,10 @@ type CreateMigrationDetails struct {
 	// Migration Display Name
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// The OCID of the registered ODMS Agent. Required for OFFLINE Migrations.
+	// The OCID of the registered ODMS Agent. Only valid for Offline Logical Migrations.
 	AgentId *string `mandatory:"false" json:"agentId"`
 
-	// The OCID of the Source Container Database Connection. Only used for ONLINE migrations.
+	// The OCID of the Source Container Database Connection. Only used for Online migrations.
 	// Only Connections of type Non-Autonomous can be used as source container databases.
 	SourceContainerDatabaseConnectionId *string `mandatory:"false" json:"sourceContainerDatabaseConnectionId"`
 

--- a/databasemigration/create_object_store_bucket.go
+++ b/databasemigration/create_object_store_bucket.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,7 +13,7 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// CreateObjectStoreBucket In lieu of a network database link, OCI Object Storage bucket will be used to store Datapump dump files for the migration.
+// CreateObjectStoreBucket In lieu of a network database link, OCI Object Storage bucket will be used to store Data Pump dump files for the migration.
 type CreateObjectStoreBucket struct {
 
 	// Namespace name of the object store bucket.

--- a/databasemigration/create_private_endpoint.go
+++ b/databasemigration/create_private_endpoint.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -18,15 +18,14 @@ import (
 type CreatePrivateEndpoint struct {
 
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to contain the
-	// private endpoint. Required if the id was not specified.
+	// private endpoint.
 	CompartmentId *string `mandatory:"true" json:"compartmentId"`
 
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN where the Private Endpoint will be bound to.
-	// Required if the id was not specified.
 	VcnId *string `mandatory:"true" json:"vcnId"`
 
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the customer's subnet where the private endpoint VNIC
-	// will reside.  Required if the id was not specified.
+	// will reside.
 	SubnetId *string `mandatory:"true" json:"subnetId"`
 }
 

--- a/databasemigration/create_replicat.go
+++ b/databasemigration/create_replicat.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,7 +13,7 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// CreateReplicat Parameters for Replicat processes.
+// CreateReplicat Parameters for GoldenGate Replicat processes.
 type CreateReplicat struct {
 
 	// Number of threads used to read trail files (valid for Parallel Replicat)

--- a/databasemigration/create_ssh_details.go
+++ b/databasemigration/create_ssh_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,14 +13,14 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// CreateSshDetails Details of the ssh key that will be used. Required for source database Manual and UserManagerOci connection types.
+// CreateSshDetails Details of the SSH key that will be used. Required for source database Manual and UserManagerOci connection types.
 // Not required for source container database connections.
 type CreateSshDetails struct {
 
-	// Name of the host the sshkey is valid for.
+	// Name of the host the SSH key is valid for.
 	Host *string `mandatory:"true" json:"host"`
 
-	// Private ssh key string.
+	// Private SSH key string.
 	Sshkey *string `mandatory:"true" json:"sshkey"`
 
 	// SSH user

--- a/databasemigration/create_vault_details.go
+++ b/databasemigration/create_vault_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/data_pump_estimate.go
+++ b/databasemigration/data_pump_estimate.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/data_pump_exclude_parameters.go
+++ b/databasemigration/data_pump_exclude_parameters.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/data_pump_job_mode.go
+++ b/databasemigration/data_pump_job_mode.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/data_pump_parameters.go
+++ b/databasemigration/data_pump_parameters.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,10 +13,10 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// DataPumpParameters Optional parameters for Datapump Export and Import. Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-62324358-2F26-4A94-B69F-1075D53FA96D__BABDECJE
+// DataPumpParameters Optional parameters for Data Pump Export and Import. Refer to Configuring Optional Initial Load Advanced Settings (https://docs.us.oracle.com/en/cloud/paas/database-migration/dmsus/working-migration-resources.html#GUID-24BD3054-FDF8-48FF-8492-636C1D4B71ED)
 type DataPumpParameters struct {
 
-	// False to force datapump worker process to run on one instance.
+	// Set to false to force Data Pump worker processes to run on one instance.
 	IsCluster *bool `mandatory:"false" json:"isCluster"`
 
 	// Estimate size of dumps that will be generated.
@@ -25,14 +25,14 @@ type DataPumpParameters struct {
 	// IMPORT: Specifies the action to be performed when data is loaded into a preexisting table.
 	TableExistsAction DataPumpTableExistsActionEnum `mandatory:"false" json:"tableExistsAction,omitempty"`
 
-	// Exclude paratemers for export and import.
+	// Exclude paratemers for Export and Import.
 	ExcludeParameters []DataPumpExcludeParametersEnum `mandatory:"false" json:"excludeParameters"`
 
-	// Maximum number of worker processes that can be used for a Datapump Import job.
+	// Maximum number of worker processes that can be used for a Data Pump Import job.
 	// For an Autonomous Database, ODMS will automatically query its CPU core count and set this property.
 	ImportParallelismDegree *int `mandatory:"false" json:"importParallelismDegree"`
 
-	// Maximum number of worker processes that can be used for a Datapump Export job.
+	// Maximum number of worker processes that can be used for a Data Pump Export job.
 	ExportParallelismDegree *int `mandatory:"false" json:"exportParallelismDegree"`
 }
 

--- a/databasemigration/data_pump_settings.go
+++ b/databasemigration/data_pump_settings.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,17 +13,17 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// DataPumpSettings Optional settings for Datapump Export and Import jobs
+// DataPumpSettings Optional settings for Data Pump Export and Import jobs
 type DataPumpSettings struct {
 
-	// DataPump job mode.
-	// Refer to docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-92C2CB46-8BC9-414D-B62E-79CD788C1E62__BABBDEHD
+	// Data Pump job mode.
+	// Refer to Data Pump Export Modes  (https://docs.oracle.com/en/database/oracle/oracle-database/19/sutil/oracle-data-pump-export-utility.html#GUID-8E497131-6B9B-4CC8-AA50-35F480CAC2C4)
 	JobMode DataPumpJobModeEnum `mandatory:"false" json:"jobMode,omitempty"`
 
 	DataPumpParameters *DataPumpParameters `mandatory:"false" json:"dataPumpParameters"`
 
 	// Defines remapping to be applied to objects as they are processed.
-	// Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D.
+	// Refer to METADATA_REMAP Procedure  (https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D)
 	MetadataRemaps []MetadataRemap `mandatory:"false" json:"metadataRemaps"`
 
 	ExportDirectoryObject *DirectoryObject `mandatory:"false" json:"exportDirectoryObject"`

--- a/databasemigration/data_pump_table_exists_action.go
+++ b/databasemigration/data_pump_table_exists_action.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/data_transfer_medium_details.go
+++ b/databasemigration/data_transfer_medium_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/database_connection_types.go
+++ b/databasemigration/database_connection_types.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/database_link_details.go
+++ b/databasemigration/database_link_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/database_object.go
+++ b/databasemigration/database_object.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/databasemigration_client.go
+++ b/databasemigration/databasemigration_client.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -138,7 +138,7 @@ func (client DatabaseMigrationClient) abortJob(ctx context.Context, request comm
 	return response, err
 }
 
-// ChangeAgentCompartment Used to configure a ODMS Agent Compartment Id.
+// ChangeAgentCompartment Used to configure an ODMS Agent Compartment ID.
 //
 // See also
 //
@@ -197,7 +197,7 @@ func (client DatabaseMigrationClient) changeAgentCompartment(ctx context.Context
 	return response, err
 }
 
-// ChangeConnectionCompartment Used to change the Databasee Connection compartment.
+// ChangeConnectionCompartment Used to change the Database Connection compartment.
 //
 // See also
 //
@@ -435,7 +435,7 @@ func (client DatabaseMigrationClient) createConnection(ctx context.Context, requ
 }
 
 // CreateMigration Create a Migration resource that contains all the details to perform the
-// database migration operation like source and destination database
+// database migration operation, such as source and destination database
 // details, credentials, etc.
 //
 // See also
@@ -495,7 +495,7 @@ func (client DatabaseMigrationClient) createMigration(ctx context.Context, reque
 	return response, err
 }
 
-// DeleteAgent Delete the ODMS Agent represented by the given ODMS Agent id.
+// DeleteAgent Delete the ODMS Agent represented by the specified ODMS Agent ID.
 //
 // See also
 //
@@ -1752,7 +1752,7 @@ func (client DatabaseMigrationClient) startMigration(ctx context.Context, reques
 	return response, err
 }
 
-// UpdateAgent Modifies the ODMS Agent represented by the given ODMS agent Id.
+// UpdateAgent Modifies the ODMS Agent represented by the given ODMS Agent ID.
 //
 // See also
 //
@@ -1811,7 +1811,7 @@ func (client DatabaseMigrationClient) updateAgent(ctx context.Context, request c
 	return response, err
 }
 
-// UpdateConnection Update a Database Connection resource details.
+// UpdateConnection Update Database Connection resource details.
 //
 // See also
 //
@@ -1865,7 +1865,7 @@ func (client DatabaseMigrationClient) updateConnection(ctx context.Context, requ
 	return response, err
 }
 
-// UpdateJob Update a Migration Job resource details.
+// UpdateJob Update Migration Job resource details.
 //
 // See also
 //
@@ -1919,7 +1919,7 @@ func (client DatabaseMigrationClient) updateJob(ctx context.Context, request com
 	return response, err
 }
 
-// UpdateMigration Update a Migration resource details.
+// UpdateMigration Update Migration resource details.
 //
 // See also
 //

--- a/databasemigration/delete_connection_request_response.go
+++ b/databasemigration/delete_connection_request_response.go
@@ -16,7 +16,7 @@ import (
 // Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/databasemigration/DeleteConnection.go.html to see an example of how to use DeleteConnectionRequest.
 type DeleteConnectionRequest struct {
 
-	// The OCID of the job
+	// The OCID of the database connection
 	ConnectionId *string `mandatory:"true" contributesTo:"path" name:"connectionId"`
 
 	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a

--- a/databasemigration/delete_migration_request_response.go
+++ b/databasemigration/delete_migration_request_response.go
@@ -16,7 +16,7 @@ import (
 // Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/databasemigration/DeleteMigration.go.html to see an example of how to use DeleteMigrationRequest.
 type DeleteMigrationRequest struct {
 
-	// The OCID of the job
+	// The OCID of the migration
 	MigrationId *string `mandatory:"true" contributesTo:"path" name:"migrationId"`
 
 	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a

--- a/databasemigration/directory_object.go
+++ b/databasemigration/directory_object.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/evaluate_migration_request_response.go
+++ b/databasemigration/evaluate_migration_request_response.go
@@ -16,7 +16,7 @@ import (
 // Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/databasemigration/EvaluateMigration.go.html to see an example of how to use EvaluateMigrationRequest.
 type EvaluateMigrationRequest struct {
 
-	// The OCID of the job
+	// The OCID of the migration
 	MigrationId *string `mandatory:"true" contributesTo:"path" name:"migrationId"`
 
 	// For optimistic concurrency control. In the PUT or DELETE call

--- a/databasemigration/extract.go
+++ b/databasemigration/extract.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/extract_performance_profile.go
+++ b/databasemigration/extract_performance_profile.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/generate_token.go
+++ b/databasemigration/generate_token.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/get_connection_request_response.go
+++ b/databasemigration/get_connection_request_response.go
@@ -16,7 +16,7 @@ import (
 // Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/databasemigration/GetConnection.go.html to see an example of how to use GetConnectionRequest.
 type GetConnectionRequest struct {
 
-	// The OCID of the job
+	// The OCID of the database connection
 	ConnectionId *string `mandatory:"true" contributesTo:"path" name:"connectionId"`
 
 	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a

--- a/databasemigration/get_migration_request_response.go
+++ b/databasemigration/get_migration_request_response.go
@@ -16,7 +16,7 @@ import (
 // Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/databasemigration/GetMigration.go.html to see an example of how to use GetMigrationRequest.
 type GetMigrationRequest struct {
 
-	// The OCID of the job
+	// The OCID of the migration
 	MigrationId *string `mandatory:"true" contributesTo:"path" name:"migrationId"`
 
 	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a

--- a/databasemigration/golden_gate_details.go
+++ b/databasemigration/golden_gate_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/golden_gate_hub.go
+++ b/databasemigration/golden_gate_hub.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -25,15 +25,15 @@ type GoldenGateHub struct {
 	// Refer to https://docs.oracle.com/en/middleware/goldengate/core/19.1/securing/network.html#GUID-A709DA55-111D-455E-8942-C9BDD1E38CAA
 	Url *string `mandatory:"true" json:"url"`
 
-	// Name of Microservices deployment to operate on source DB
+	// Name of GoldenGate deployment to operate on source database
 	SourceMicroservicesDeploymentName *string `mandatory:"true" json:"sourceMicroservicesDeploymentName"`
 
-	// Name of Microservices deployment to operate on target DB
+	// Name of GoldenGate deployment to operate on target database
 	TargetMicroservicesDeploymentName *string `mandatory:"true" json:"targetMicroservicesDeploymentName"`
 
 	SourceContainerDbAdminCredentials *AdminCredentials `mandatory:"false" json:"sourceContainerDbAdminCredentials"`
 
-	// OCID of Golden Gate compute instance.
+	// OCID of GoldenGate compute instance.
 	ComputeId *string `mandatory:"false" json:"computeId"`
 }
 

--- a/databasemigration/golden_gate_settings.go
+++ b/databasemigration/golden_gate_settings.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/job.go
+++ b/databasemigration/job.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -28,13 +28,13 @@ type Job struct {
 	// The job type.
 	Type JobTypesEnum `mandatory:"true" json:"type"`
 
-	// The time the DB Migration Job was created. An RFC3339 formatted datetime string
+	// The time the Migration Job was created. An RFC3339 formatted datetime string
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
 	// The current state of the migration job.
 	LifecycleState JobLifecycleStatesEnum `mandatory:"true" json:"lifecycleState"`
 
-	// The time the DB Migration Job was last updated. An RFC3339 formatted datetime string
+	// The time the Migration Job was last updated. An RFC3339 formatted datetime string
 	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
 
 	Progress *MigrationJobProgressResource `mandatory:"false" json:"progress"`

--- a/databasemigration/job_collection.go
+++ b/databasemigration/job_collection.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/job_lifecycle_states.go
+++ b/databasemigration/job_lifecycle_states.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/job_output_summary.go
+++ b/databasemigration/job_output_summary.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/job_output_summary_collection.go
+++ b/databasemigration/job_output_summary_collection.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/job_phase_status.go
+++ b/databasemigration/job_phase_status.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/job_summary.go
+++ b/databasemigration/job_summary.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -28,7 +28,7 @@ type JobSummary struct {
 	// The job type.
 	Type JobTypesEnum `mandatory:"true" json:"type"`
 
-	// The time the DB Migration Job was created. An RFC3339 formatted datetime string
+	// The time the Migration Job was created. An RFC3339 formatted datetime string
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
 	// The current state of the migration Deployment.
@@ -36,7 +36,7 @@ type JobSummary struct {
 
 	Progress *MigrationJobProgressSummary `mandatory:"false" json:"progress"`
 
-	// The time the DB Migration Job was last updated. An RFC3339 formatted datetime string
+	// The time the Migration Job was last updated. An RFC3339 formatted datetime string
 	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
 
 	// A message describing the current state in more detail. For example, can be used to provide actionable information

--- a/databasemigration/job_types.go
+++ b/databasemigration/job_types.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/lifecycle_states.go
+++ b/databasemigration/lifecycle_states.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/metadata_remap.go
+++ b/databasemigration/metadata_remap.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -14,10 +14,10 @@ import (
 )
 
 // MetadataRemap Defines remapping to be applied to objects as they are processed.
-// Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D.
+// Refer to METADATA_REMAP Procedure  (https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D)
 type MetadataRemap struct {
 
-	// Type of remap. Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D__BABDJGDI
+	// Type of remap. Refer to METADATA_REMAP Procedure  (https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D)
 	Type MetadataRemapTypeEnum `mandatory:"true" json:"type"`
 
 	// Specifies the value which needs to be reset.

--- a/databasemigration/migration.go
+++ b/databasemigration/migration.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -37,17 +37,17 @@ type Migration struct {
 	// The time the Migration was created. An RFC3339 formatted datetime string.
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
-	// The current state of the Migration Resource.
+	// The current state of the Migration resource.
 	LifecycleState LifecycleStatesEnum `mandatory:"true" json:"lifecycleState"`
 
 	// Name of a migration phase. The Job will wait after executing this
 	// phase until the Resume Job endpoint is called.
 	WaitAfter OdmsJobPhasesEnum `mandatory:"false" json:"waitAfter,omitempty"`
 
-	// The OCID of the registered On-Prem ODMS Agent. Required for Offline Migrations.
+	// The OCID of the registered on-premises ODMS Agent. Only valid for Offline Migrations.
 	AgentId *string `mandatory:"false" json:"agentId"`
 
-	// OCID of the Secret in the OCI vault containing the Migration credentials. Used to store Golden Gate admin user credentials.
+	// OCID of the Secret in the OCI vault containing the Migration credentials. Used to store GoldenGate administrator user credentials.
 	CredentialsSecretId *string `mandatory:"false" json:"credentialsSecretId"`
 
 	// The OCID of the Source Container Database Connection.

--- a/databasemigration/migration_collection.go
+++ b/databasemigration/migration_collection.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/migration_job_progress_resource.go
+++ b/databasemigration/migration_job_progress_resource.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/migration_job_progress_summary.go
+++ b/databasemigration/migration_job_progress_summary.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/migration_phase_collection.go
+++ b/databasemigration/migration_phase_collection.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/migration_phase_summary.go
+++ b/databasemigration/migration_phase_summary.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/migration_status.go
+++ b/databasemigration/migration_status.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/migration_summary.go
+++ b/databasemigration/migration_summary.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -46,7 +46,7 @@ type MigrationSummary struct {
 	// OCID of the current ODMS Job in execution for the Migration, if any.
 	ExecutingJobId *string `mandatory:"false" json:"executingJobId"`
 
-	// The OCID of the registered On-Prem ODMS Agent. Required for Offline Migrations.
+	// The OCID of the registered on-premises ODMS Agent. Only valid for Offline Migrations.
 	AgentId *string `mandatory:"false" json:"agentId"`
 
 	VaultDetails *VaultDetails `mandatory:"false" json:"vaultDetails"`

--- a/databasemigration/migration_types.go
+++ b/databasemigration/migration_types.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/object_store_bucket.go
+++ b/databasemigration/object_store_bucket.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,7 +13,7 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// ObjectStoreBucket In lieu of a network database link, OCI Object Storage bucket will be used to store Datapump dump files for the migration.
+// ObjectStoreBucket In lieu of a network database link, OCI Object Storage bucket will be used to store Data Pump dump files for the migration.
 type ObjectStoreBucket struct {
 
 	// Namespace name of the object store bucket.

--- a/databasemigration/odms_job_phases.go
+++ b/databasemigration/odms_job_phases.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/odms_phase_actions.go
+++ b/databasemigration/odms_phase_actions.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/operation_status.go
+++ b/databasemigration/operation_status.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/operation_types.go
+++ b/databasemigration/operation_types.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/par_link.go
+++ b/databasemigration/par_link.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/phase_status.go
+++ b/databasemigration/phase_status.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/private_endpoint_details.go
+++ b/databasemigration/private_endpoint_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/replicat.go
+++ b/databasemigration/replicat.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -19,10 +19,10 @@ type Replicat struct {
 	// Number of threads used to read trail files (valid for Parallel Replicat)
 	MapParallelism *int `mandatory:"false" json:"mapParallelism"`
 
-	// Defines the range in which the Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
+	// Defines the range in which Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
 	MinApplyParallelism *int `mandatory:"false" json:"minApplyParallelism"`
 
-	// Defines the range in which the Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
+	// Defines the range in which Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
 	MaxApplyParallelism *int `mandatory:"false" json:"maxApplyParallelism"`
 }
 

--- a/databasemigration/resume_job_details.go
+++ b/databasemigration/resume_job_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/retrieve_supported_phases_request_response.go
+++ b/databasemigration/retrieve_supported_phases_request_response.go
@@ -16,7 +16,7 @@ import (
 // Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/databasemigration/RetrieveSupportedPhases.go.html to see an example of how to use RetrieveSupportedPhasesRequest.
 type RetrieveSupportedPhasesRequest struct {
 
-	// The OCID of the job
+	// The OCID of the migration
 	MigrationId *string `mandatory:"true" contributesTo:"path" name:"migrationId"`
 
 	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a

--- a/databasemigration/sort_orders.go
+++ b/databasemigration/sort_orders.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/ssh_details.go
+++ b/databasemigration/ssh_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,10 +13,10 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// SshDetails Details of the ssh key that will be used.
+// SshDetails Details of the SSH key that will be used.
 type SshDetails struct {
 
-	// Name of the host the sshkey is valid for.
+	// Name of the host the SSH key is valid for.
 	Host *string `mandatory:"true" json:"host"`
 
 	// SSH user

--- a/databasemigration/start_migration_details.go
+++ b/databasemigration/start_migration_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/start_migration_request_response.go
+++ b/databasemigration/start_migration_request_response.go
@@ -16,7 +16,7 @@ import (
 // Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/databasemigration/StartMigration.go.html to see an example of how to use StartMigrationRequest.
 type StartMigrationRequest struct {
 
-	// The OCID of the job
+	// The OCID of the migration
 	MigrationId *string `mandatory:"true" contributesTo:"path" name:"migrationId"`
 
 	// For optimistic concurrency control. In the PUT or DELETE call

--- a/databasemigration/unsupported_database_object.go
+++ b/databasemigration/unsupported_database_object.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/update_admin_credentials.go
+++ b/databasemigration/update_admin_credentials.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,13 +13,13 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// UpdateAdminCredentials Database Admin Credentials details. An empty object would result in the removal of the stored details.
+// UpdateAdminCredentials Database Administrator Credentials details. An empty object would result in the removal of the stored details.
 type UpdateAdminCredentials struct {
 
-	// Admin username
+	// Administrator username
 	Username *string `mandatory:"false" json:"username"`
 
-	// Admin password
+	// Administrator password
 	Password *string `mandatory:"false" json:"password"`
 }
 

--- a/databasemigration/update_agent_details.go
+++ b/databasemigration/update_agent_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/update_connect_descriptor.go
+++ b/databasemigration/update_connect_descriptor.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/update_connection_details.go
+++ b/databasemigration/update_connection_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/update_connection_request_response.go
+++ b/databasemigration/update_connection_request_response.go
@@ -16,7 +16,7 @@ import (
 // Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/databasemigration/UpdateConnection.go.html to see an example of how to use UpdateConnectionRequest.
 type UpdateConnectionRequest struct {
 
-	// The OCID of the job
+	// The OCID of the database connection
 	ConnectionId *string `mandatory:"true" contributesTo:"path" name:"connectionId"`
 
 	// Database Connection properties.

--- a/databasemigration/update_data_pump_parameters.go
+++ b/databasemigration/update_data_pump_parameters.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,11 +13,11 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// UpdateDataPumpParameters Optional parameters for Datapump Export and Import. Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-62324358-2F26-4A94-B69F-1075D53FA96D__BABDECJE
+// UpdateDataPumpParameters Optional parameters for Data Pump Export and Import. Refer to Configuring Optional Initial Load Advanced Settings (https://docs-uat.us.oracle.com/en/cloud/paas/database-migration/dmsus/working-migration-resources.html#GUID-24BD3054-FDF8-48FF-8492-636C1D4B71ED)
 // If an empty object is specified, the stored Data Pump Parameter details will be removed.
 type UpdateDataPumpParameters struct {
 
-	// False to force datapump worker process to run on one instance.
+	// Set to false to force Data Pump worker processes to run on one instance.
 	IsCluster *bool `mandatory:"false" json:"isCluster"`
 
 	// Estimate size of dumps that will be generated.
@@ -26,14 +26,14 @@ type UpdateDataPumpParameters struct {
 	// IMPORT: Specifies the action to be performed when data is loaded into a preexisting table.
 	TableExistsAction DataPumpTableExistsActionEnum `mandatory:"false" json:"tableExistsAction,omitempty"`
 
-	// Exclude paratemers for export and import. If specified, the stored list will be replaced.
+	// Exclude paratemers for Export and Import. If specified, the stored list will be replaced.
 	ExcludeParameters []DataPumpExcludeParametersEnum `mandatory:"false" json:"excludeParameters"`
 
-	// Maximum number of worker processes that can be used for a Datapump Import job.
+	// Maximum number of worker processes that can be used for a Data Pump Import job.
 	// For an Autonomous Database, ODMS will automatically query its CPU core count and set this property.
 	ImportParallelismDegree *int `mandatory:"false" json:"importParallelismDegree"`
 
-	// Maximum number of worker processes that can be used for a Datapump Export job.
+	// Maximum number of worker processes that can be used for a Data Pump Export job.
 	ExportParallelismDegree *int `mandatory:"false" json:"exportParallelismDegree"`
 }
 

--- a/databasemigration/update_data_pump_settings.go
+++ b/databasemigration/update_data_pump_settings.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,17 +13,17 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// UpdateDataPumpSettings Optional settings for Datapump Export and Import jobs
+// UpdateDataPumpSettings Optional settings for Data Pump Export and Import jobs
 type UpdateDataPumpSettings struct {
 
-	// DataPump job mode.
-	// Refer to docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-92C2CB46-8BC9-414D-B62E-79CD788C1E62__BABBDEHD
+	// Data Pump job mode.
+	// Refer to Data Pump Export Modes  (https://docs.oracle.com/en/database/oracle/oracle-database/19/sutil/oracle-data-pump-export-utility.html#GUID-8E497131-6B9B-4CC8-AA50-35F480CAC2C4)
 	JobMode DataPumpJobModeEnum `mandatory:"false" json:"jobMode,omitempty"`
 
 	DataPumpParameters *UpdateDataPumpParameters `mandatory:"false" json:"dataPumpParameters"`
 
-	// Defines remapping to be applied to objects as they are processed.
-	// Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D.
+	// Defines remappings to be applied to objects as they are processed.
+	// Refer to METADATA_REMAP Procedure  (https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D)
 	// If specified, the list will be replaced entirely. Empty list will remove stored Metadata Remap details.
 	MetadataRemaps []MetadataRemap `mandatory:"false" json:"metadataRemaps"`
 

--- a/databasemigration/update_data_transfer_medium_details.go
+++ b/databasemigration/update_data_transfer_medium_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -14,7 +14,7 @@ import (
 )
 
 // UpdateDataTransferMediumDetails Data Transfer Medium details for the Migration.
-// Only one type of medium details can be specified and will replace the stored Data Transfer Medium details.
+// Only one type of data transfer medium can be specified and will replace the stored Data Transfer Medium details.
 // If an empty object is specified, the stored Data Transfer Medium details will be removed.
 type UpdateDataTransferMediumDetails struct {
 	DatabaseLinkDetails *UpdateDatabaseLinkDetails `mandatory:"false" json:"databaseLinkDetails"`

--- a/databasemigration/update_database_link_details.go
+++ b/databasemigration/update_database_link_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/update_directory_object.go
+++ b/databasemigration/update_directory_object.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/update_extract.go
+++ b/databasemigration/update_extract.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/update_golden_gate_details.go
+++ b/databasemigration/update_golden_gate_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/update_golden_gate_hub.go
+++ b/databasemigration/update_golden_gate_hub.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -27,13 +27,13 @@ type UpdateGoldenGateHub struct {
 	// Refer to https://docs.oracle.com/en/middleware/goldengate/core/19.1/securing/network.html#GUID-A709DA55-111D-455E-8942-C9BDD1E38CAA
 	Url *string `mandatory:"false" json:"url"`
 
-	// Name of Microservices deployment to operate on source DB
+	// Name of GoldenGate deployment to operate on source database
 	SourceMicroservicesDeploymentName *string `mandatory:"false" json:"sourceMicroservicesDeploymentName"`
 
-	// Name of Microservices deployment to operate on target DB
+	// Name of GoldenGate deployment to operate on target database
 	TargetMicroservicesDeploymentName *string `mandatory:"false" json:"targetMicroservicesDeploymentName"`
 
-	// OCID of Golden Gate compute instance. An empty value will remove the stored computeId.
+	// OCID of GoldenGate compute instance. An empty value will remove the stored computeId.
 	ComputeId *string `mandatory:"false" json:"computeId"`
 }
 

--- a/databasemigration/update_golden_gate_settings.go
+++ b/databasemigration/update_golden_gate_settings.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -14,7 +14,7 @@ import (
 )
 
 // UpdateGoldenGateSettings Optional settings for Oracle GoldenGate processes
-// If an empty object is specified, the stored Golden Gate Settings details will be removed.
+// If an empty object is specified, the stored GoldenGate Settings details will be removed.
 type UpdateGoldenGateSettings struct {
 	Extract *UpdateExtract `mandatory:"false" json:"extract"`
 

--- a/databasemigration/update_job_details.go
+++ b/databasemigration/update_job_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/update_migration_details.go
+++ b/databasemigration/update_migration_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -28,9 +28,9 @@ type UpdateMigrationDetails struct {
 	// The OCID of the Source Database Connection.
 	SourceDatabaseConnectionId *string `mandatory:"false" json:"sourceDatabaseConnectionId"`
 
-	// The OCID of the Source Container Database Connection. Only used for ONLINE migrations.
+	// The OCID of the Source Container Database Connection. Only used for Online migrations.
 	// Only Connections of type Non-Autonomous can be used as source container databases.
-	// An empty value would remove the stored Connection Id.
+	// An empty value would remove the stored Connection ID.
 	SourceContainerDatabaseConnectionId *string `mandatory:"false" json:"sourceContainerDatabaseConnectionId"`
 
 	// The OCID of the Target Database Connection.

--- a/databasemigration/update_migration_request_response.go
+++ b/databasemigration/update_migration_request_response.go
@@ -16,7 +16,7 @@ import (
 // Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/databasemigration/UpdateMigration.go.html to see an example of how to use UpdateMigrationRequest.
 type UpdateMigrationRequest struct {
 
-	// The OCID of the job
+	// The OCID of the migration
 	MigrationId *string `mandatory:"true" contributesTo:"path" name:"migrationId"`
 
 	// Migration properties.

--- a/databasemigration/update_object_store_bucket.go
+++ b/databasemigration/update_object_store_bucket.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/update_private_endpoint.go
+++ b/databasemigration/update_private_endpoint.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/update_replicat.go
+++ b/databasemigration/update_replicat.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -20,10 +20,10 @@ type UpdateReplicat struct {
 	// Number of threads used to read trail files (valid for Parallel Replicat)
 	MapParallelism *int `mandatory:"false" json:"mapParallelism"`
 
-	// Defines the range in which the Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
+	// Defines the range in which Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
 	MinApplyParallelism *int `mandatory:"false" json:"minApplyParallelism"`
 
-	// Defines the range in which the Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
+	// Defines the range in which Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
 	MaxApplyParallelism *int `mandatory:"false" json:"maxApplyParallelism"`
 }
 

--- a/databasemigration/update_ssh_details.go
+++ b/databasemigration/update_ssh_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -13,13 +13,13 @@ import (
 	"github.com/oracle/oci-go-sdk/v40/common"
 )
 
-// UpdateSshDetails Details of the ssh key that will be used.
+// UpdateSshDetails Details of the SSH key that will be used.
 type UpdateSshDetails struct {
 
-	// Name of the host the sshkey is valid for.
+	// Name of the host the SSH key is valid for.
 	Host *string `mandatory:"false" json:"host"`
 
-	// Private ssh key string.
+	// Private SSH key string.
 	Sshkey *string `mandatory:"false" json:"sshkey"`
 
 	// SSH user

--- a/databasemigration/update_vault_details.go
+++ b/databasemigration/update_vault_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/vault_details.go
+++ b/databasemigration/vault_details.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/work_request.go
+++ b/databasemigration/work_request.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/work_request_collection.go
+++ b/databasemigration/work_request_collection.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/work_request_error.go
+++ b/databasemigration/work_request_error.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration
@@ -17,7 +17,7 @@ import (
 type WorkRequestError struct {
 
 	// A machine-usable code for the error that occured. Error codes are listed on
-	// (https://docs.cloud.oracle.com/Content/API/References/apierrors.htm)
+	// API Errors (https://docs.cloud.oracle.com/Content/API/References/apierrors.htm)
 	Code *string `mandatory:"true" json:"code"`
 
 	// A human-readable error string.

--- a/databasemigration/work_request_error_collection.go
+++ b/databasemigration/work_request_error_collection.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/work_request_log_entry.go
+++ b/databasemigration/work_request_log_entry.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/work_request_log_entry_collection.go
+++ b/databasemigration/work_request_log_entry_collection.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/work_request_resource.go
+++ b/databasemigration/work_request_resource.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/databasemigration/work_request_summary.go
+++ b/databasemigration/work_request_summary.go
@@ -2,9 +2,9 @@
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
-// REST API for Zero Downtime Migration (Oracle Database Migration Service --ODMS-- as customer-facing service name)
+// Database Migration API
 //
-// Provides users the ability to perform Zero Downtime migration operations
+// Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
 //
 
 package databasemigration

--- a/objectstorage/bucket.go
+++ b/objectstorage/bucket.go
@@ -102,6 +102,11 @@ type Bucket struct {
 	// The versioning status on the bucket. A bucket is created with versioning `Disabled` by default.
 	// For versioning `Enabled`, objects are protected from overwrites and deletes, by maintaining their version history. When versioning is `Suspended`, the previous versions will still remain but new versions will no longer be created when overwitten or deleted.
 	Versioning BucketVersioningEnum `mandatory:"false" json:"versioning,omitempty"`
+
+	// The auto tiering status on the bucket. A bucket is created with auto tiering `Disabled` by default.
+	// For auto tiering `InfrequentAccess`, objects are transitioned automatically between the 'Standard'
+	// and 'InfrequentAccess' tiers based on the access pattern of the objects.
+	AutoTiering BucketAutoTieringEnum `mandatory:"false" json:"autoTiering,omitempty"`
 }
 
 func (m Bucket) String() string {
@@ -176,6 +181,29 @@ var mappingBucketVersioning = map[string]BucketVersioningEnum{
 func GetBucketVersioningEnumValues() []BucketVersioningEnum {
 	values := make([]BucketVersioningEnum, 0)
 	for _, v := range mappingBucketVersioning {
+		values = append(values, v)
+	}
+	return values
+}
+
+// BucketAutoTieringEnum Enum with underlying type: string
+type BucketAutoTieringEnum string
+
+// Set of constants representing the allowable values for BucketAutoTieringEnum
+const (
+	BucketAutoTieringDisabled         BucketAutoTieringEnum = "Disabled"
+	BucketAutoTieringInfrequentaccess BucketAutoTieringEnum = "InfrequentAccess"
+)
+
+var mappingBucketAutoTiering = map[string]BucketAutoTieringEnum{
+	"Disabled":         BucketAutoTieringDisabled,
+	"InfrequentAccess": BucketAutoTieringInfrequentaccess,
+}
+
+// GetBucketAutoTieringEnumValues Enumerates the set of values for BucketAutoTieringEnum
+func GetBucketAutoTieringEnumValues() []BucketAutoTieringEnum {
+	values := make([]BucketAutoTieringEnum, 0)
+	for _, v := range mappingBucketAutoTiering {
 		values = append(values, v)
 	}
 	return values

--- a/objectstorage/create_bucket_details.go
+++ b/objectstorage/create_bucket_details.go
@@ -65,6 +65,12 @@ type CreateBucketDetails struct {
 
 	// Set the versioning status on the bucket. By default, a bucket is created with versioning `Disabled`. Use this option to enable versioning during bucket creation. Objects in a version enabled bucket are protected from overwrites and deletions. Previous versions of the same object will be available in the bucket.
 	Versioning CreateBucketDetailsVersioningEnum `mandatory:"false" json:"versioning,omitempty"`
+
+	// Set the auto tiering status on the bucket. By default, a bucket is created with auto tiering `Disabled`.
+	// Use this option to enable auto tiering during bucket creation. Objects in a bucket with auto tiering set to
+	// `InfrequentAccess` are transitioned automatically between the 'Standard' and 'InfrequentAccess'
+	// tiers based on the access pattern of the objects.
+	AutoTiering BucketAutoTieringEnum `mandatory:"false" json:"autoTiering,omitempty"`
 }
 
 func (m CreateBucketDetails) String() string {

--- a/objectstorage/get_bucket_request_response.go
+++ b/objectstorage/get_bucket_request_response.go
@@ -36,8 +36,9 @@ type GetBucketRequest struct {
 	OpcClientRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-client-request-id"`
 
 	// Bucket summary includes the 'namespace', 'name', 'compartmentId', 'createdBy', 'timeCreated',
-	// and 'etag' fields. This parameter can also include 'approximateCount' (approximate number of objects) and 'approximateSize'
-	// (total approximate size in bytes of all objects). For example 'approximateCount,approximateSize'.
+	// and 'etag' fields. This parameter can also include 'approximateCount' (approximate number of objects), 'approximateSize'
+	// (total approximate size in bytes of all objects) and 'autoTiering' (state of auto tiering on the bucket).
+	// For example 'approximateCount,approximateSize,autoTiering'.
 	Fields []GetBucketFieldsEnum `contributesTo:"query" name:"fields" omitEmpty:"true" collectionFormat:"csv"`
 
 	// Metadata about the request. This information will not be transmitted to the service, but
@@ -109,11 +110,13 @@ type GetBucketFieldsEnum string
 const (
 	GetBucketFieldsApproximatecount GetBucketFieldsEnum = "approximateCount"
 	GetBucketFieldsApproximatesize  GetBucketFieldsEnum = "approximateSize"
+	GetBucketFieldsAutotiering      GetBucketFieldsEnum = "autoTiering"
 )
 
 var mappingGetBucketFields = map[string]GetBucketFieldsEnum{
 	"approximateCount": GetBucketFieldsApproximatecount,
 	"approximateSize":  GetBucketFieldsApproximatesize,
+	"autoTiering":      GetBucketFieldsAutotiering,
 }
 
 // GetGetBucketFieldsEnumValues Enumerates the set of values for GetBucketFieldsEnum

--- a/objectstorage/update_bucket_details.go
+++ b/objectstorage/update_bucket_details.go
@@ -65,6 +65,11 @@ type UpdateBucketDetails struct {
 	// When the object is overwritten or deleted, previous versions will still be available. When versioning is `Suspended`, the previous versions will still remain but new versions will no longer be created when overwitten or deleted.
 	// Versioning cannot be disabled on a bucket once enabled.
 	Versioning UpdateBucketDetailsVersioningEnum `mandatory:"false" json:"versioning,omitempty"`
+
+	// The auto tiering status on the bucket. If in state `InfrequentAccess`, objects are transitioned
+	// automatically between the 'Standard' and 'InfrequentAccess' tiers based on the access pattern of the objects.
+	// When auto tiering is `Disabled`, there will be no automatic transitions between storage tiers.
+	AutoTiering BucketAutoTieringEnum `mandatory:"false" json:"autoTiering,omitempty"`
 }
 
 func (m UpdateBucketDetails) String() string {


### PR DESCRIPTION
### Added

- VCN id parameters were moved from being required to being optional on all list operations in the Networking service

- Support for RACs (real application clusters) for external container, non-container, and pluggable databases in the Database service

- Support for data masking in the Cloud Guard service

- Support for opting out of DNS records during instance launch, as well as attaching secondary VNICs, in the Compute service

- Support for mutable sizes on cluster networks in the Autoscaling service

- Support for auto-tiering on buckets in the Object Storage service








