### PR TITLE
Releasing version 41.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## 41.1.0 - 2021-06-01
+### Added
+- Support for configuration of autonomous database KMS keys in the Database service
+- Support for creating database software images with any supported RUs in the Database service
+- Support for creating database software images from an existing database home in the Database service
+- Support for listing all NSGs associated with a given VLAN in the Networking service
+- Support for a duration windows, task failure reasons, and next execution times on scheduled tasks in the Logging Analytics service 
+- Support for calling Oracle Cloud Infrastructure services in the sa-vinhedo-1 region
+
 ## 41.0.0 - 2021-05-25
 ### Added
 - Support for the Generic Artifacts service

--- a/common/common.go
+++ b/common/common.go
@@ -75,6 +75,8 @@ const (
 	RegionSASaopaulo1 Region = "sa-saopaulo-1"
 	//RegionSASantiago1 region for santiago
 	RegionSASantiago1 Region = "sa-santiago-1"
+	//RegionSAVinhedo1 region for vinhedo
+	RegionSAVinhedo1 Region = "sa-vinhedo-1"
 
 	//RegionUSLangley1 region for Langley
 	RegionUSLangley1 Region = "us-langley-1"
@@ -131,6 +133,7 @@ var shortNameRegion = map[string]Region{
 	"sjc": RegionSJC1,
 	"gru": RegionSASaopaulo1,
 	"scl": RegionSASantiago1,
+	"vcp": RegionSAVinhedo1,
 	"ltn": RegionUKGovLondon1,
 	"brs": RegionUKGovCardiff1,
 }
@@ -172,6 +175,7 @@ var regionRealm = map[Region]string{
 
 	RegionSASaopaulo1: "oc1",
 	RegionSASantiago1: "oc1",
+	RegionSAVinhedo1:  "oc1",
 
 	RegionUSLangley1: "oc2",
 	RegionUSLuke1:    "oc2",

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -47,6 +47,10 @@ func TestEndpoint(t *testing.T) {
 	endpoint = region.Endpoint("bar")
 	assert.Equal(t, "bar.sa-santiago-1.oraclecloud.com", endpoint)
 
+	region = StringToRegion("sa-vinhedo-1")
+	endpoint = region.Endpoint("bar")
+	assert.Equal(t, "bar.sa-vinhedo-1.oraclecloud.com", endpoint)
+
 	// OC2
 	region = StringToRegion("us-langley-1")
 	endpoint = region.Endpoint("bar")
@@ -154,6 +158,13 @@ func TestEndpointForTemplate(t *testing.T) {
 			expected:         "https://foo.region.oraclecloud.com",
 		},
 		{
+			// template with second level domain
+			region:           StringToRegion("sa-vinhedo-1"),
+			service:          "test",
+			endpointTemplate: "https://foo.region.{secondLevelDomain}",
+			expected:         "https://foo.region.oraclecloud.com",
+		},
+		{
 			// template with everything for OC2
 			region:           StringToRegion("us-langley-1"),
 			service:          "test",
@@ -246,6 +257,9 @@ func TestStringToRegion(t *testing.T) {
 
 	region = StringToRegion("scl")
 	assert.Equal(t, RegionSASantiago1, region)
+
+	region = StringToRegion("vcp")
+	assert.Equal(t, RegionSAVinhedo1, region)
 
 	regionMetadataEnvVar := `{"realmKey":"OC0","realmDomainComponent":"testRealm.com","regionKey":"RTK","regionIdentifier":"us-testregion-1"}`
 	os.Unsetenv("OCI_REGION_METADATA")

--- a/common/version.go
+++ b/common/version.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	major = "41"
-	minor = "0"
+	minor = "1"
 	patch = "0"
 	tag   = ""
 )

--- a/core/core_virtualnetwork_client.go
+++ b/core/core_virtualnetwork_client.go
@@ -9591,7 +9591,8 @@ func (client VirtualNetworkClient) listNetworkSecurityGroupVnics(ctx context.Con
 	return response, err
 }
 
-// ListNetworkSecurityGroups Lists the network security groups in the specified compartment.
+// ListNetworkSecurityGroups Lists either the network security groups in the specified compartment, or those associated with the specified VLAN.
+// You must specify either a `vlanId` or a `compartmentId`, but not both. If you specify a `vlanId`, all other parameters are ignored.
 //
 // See also
 //

--- a/core/list_network_security_groups_request_response.go
+++ b/core/list_network_security_groups_request_response.go
@@ -17,7 +17,10 @@ import (
 type ListNetworkSecurityGroupsRequest struct {
 
 	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment.
-	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+	CompartmentId *string `mandatory:"false" contributesTo:"query" name:"compartmentId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VLAN.
+	VlanId *string `mandatory:"false" contributesTo:"query" name:"vlanId"`
 
 	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
 	VcnId *string `mandatory:"false" contributesTo:"query" name:"vcnId"`

--- a/database/autonomous_database.go
+++ b/database/autonomous_database.go
@@ -37,6 +37,15 @@ type AutonomousDatabase struct {
 	// Information about the current lifecycle state.
 	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
 
+	// The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Oracle Cloud Infrastructure vault (https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+	VaultId *string `mandatory:"false" json:"vaultId"`
+
+	// KMS key lifecycle details.
+	KmsKeyLifecycleDetails *string `mandatory:"false" json:"kmsKeyLifecycleDetails"`
+
 	// Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB of memory. For Always Free databases, memory and CPU cannot be scaled.
 	IsFreeTier *bool `mandatory:"false" json:"isFreeTier"`
 
@@ -51,6 +60,9 @@ type AutonomousDatabase struct {
 	TimeDeletionOfFreeAutonomousDatabase *common.SDKTime `mandatory:"false" json:"timeDeletionOfFreeAutonomousDatabase"`
 
 	BackupConfig *AutonomousDatabaseBackupConfig `mandatory:"false" json:"backupConfig"`
+
+	// Key History Entry.
+	KeyHistoryEntry []AutonomousDatabaseKeyHistoryEntry `mandatory:"false" json:"keyHistoryEntry"`
 
 	// The quantity of data in the database, in gigabytes.
 	DataStorageSizeInGBs *int `mandatory:"false" json:"dataStorageSizeInGBs"`
@@ -269,6 +281,7 @@ const (
 	AutonomousDatabaseLifecycleStateRecreating              AutonomousDatabaseLifecycleStateEnum = "RECREATING"
 	AutonomousDatabaseLifecycleStateRoleChangeInProgress    AutonomousDatabaseLifecycleStateEnum = "ROLE_CHANGE_IN_PROGRESS"
 	AutonomousDatabaseLifecycleStateUpgrading               AutonomousDatabaseLifecycleStateEnum = "UPGRADING"
+	AutonomousDatabaseLifecycleStateInaccessible            AutonomousDatabaseLifecycleStateEnum = "INACCESSIBLE"
 )
 
 var mappingAutonomousDatabaseLifecycleState = map[string]AutonomousDatabaseLifecycleStateEnum{
@@ -291,6 +304,7 @@ var mappingAutonomousDatabaseLifecycleState = map[string]AutonomousDatabaseLifec
 	"RECREATING":                AutonomousDatabaseLifecycleStateRecreating,
 	"ROLE_CHANGE_IN_PROGRESS":   AutonomousDatabaseLifecycleStateRoleChangeInProgress,
 	"UPGRADING":                 AutonomousDatabaseLifecycleStateUpgrading,
+	"INACCESSIBLE":              AutonomousDatabaseLifecycleStateInaccessible,
 }
 
 // GetAutonomousDatabaseLifecycleStateEnumValues Enumerates the set of values for AutonomousDatabaseLifecycleStateEnum

--- a/database/autonomous_database_backup.go
+++ b/database/autonomous_database_backup.go
@@ -57,6 +57,12 @@ type AutonomousDatabaseBackup struct {
 
 	// The wallet name for Oracle Key Vault.
 	KeyStoreWalletName *string `mandatory:"false" json:"keyStoreWalletName"`
+
+	// The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Oracle Cloud Infrastructure vault (https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+	VaultId *string `mandatory:"false" json:"vaultId"`
 }
 
 func (m AutonomousDatabaseBackup) String() string {

--- a/database/autonomous_database_backup_summary.go
+++ b/database/autonomous_database_backup_summary.go
@@ -59,6 +59,12 @@ type AutonomousDatabaseBackupSummary struct {
 
 	// The wallet name for Oracle Key Vault.
 	KeyStoreWalletName *string `mandatory:"false" json:"keyStoreWalletName"`
+
+	// The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Oracle Cloud Infrastructure vault (https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+	VaultId *string `mandatory:"false" json:"vaultId"`
 }
 
 func (m AutonomousDatabaseBackupSummary) String() string {

--- a/database/autonomous_database_key_history_entry.go
+++ b/database/autonomous_database_key_history_entry.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/v41/common"
+)
+
+// AutonomousDatabaseKeyHistoryEntry The Autonomous Database Vault (https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts) service key management history entry.
+type AutonomousDatabaseKeyHistoryEntry struct {
+
+	// The id of the Autonomous Database Vault (https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts) service key management history entry.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Oracle Cloud Infrastructure vault (https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+	VaultId *string `mandatory:"false" json:"vaultId"`
+
+	// The date and time the kms key activated.
+	TimeActivated *common.SDKTime `mandatory:"false" json:"timeActivated"`
+}
+
+func (m AutonomousDatabaseKeyHistoryEntry) String() string {
+	return common.PointerString(m)
+}

--- a/database/autonomous_database_standby_summary.go
+++ b/database/autonomous_database_standby_summary.go
@@ -54,6 +54,7 @@ const (
 	AutonomousDatabaseStandbySummaryLifecycleStateRecreating              AutonomousDatabaseStandbySummaryLifecycleStateEnum = "RECREATING"
 	AutonomousDatabaseStandbySummaryLifecycleStateRoleChangeInProgress    AutonomousDatabaseStandbySummaryLifecycleStateEnum = "ROLE_CHANGE_IN_PROGRESS"
 	AutonomousDatabaseStandbySummaryLifecycleStateUpgrading               AutonomousDatabaseStandbySummaryLifecycleStateEnum = "UPGRADING"
+	AutonomousDatabaseStandbySummaryLifecycleStateInaccessible            AutonomousDatabaseStandbySummaryLifecycleStateEnum = "INACCESSIBLE"
 )
 
 var mappingAutonomousDatabaseStandbySummaryLifecycleState = map[string]AutonomousDatabaseStandbySummaryLifecycleStateEnum{
@@ -76,6 +77,7 @@ var mappingAutonomousDatabaseStandbySummaryLifecycleState = map[string]Autonomou
 	"RECREATING":                AutonomousDatabaseStandbySummaryLifecycleStateRecreating,
 	"ROLE_CHANGE_IN_PROGRESS":   AutonomousDatabaseStandbySummaryLifecycleStateRoleChangeInProgress,
 	"UPGRADING":                 AutonomousDatabaseStandbySummaryLifecycleStateUpgrading,
+	"INACCESSIBLE":              AutonomousDatabaseStandbySummaryLifecycleStateInaccessible,
 }
 
 // GetAutonomousDatabaseStandbySummaryLifecycleStateEnumValues Enumerates the set of values for AutonomousDatabaseStandbySummaryLifecycleStateEnum

--- a/database/autonomous_database_summary.go
+++ b/database/autonomous_database_summary.go
@@ -38,6 +38,15 @@ type AutonomousDatabaseSummary struct {
 	// Information about the current lifecycle state.
 	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
 
+	// The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Oracle Cloud Infrastructure vault (https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+	VaultId *string `mandatory:"false" json:"vaultId"`
+
+	// KMS key lifecycle details.
+	KmsKeyLifecycleDetails *string `mandatory:"false" json:"kmsKeyLifecycleDetails"`
+
 	// Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB of memory. For Always Free databases, memory and CPU cannot be scaled.
 	IsFreeTier *bool `mandatory:"false" json:"isFreeTier"`
 
@@ -52,6 +61,9 @@ type AutonomousDatabaseSummary struct {
 	TimeDeletionOfFreeAutonomousDatabase *common.SDKTime `mandatory:"false" json:"timeDeletionOfFreeAutonomousDatabase"`
 
 	BackupConfig *AutonomousDatabaseBackupConfig `mandatory:"false" json:"backupConfig"`
+
+	// Key History Entry.
+	KeyHistoryEntry []AutonomousDatabaseKeyHistoryEntry `mandatory:"false" json:"keyHistoryEntry"`
 
 	// The quantity of data in the database, in gigabytes.
 	DataStorageSizeInGBs *int `mandatory:"false" json:"dataStorageSizeInGBs"`
@@ -270,6 +282,7 @@ const (
 	AutonomousDatabaseSummaryLifecycleStateRecreating              AutonomousDatabaseSummaryLifecycleStateEnum = "RECREATING"
 	AutonomousDatabaseSummaryLifecycleStateRoleChangeInProgress    AutonomousDatabaseSummaryLifecycleStateEnum = "ROLE_CHANGE_IN_PROGRESS"
 	AutonomousDatabaseSummaryLifecycleStateUpgrading               AutonomousDatabaseSummaryLifecycleStateEnum = "UPGRADING"
+	AutonomousDatabaseSummaryLifecycleStateInaccessible            AutonomousDatabaseSummaryLifecycleStateEnum = "INACCESSIBLE"
 )
 
 var mappingAutonomousDatabaseSummaryLifecycleState = map[string]AutonomousDatabaseSummaryLifecycleStateEnum{
@@ -292,6 +305,7 @@ var mappingAutonomousDatabaseSummaryLifecycleState = map[string]AutonomousDataba
 	"RECREATING":                AutonomousDatabaseSummaryLifecycleStateRecreating,
 	"ROLE_CHANGE_IN_PROGRESS":   AutonomousDatabaseSummaryLifecycleStateRoleChangeInProgress,
 	"UPGRADING":                 AutonomousDatabaseSummaryLifecycleStateUpgrading,
+	"INACCESSIBLE":              AutonomousDatabaseSummaryLifecycleStateInaccessible,
 }
 
 // GetAutonomousDatabaseSummaryLifecycleStateEnumValues Enumerates the set of values for AutonomousDatabaseSummaryLifecycleStateEnum

--- a/database/configure_autonomous_database_vault_key_details.go
+++ b/database/configure_autonomous_database_vault_key_details.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/v41/common"
+)
+
+// ConfigureAutonomousDatabaseVaultKeyDetails Configuration details for the Autonomous Database vault (https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts) key.
+type ConfigureAutonomousDatabaseVaultKeyDetails struct {
+
+	// The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Oracle Cloud Infrastructure vault (https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+	VaultId *string `mandatory:"false" json:"vaultId"`
+
+	// True if disable Customer Managed Keys and use Oracle Managed Keys.
+	IsUsingOracleManagedKeys *bool `mandatory:"false" json:"isUsingOracleManagedKeys"`
+}
+
+func (m ConfigureAutonomousDatabaseVaultKeyDetails) String() string {
+	return common.PointerString(m)
+}

--- a/database/configure_autonomous_database_vault_key_request_response.go
+++ b/database/configure_autonomous_database_vault_key_request_response.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/v41/common"
+	"net/http"
+)
+
+// ConfigureAutonomousDatabaseVaultKeyRequest wrapper for the ConfigureAutonomousDatabaseVaultKey operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/database/ConfigureAutonomousDatabaseVaultKey.go.html to see an example of how to use ConfigureAutonomousDatabaseVaultKeyRequest.
+type ConfigureAutonomousDatabaseVaultKeyRequest struct {
+
+	// The database OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	AutonomousDatabaseId *string `mandatory:"true" contributesTo:"path" name:"autonomousDatabaseId"`
+
+	// Configuration details for the Autonomous Database Vault service key (https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+	ConfigureAutonomousDatabaseVaultKeyDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ConfigureAutonomousDatabaseVaultKeyRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ConfigureAutonomousDatabaseVaultKeyRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ConfigureAutonomousDatabaseVaultKeyRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ConfigureAutonomousDatabaseVaultKeyRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ConfigureAutonomousDatabaseVaultKeyResponse wrapper for the ConfigureAutonomousDatabaseVaultKey operation
+type ConfigureAutonomousDatabaseVaultKeyResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request. Multiple OCID values are returned in a comma-separated list. Use GetWorkRequest with a work request OCID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ConfigureAutonomousDatabaseVaultKeyResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ConfigureAutonomousDatabaseVaultKeyResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/create_autonomous_database_base.go
+++ b/database/create_autonomous_database_base.go
@@ -40,6 +40,12 @@ type CreateAutonomousDatabaseBase interface {
 	// Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB of memory. For Always Free databases, memory and CPU cannot be scaled.
 	GetIsFreeTier() *bool
 
+	// The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+	GetKmsKeyId() *string
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Oracle Cloud Infrastructure vault (https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+	GetVaultId() *string
+
 	// The password must be between 12 and 30 characters long, and must contain at least 1 uppercase, 1 lowercase, and 1 numeric character. It cannot contain the double quote symbol (") or the username "admin", regardless of casing.
 	GetAdminPassword() *string
 
@@ -142,6 +148,8 @@ type createautonomousdatabasebase struct {
 	DbWorkload                               CreateAutonomousDatabaseBaseDbWorkloadEnum   `mandatory:"false" json:"dbWorkload,omitempty"`
 	DataStorageSizeInTBs                     *int                                         `mandatory:"false" json:"dataStorageSizeInTBs"`
 	IsFreeTier                               *bool                                        `mandatory:"false" json:"isFreeTier"`
+	KmsKeyId                                 *string                                      `mandatory:"false" json:"kmsKeyId"`
+	VaultId                                  *string                                      `mandatory:"false" json:"vaultId"`
 	AdminPassword                            *string                                      `mandatory:"false" json:"adminPassword"`
 	DisplayName                              *string                                      `mandatory:"false" json:"displayName"`
 	LicenseModel                             CreateAutonomousDatabaseBaseLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
@@ -181,6 +189,8 @@ func (m *createautonomousdatabasebase) UnmarshalJSON(data []byte) error {
 	m.DbWorkload = s.Model.DbWorkload
 	m.DataStorageSizeInTBs = s.Model.DataStorageSizeInTBs
 	m.IsFreeTier = s.Model.IsFreeTier
+	m.KmsKeyId = s.Model.KmsKeyId
+	m.VaultId = s.Model.VaultId
 	m.AdminPassword = s.Model.AdminPassword
 	m.DisplayName = s.Model.DisplayName
 	m.LicenseModel = s.Model.LicenseModel
@@ -267,6 +277,16 @@ func (m createautonomousdatabasebase) GetDataStorageSizeInTBs() *int {
 //GetIsFreeTier returns IsFreeTier
 func (m createautonomousdatabasebase) GetIsFreeTier() *bool {
 	return m.IsFreeTier
+}
+
+//GetKmsKeyId returns KmsKeyId
+func (m createautonomousdatabasebase) GetKmsKeyId() *string {
+	return m.KmsKeyId
+}
+
+//GetVaultId returns VaultId
+func (m createautonomousdatabasebase) GetVaultId() *string {
+	return m.VaultId
 }
 
 //GetAdminPassword returns AdminPassword

--- a/database/create_autonomous_database_clone_details.go
+++ b/database/create_autonomous_database_clone_details.go
@@ -35,6 +35,12 @@ type CreateAutonomousDatabaseCloneDetails struct {
 	// Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB of memory. For Always Free databases, memory and CPU cannot be scaled.
 	IsFreeTier *bool `mandatory:"false" json:"isFreeTier"`
 
+	// The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Oracle Cloud Infrastructure vault (https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+	VaultId *string `mandatory:"false" json:"vaultId"`
+
 	// The password must be between 12 and 30 characters long, and must contain at least 1 uppercase, 1 lowercase, and 1 numeric character. It cannot contain the double quote symbol (") or the username "admin", regardless of casing.
 	AdminPassword *string `mandatory:"false" json:"adminPassword"`
 
@@ -167,6 +173,16 @@ func (m CreateAutonomousDatabaseCloneDetails) GetDataStorageSizeInTBs() *int {
 //GetIsFreeTier returns IsFreeTier
 func (m CreateAutonomousDatabaseCloneDetails) GetIsFreeTier() *bool {
 	return m.IsFreeTier
+}
+
+//GetKmsKeyId returns KmsKeyId
+func (m CreateAutonomousDatabaseCloneDetails) GetKmsKeyId() *string {
+	return m.KmsKeyId
+}
+
+//GetVaultId returns VaultId
+func (m CreateAutonomousDatabaseCloneDetails) GetVaultId() *string {
+	return m.VaultId
 }
 
 //GetAdminPassword returns AdminPassword

--- a/database/create_autonomous_database_details.go
+++ b/database/create_autonomous_database_details.go
@@ -32,6 +32,12 @@ type CreateAutonomousDatabaseDetails struct {
 	// Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB of memory. For Always Free databases, memory and CPU cannot be scaled.
 	IsFreeTier *bool `mandatory:"false" json:"isFreeTier"`
 
+	// The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Oracle Cloud Infrastructure vault (https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+	VaultId *string `mandatory:"false" json:"vaultId"`
+
 	// The password must be between 12 and 30 characters long, and must contain at least 1 uppercase, 1 lowercase, and 1 numeric character. It cannot contain the double quote symbol (") or the username "admin", regardless of casing.
 	AdminPassword *string `mandatory:"false" json:"adminPassword"`
 
@@ -161,6 +167,16 @@ func (m CreateAutonomousDatabaseDetails) GetDataStorageSizeInTBs() *int {
 //GetIsFreeTier returns IsFreeTier
 func (m CreateAutonomousDatabaseDetails) GetIsFreeTier() *bool {
 	return m.IsFreeTier
+}
+
+//GetKmsKeyId returns KmsKeyId
+func (m CreateAutonomousDatabaseDetails) GetKmsKeyId() *string {
+	return m.KmsKeyId
+}
+
+//GetVaultId returns VaultId
+func (m CreateAutonomousDatabaseDetails) GetVaultId() *string {
+	return m.VaultId
 }
 
 //GetAdminPassword returns AdminPassword

--- a/database/create_autonomous_database_from_backup_details.go
+++ b/database/create_autonomous_database_from_backup_details.go
@@ -35,6 +35,12 @@ type CreateAutonomousDatabaseFromBackupDetails struct {
 	// Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB of memory. For Always Free databases, memory and CPU cannot be scaled.
 	IsFreeTier *bool `mandatory:"false" json:"isFreeTier"`
 
+	// The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Oracle Cloud Infrastructure vault (https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+	VaultId *string `mandatory:"false" json:"vaultId"`
+
 	// The password must be between 12 and 30 characters long, and must contain at least 1 uppercase, 1 lowercase, and 1 numeric character. It cannot contain the double quote symbol (") or the username "admin", regardless of casing.
 	AdminPassword *string `mandatory:"false" json:"adminPassword"`
 
@@ -167,6 +173,16 @@ func (m CreateAutonomousDatabaseFromBackupDetails) GetDataStorageSizeInTBs() *in
 //GetIsFreeTier returns IsFreeTier
 func (m CreateAutonomousDatabaseFromBackupDetails) GetIsFreeTier() *bool {
 	return m.IsFreeTier
+}
+
+//GetKmsKeyId returns KmsKeyId
+func (m CreateAutonomousDatabaseFromBackupDetails) GetKmsKeyId() *string {
+	return m.KmsKeyId
+}
+
+//GetVaultId returns VaultId
+func (m CreateAutonomousDatabaseFromBackupDetails) GetVaultId() *string {
+	return m.VaultId
 }
 
 //GetAdminPassword returns AdminPassword

--- a/database/create_autonomous_database_from_backup_timestamp_details.go
+++ b/database/create_autonomous_database_from_backup_timestamp_details.go
@@ -38,6 +38,12 @@ type CreateAutonomousDatabaseFromBackupTimestampDetails struct {
 	// Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB of memory. For Always Free databases, memory and CPU cannot be scaled.
 	IsFreeTier *bool `mandatory:"false" json:"isFreeTier"`
 
+	// The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Oracle Cloud Infrastructure vault (https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+	VaultId *string `mandatory:"false" json:"vaultId"`
+
 	// The password must be between 12 and 30 characters long, and must contain at least 1 uppercase, 1 lowercase, and 1 numeric character. It cannot contain the double quote symbol (") or the username "admin", regardless of casing.
 	AdminPassword *string `mandatory:"false" json:"adminPassword"`
 
@@ -170,6 +176,16 @@ func (m CreateAutonomousDatabaseFromBackupTimestampDetails) GetDataStorageSizeIn
 //GetIsFreeTier returns IsFreeTier
 func (m CreateAutonomousDatabaseFromBackupTimestampDetails) GetIsFreeTier() *bool {
 	return m.IsFreeTier
+}
+
+//GetKmsKeyId returns KmsKeyId
+func (m CreateAutonomousDatabaseFromBackupTimestampDetails) GetKmsKeyId() *string {
+	return m.KmsKeyId
+}
+
+//GetVaultId returns VaultId
+func (m CreateAutonomousDatabaseFromBackupTimestampDetails) GetVaultId() *string {
+	return m.VaultId
 }
 
 //GetAdminPassword returns AdminPassword

--- a/database/create_database_software_image_details.go
+++ b/database/create_database_software_image_details.go
@@ -49,6 +49,9 @@ type CreateDatabaseSoftwareImageDetails struct {
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Database Home.
+	SourceDbHomeId *string `mandatory:"false" json:"sourceDbHomeId"`
 }
 
 func (m CreateDatabaseSoftwareImageDetails) String() string {

--- a/database/create_db_home_base.go
+++ b/database/create_db_home_base.go
@@ -38,6 +38,9 @@ type CreateDbHomeBase interface {
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	GetDefinedTags() map[string]map[string]interface{}
+
+	// If true, the customer acknowledges that the specified Oracle Database software is an older release that is not currently supported by OCI.
+	GetIsDesupportedVersion() *bool
 }
 
 type createdbhomebase struct {
@@ -48,6 +51,7 @@ type createdbhomebase struct {
 	DatabaseSoftwareImageId *string                           `mandatory:"false" json:"databaseSoftwareImageId"`
 	FreeformTags            map[string]string                 `mandatory:"false" json:"freeformTags"`
 	DefinedTags             map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+	IsDesupportedVersion    *bool                             `mandatory:"false" json:"isDesupportedVersion"`
 	Source                  string                            `json:"source"`
 }
 
@@ -68,6 +72,7 @@ func (m *createdbhomebase) UnmarshalJSON(data []byte) error {
 	m.DatabaseSoftwareImageId = s.Model.DatabaseSoftwareImageId
 	m.FreeformTags = s.Model.FreeformTags
 	m.DefinedTags = s.Model.DefinedTags
+	m.IsDesupportedVersion = s.Model.IsDesupportedVersion
 	m.Source = s.Model.Source
 
 	return err
@@ -135,6 +140,11 @@ func (m createdbhomebase) GetFreeformTags() map[string]string {
 //GetDefinedTags returns DefinedTags
 func (m createdbhomebase) GetDefinedTags() map[string]map[string]interface{} {
 	return m.DefinedTags
+}
+
+//GetIsDesupportedVersion returns IsDesupportedVersion
+func (m createdbhomebase) GetIsDesupportedVersion() *bool {
+	return m.IsDesupportedVersion
 }
 
 func (m createdbhomebase) String() string {

--- a/database/create_db_home_with_db_system_id_details.go
+++ b/database/create_db_home_with_db_system_id_details.go
@@ -41,6 +41,9 @@ type CreateDbHomeWithDbSystemIdDetails struct {
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
+	// If true, the customer acknowledges that the specified Oracle Database software is an older release that is not currently supported by OCI.
+	IsDesupportedVersion *bool `mandatory:"false" json:"isDesupportedVersion"`
+
 	// A valid Oracle Database version. To get a list of supported versions, use the ListDbVersions operation.
 	DbVersion *string `mandatory:"false" json:"dbVersion"`
 
@@ -75,6 +78,11 @@ func (m CreateDbHomeWithDbSystemIdDetails) GetFreeformTags() map[string]string {
 //GetDefinedTags returns DefinedTags
 func (m CreateDbHomeWithDbSystemIdDetails) GetDefinedTags() map[string]map[string]interface{} {
 	return m.DefinedTags
+}
+
+//GetIsDesupportedVersion returns IsDesupportedVersion
+func (m CreateDbHomeWithDbSystemIdDetails) GetIsDesupportedVersion() *bool {
+	return m.IsDesupportedVersion
 }
 
 func (m CreateDbHomeWithDbSystemIdDetails) String() string {

--- a/database/create_db_home_with_db_system_id_from_backup_details.go
+++ b/database/create_db_home_with_db_system_id_from_backup_details.go
@@ -42,6 +42,9 @@ type CreateDbHomeWithDbSystemIdFromBackupDetails struct {
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// If true, the customer acknowledges that the specified Oracle Database software is an older release that is not currently supported by OCI.
+	IsDesupportedVersion *bool `mandatory:"false" json:"isDesupportedVersion"`
 }
 
 //GetDisplayName returns DisplayName
@@ -72,6 +75,11 @@ func (m CreateDbHomeWithDbSystemIdFromBackupDetails) GetFreeformTags() map[strin
 //GetDefinedTags returns DefinedTags
 func (m CreateDbHomeWithDbSystemIdFromBackupDetails) GetDefinedTags() map[string]map[string]interface{} {
 	return m.DefinedTags
+}
+
+//GetIsDesupportedVersion returns IsDesupportedVersion
+func (m CreateDbHomeWithDbSystemIdFromBackupDetails) GetIsDesupportedVersion() *bool {
+	return m.IsDesupportedVersion
 }
 
 func (m CreateDbHomeWithDbSystemIdFromBackupDetails) String() string {

--- a/database/create_db_home_with_db_system_id_from_database_details.go
+++ b/database/create_db_home_with_db_system_id_from_database_details.go
@@ -42,6 +42,9 @@ type CreateDbHomeWithDbSystemIdFromDatabaseDetails struct {
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// If true, the customer acknowledges that the specified Oracle Database software is an older release that is not currently supported by OCI.
+	IsDesupportedVersion *bool `mandatory:"false" json:"isDesupportedVersion"`
 }
 
 //GetDisplayName returns DisplayName
@@ -72,6 +75,11 @@ func (m CreateDbHomeWithDbSystemIdFromDatabaseDetails) GetFreeformTags() map[str
 //GetDefinedTags returns DefinedTags
 func (m CreateDbHomeWithDbSystemIdFromDatabaseDetails) GetDefinedTags() map[string]map[string]interface{} {
 	return m.DefinedTags
+}
+
+//GetIsDesupportedVersion returns IsDesupportedVersion
+func (m CreateDbHomeWithDbSystemIdFromDatabaseDetails) GetIsDesupportedVersion() *bool {
+	return m.IsDesupportedVersion
 }
 
 func (m CreateDbHomeWithDbSystemIdFromDatabaseDetails) String() string {

--- a/database/create_db_home_with_vm_cluster_id_details.go
+++ b/database/create_db_home_with_vm_cluster_id_details.go
@@ -41,6 +41,9 @@ type CreateDbHomeWithVmClusterIdDetails struct {
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
 
+	// If true, the customer acknowledges that the specified Oracle Database software is an older release that is not currently supported by OCI.
+	IsDesupportedVersion *bool `mandatory:"false" json:"isDesupportedVersion"`
+
 	// A valid Oracle Database version. To get a list of supported versions, use the ListDbVersions operation.
 	DbVersion *string `mandatory:"false" json:"dbVersion"`
 
@@ -75,6 +78,11 @@ func (m CreateDbHomeWithVmClusterIdDetails) GetFreeformTags() map[string]string 
 //GetDefinedTags returns DefinedTags
 func (m CreateDbHomeWithVmClusterIdDetails) GetDefinedTags() map[string]map[string]interface{} {
 	return m.DefinedTags
+}
+
+//GetIsDesupportedVersion returns IsDesupportedVersion
+func (m CreateDbHomeWithVmClusterIdDetails) GetIsDesupportedVersion() *bool {
+	return m.IsDesupportedVersion
 }
 
 func (m CreateDbHomeWithVmClusterIdDetails) String() string {

--- a/database/create_db_home_with_vm_cluster_id_from_backup_details.go
+++ b/database/create_db_home_with_vm_cluster_id_from_backup_details.go
@@ -42,6 +42,9 @@ type CreateDbHomeWithVmClusterIdFromBackupDetails struct {
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// If true, the customer acknowledges that the specified Oracle Database software is an older release that is not currently supported by OCI.
+	IsDesupportedVersion *bool `mandatory:"false" json:"isDesupportedVersion"`
 }
 
 //GetDisplayName returns DisplayName
@@ -72,6 +75,11 @@ func (m CreateDbHomeWithVmClusterIdFromBackupDetails) GetFreeformTags() map[stri
 //GetDefinedTags returns DefinedTags
 func (m CreateDbHomeWithVmClusterIdFromBackupDetails) GetDefinedTags() map[string]map[string]interface{} {
 	return m.DefinedTags
+}
+
+//GetIsDesupportedVersion returns IsDesupportedVersion
+func (m CreateDbHomeWithVmClusterIdFromBackupDetails) GetIsDesupportedVersion() *bool {
+	return m.IsDesupportedVersion
 }
 
 func (m CreateDbHomeWithVmClusterIdFromBackupDetails) String() string {

--- a/database/create_refreshable_autonomous_database_clone_details.go
+++ b/database/create_refreshable_autonomous_database_clone_details.go
@@ -35,6 +35,12 @@ type CreateRefreshableAutonomousDatabaseCloneDetails struct {
 	// Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB of memory. For Always Free databases, memory and CPU cannot be scaled.
 	IsFreeTier *bool `mandatory:"false" json:"isFreeTier"`
 
+	// The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Oracle Cloud Infrastructure vault (https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+	VaultId *string `mandatory:"false" json:"vaultId"`
+
 	// The password must be between 12 and 30 characters long, and must contain at least 1 uppercase, 1 lowercase, and 1 numeric character. It cannot contain the double quote symbol (") or the username "admin", regardless of casing.
 	AdminPassword *string `mandatory:"false" json:"adminPassword"`
 
@@ -167,6 +173,16 @@ func (m CreateRefreshableAutonomousDatabaseCloneDetails) GetDataStorageSizeInTBs
 //GetIsFreeTier returns IsFreeTier
 func (m CreateRefreshableAutonomousDatabaseCloneDetails) GetIsFreeTier() *bool {
 	return m.IsFreeTier
+}
+
+//GetKmsKeyId returns KmsKeyId
+func (m CreateRefreshableAutonomousDatabaseCloneDetails) GetKmsKeyId() *string {
+	return m.KmsKeyId
+}
+
+//GetVaultId returns VaultId
+func (m CreateRefreshableAutonomousDatabaseCloneDetails) GetVaultId() *string {
+	return m.VaultId
 }
 
 //GetAdminPassword returns AdminPassword

--- a/database/database_client.go
+++ b/database/database_client.go
@@ -1227,6 +1227,65 @@ func (client DatabaseClient) completeExternalBackupJob(ctx context.Context, requ
 	return response, err
 }
 
+// ConfigureAutonomousDatabaseVaultKey Configures the Autonomous Database Vault service key (https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/database/ConfigureAutonomousDatabaseVaultKey.go.html to see an example of how to use ConfigureAutonomousDatabaseVaultKey API.
+func (client DatabaseClient) ConfigureAutonomousDatabaseVaultKey(ctx context.Context, request ConfigureAutonomousDatabaseVaultKeyRequest) (response ConfigureAutonomousDatabaseVaultKeyResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.configureAutonomousDatabaseVaultKey, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ConfigureAutonomousDatabaseVaultKeyResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ConfigureAutonomousDatabaseVaultKeyResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ConfigureAutonomousDatabaseVaultKeyResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ConfigureAutonomousDatabaseVaultKeyResponse")
+	}
+	return
+}
+
+// configureAutonomousDatabaseVaultKey implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) configureAutonomousDatabaseVaultKey(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/autonomousDatabases/{autonomousDatabaseId}/actions/configureAutonomousDatabaseVaultKey", binaryReqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ConfigureAutonomousDatabaseVaultKeyResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // CreateAutonomousContainerDatabase Creates an Autonomous Container Database in the specified Autonomous Exadata Infrastructure.
 //
 // See also

--- a/database/list_db_versions_request_response.go
+++ b/database/list_db_versions_request_response.go
@@ -39,6 +39,9 @@ type ListDbVersionsRequest struct {
 	// If provided, filters the results to the set of database versions which are supported for Upgrade.
 	IsUpgradeSupported *bool `mandatory:"false" contributesTo:"query" name:"isUpgradeSupported"`
 
+	// If true, filters the results to the set of Oracle Database versions that are supported for OCI database software images.
+	IsDatabaseSoftwareImageSupported *bool `mandatory:"false" contributesTo:"query" name:"isDatabaseSoftwareImageSupported"`
+
 	// Unique Oracle-assigned identifier for the request.
 	// If you need to contact Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`

--- a/loganalytics/abstract_command_descriptor.go
+++ b/loganalytics/abstract_command_descriptor.go
@@ -85,6 +85,10 @@ func (m *abstractcommanddescriptor) UnmarshalPolymorphicJSON(data []byte) (inter
 		mm := MultiSearchCommandDescriptor{}
 		err = json.Unmarshal(data, &mm)
 		return mm, err
+	case "COMPARE":
+		mm := CompareCommandDescriptor{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
 	case "STATS":
 		mm := StatsCommandDescriptor{}
 		err = json.Unmarshal(data, &mm)
@@ -317,6 +321,7 @@ const (
 	AbstractCommandDescriptorNameCreateView      AbstractCommandDescriptorNameEnum = "CREATE_VIEW"
 	AbstractCommandDescriptorNameMap             AbstractCommandDescriptorNameEnum = "MAP"
 	AbstractCommandDescriptorNameNlp             AbstractCommandDescriptorNameEnum = "NLP"
+	AbstractCommandDescriptorNameCompare         AbstractCommandDescriptorNameEnum = "COMPARE"
 )
 
 var mappingAbstractCommandDescriptorName = map[string]AbstractCommandDescriptorNameEnum{
@@ -361,6 +366,7 @@ var mappingAbstractCommandDescriptorName = map[string]AbstractCommandDescriptorN
 	"CREATE_VIEW":      AbstractCommandDescriptorNameCreateView,
 	"MAP":              AbstractCommandDescriptorNameMap,
 	"NLP":              AbstractCommandDescriptorNameNlp,
+	"COMPARE":          AbstractCommandDescriptorNameCompare,
 }
 
 // GetAbstractCommandDescriptorNameEnumValues Enumerates the set of values for AbstractCommandDescriptorNameEnum

--- a/loganalytics/compare_command_descriptor.go
+++ b/loganalytics/compare_command_descriptor.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// LogAnalytics API
+//
+// The LogAnalytics API for the LogAnalytics service.
+//
+
+package loganalytics
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/v41/common"
+)
+
+// CompareCommandDescriptor Command descriptor for querylanguage COMPARE command.
+type CompareCommandDescriptor struct {
+
+	// Command fragment display string from user specified query string formatted by query builder.
+	DisplayQueryString *string `mandatory:"true" json:"displayQueryString"`
+
+	// Command fragment internal string from user specified query string formatted by query builder.
+	InternalQueryString *string `mandatory:"true" json:"internalQueryString"`
+
+	// querylanguage command designation for example; reporting vs filtering
+	Category *string `mandatory:"false" json:"category"`
+
+	// Fields referenced in command fragment from user specified query string.
+	ReferencedFields []AbstractField `mandatory:"false" json:"referencedFields"`
+
+	// Fields declared in command fragment from user specified query string.
+	DeclaredFields []AbstractField `mandatory:"false" json:"declaredFields"`
+}
+
+//GetDisplayQueryString returns DisplayQueryString
+func (m CompareCommandDescriptor) GetDisplayQueryString() *string {
+	return m.DisplayQueryString
+}
+
+//GetInternalQueryString returns InternalQueryString
+func (m CompareCommandDescriptor) GetInternalQueryString() *string {
+	return m.InternalQueryString
+}
+
+//GetCategory returns Category
+func (m CompareCommandDescriptor) GetCategory() *string {
+	return m.Category
+}
+
+//GetReferencedFields returns ReferencedFields
+func (m CompareCommandDescriptor) GetReferencedFields() []AbstractField {
+	return m.ReferencedFields
+}
+
+//GetDeclaredFields returns DeclaredFields
+func (m CompareCommandDescriptor) GetDeclaredFields() []AbstractField {
+	return m.DeclaredFields
+}
+
+func (m CompareCommandDescriptor) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m CompareCommandDescriptor) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCompareCommandDescriptor CompareCommandDescriptor
+	s := struct {
+		DiscriminatorParam string `json:"name"`
+		MarshalTypeCompareCommandDescriptor
+	}{
+		"COMPARE",
+		(MarshalTypeCompareCommandDescriptor)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *CompareCommandDescriptor) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Category            *string         `json:"category"`
+		ReferencedFields    []abstractfield `json:"referencedFields"`
+		DeclaredFields      []abstractfield `json:"declaredFields"`
+		DisplayQueryString  *string         `json:"displayQueryString"`
+		InternalQueryString *string         `json:"internalQueryString"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Category = model.Category
+
+	m.ReferencedFields = make([]AbstractField, len(model.ReferencedFields))
+	for i, n := range model.ReferencedFields {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.ReferencedFields[i] = nn.(AbstractField)
+		} else {
+			m.ReferencedFields[i] = nil
+		}
+	}
+
+	m.DeclaredFields = make([]AbstractField, len(model.DeclaredFields))
+	for i, n := range model.DeclaredFields {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.DeclaredFields[i] = nn.(AbstractField)
+		} else {
+			m.DeclaredFields[i] = nil
+		}
+	}
+
+	m.DisplayQueryString = model.DisplayQueryString
+
+	m.InternalQueryString = model.InternalQueryString
+
+	return
+}

--- a/loganalytics/cron_schedule.go
+++ b/loganalytics/cron_schedule.go
@@ -23,6 +23,10 @@ type CronSchedule struct {
 	// Time zone, by default UTC.
 	TimeZone *string `mandatory:"true" json:"timeZone"`
 
+	// The date and time the scheduled task should execute first time after create or update;
+	// thereafter the task will execute as specified in the schedule.
+	TimeOfFirstExecution *common.SDKTime `mandatory:"false" json:"timeOfFirstExecution"`
+
 	// Schedule misfire retry policy.
 	MisfirePolicy ScheduleMisfirePolicyEnum `mandatory:"false" json:"misfirePolicy,omitempty"`
 }
@@ -30,6 +34,11 @@ type CronSchedule struct {
 //GetMisfirePolicy returns MisfirePolicy
 func (m CronSchedule) GetMisfirePolicy() ScheduleMisfirePolicyEnum {
 	return m.MisfirePolicy
+}
+
+//GetTimeOfFirstExecution returns TimeOfFirstExecution
+func (m CronSchedule) GetTimeOfFirstExecution() *common.SDKTime {
+	return m.TimeOfFirstExecution
 }
 
 func (m CronSchedule) String() string {

--- a/loganalytics/fixed_frequency_schedule.go
+++ b/loganalytics/fixed_frequency_schedule.go
@@ -23,6 +23,10 @@ type FixedFrequencySchedule struct {
 	// The value must be at least 5 minutes (PT5M) and at most 3 weeks (P21D or PT30240M).
 	RecurringInterval *string `mandatory:"true" json:"recurringInterval"`
 
+	// The date and time the scheduled task should execute first time after create or update;
+	// thereafter the task will execute as specified in the schedule.
+	TimeOfFirstExecution *common.SDKTime `mandatory:"false" json:"timeOfFirstExecution"`
+
 	// Number of times (0-based) to execute until auto-stop.
 	// Default value -1 will execute indefinitely.
 	// Value 0 will execute once.
@@ -35,6 +39,11 @@ type FixedFrequencySchedule struct {
 //GetMisfirePolicy returns MisfirePolicy
 func (m FixedFrequencySchedule) GetMisfirePolicy() ScheduleMisfirePolicyEnum {
 	return m.MisfirePolicy
+}
+
+//GetTimeOfFirstExecution returns TimeOfFirstExecution
+func (m FixedFrequencySchedule) GetTimeOfFirstExecution() *common.SDKTime {
+	return m.TimeOfFirstExecution
 }
 
 func (m FixedFrequencySchedule) String() string {

--- a/loganalytics/namespace.go
+++ b/loganalytics/namespace.go
@@ -27,6 +27,9 @@ type Namespace struct {
 
 	// This indicates if the log set feature is enabled for the tenancy
 	IsLogSetEnabled *bool `mandatory:"false" json:"isLogSetEnabled"`
+
+	// This indicates if data has ever been ingested for the tenancy in Logging Analytics
+	IsDataEverIngested *bool `mandatory:"false" json:"isDataEverIngested"`
 }
 
 func (m Namespace) String() string {

--- a/loganalytics/namespace_summary.go
+++ b/loganalytics/namespace_summary.go
@@ -27,6 +27,9 @@ type NamespaceSummary struct {
 
 	// This indicates if the log set feature is enabled for the tenancy
 	IsLogSetEnabled *bool `mandatory:"false" json:"isLogSetEnabled"`
+
+	// This indicates if data has ever been ingested for the tenancy in Logging Analytics
+	IsDataEverIngested *bool `mandatory:"false" json:"isDataEverIngested"`
 }
 
 func (m NamespaceSummary) String() string {

--- a/loganalytics/schedule.go
+++ b/loganalytics/schedule.go
@@ -19,12 +19,17 @@ type Schedule interface {
 
 	// Schedule misfire retry policy.
 	GetMisfirePolicy() ScheduleMisfirePolicyEnum
+
+	// The date and time the scheduled task should execute first time after create or update;
+	// thereafter the task will execute as specified in the schedule.
+	GetTimeOfFirstExecution() *common.SDKTime
 }
 
 type schedule struct {
-	JsonData      []byte
-	MisfirePolicy ScheduleMisfirePolicyEnum `mandatory:"false" json:"misfirePolicy,omitempty"`
-	Type          string                    `json:"type"`
+	JsonData             []byte
+	MisfirePolicy        ScheduleMisfirePolicyEnum `mandatory:"false" json:"misfirePolicy,omitempty"`
+	TimeOfFirstExecution *common.SDKTime           `mandatory:"false" json:"timeOfFirstExecution"`
+	Type                 string                    `json:"type"`
 }
 
 // UnmarshalJSON unmarshals json
@@ -39,6 +44,7 @@ func (m *schedule) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	m.MisfirePolicy = s.Model.MisfirePolicy
+	m.TimeOfFirstExecution = s.Model.TimeOfFirstExecution
 	m.Type = s.Model.Type
 
 	return err
@@ -69,6 +75,11 @@ func (m *schedule) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
 //GetMisfirePolicy returns MisfirePolicy
 func (m schedule) GetMisfirePolicy() ScheduleMisfirePolicyEnum {
 	return m.MisfirePolicy
+}
+
+//GetTimeOfFirstExecution returns TimeOfFirstExecution
+func (m schedule) GetTimeOfFirstExecution() *common.SDKTime {
+	return m.TimeOfFirstExecution
 }
 
 func (m schedule) String() string {

--- a/loganalytics/scheduled_task.go
+++ b/loganalytics/scheduled_task.go
@@ -49,11 +49,18 @@ type ScheduledTask interface {
 	// Status of the scheduled task.
 	GetTaskStatus() ScheduledTaskTaskStatusEnum
 
+	// reason for taskStatus PAUSED.
+	GetPauseReason() ScheduledTaskPauseReasonEnum
+
 	// most recent Work Request Identifier OCID  (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) for the asynchronous request.
 	GetWorkRequestId() *string
 
 	// Number of execution occurrences.
 	GetNumOccurrences() *int64
+
+	// The date and time the scheduled task will execute next,
+	// in the format defined by RFC3339.
+	GetTimeOfNextExecution() *common.SDKTime
 
 	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
 	// Example: `{"bar-key": "value"}`
@@ -65,22 +72,24 @@ type ScheduledTask interface {
 }
 
 type scheduledtask struct {
-	JsonData       []byte
-	Id             *string                           `mandatory:"true" json:"id"`
-	DisplayName    *string                           `mandatory:"true" json:"displayName"`
-	TaskType       TaskTypeEnum                      `mandatory:"true" json:"taskType"`
-	Schedules      []Schedule                        `mandatory:"true" json:"schedules"`
-	Action         Action                            `mandatory:"true" json:"action"`
-	CompartmentId  *string                           `mandatory:"true" json:"compartmentId"`
-	TimeCreated    *common.SDKTime                   `mandatory:"true" json:"timeCreated"`
-	TimeUpdated    *common.SDKTime                   `mandatory:"true" json:"timeUpdated"`
-	LifecycleState ScheduledTaskLifecycleStateEnum   `mandatory:"true" json:"lifecycleState"`
-	TaskStatus     ScheduledTaskTaskStatusEnum       `mandatory:"false" json:"taskStatus,omitempty"`
-	WorkRequestId  *string                           `mandatory:"false" json:"workRequestId"`
-	NumOccurrences *int64                            `mandatory:"false" json:"numOccurrences"`
-	FreeformTags   map[string]string                 `mandatory:"false" json:"freeformTags"`
-	DefinedTags    map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
-	Kind           string                            `json:"kind"`
+	JsonData            []byte
+	Id                  *string                           `mandatory:"true" json:"id"`
+	DisplayName         *string                           `mandatory:"true" json:"displayName"`
+	TaskType            TaskTypeEnum                      `mandatory:"true" json:"taskType"`
+	Schedules           []Schedule                        `mandatory:"true" json:"schedules"`
+	Action              Action                            `mandatory:"true" json:"action"`
+	CompartmentId       *string                           `mandatory:"true" json:"compartmentId"`
+	TimeCreated         *common.SDKTime                   `mandatory:"true" json:"timeCreated"`
+	TimeUpdated         *common.SDKTime                   `mandatory:"true" json:"timeUpdated"`
+	LifecycleState      ScheduledTaskLifecycleStateEnum   `mandatory:"true" json:"lifecycleState"`
+	TaskStatus          ScheduledTaskTaskStatusEnum       `mandatory:"false" json:"taskStatus,omitempty"`
+	PauseReason         ScheduledTaskPauseReasonEnum      `mandatory:"false" json:"pauseReason,omitempty"`
+	WorkRequestId       *string                           `mandatory:"false" json:"workRequestId"`
+	NumOccurrences      *int64                            `mandatory:"false" json:"numOccurrences"`
+	TimeOfNextExecution *common.SDKTime                   `mandatory:"false" json:"timeOfNextExecution"`
+	FreeformTags        map[string]string                 `mandatory:"false" json:"freeformTags"`
+	DefinedTags         map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+	Kind                string                            `json:"kind"`
 }
 
 // UnmarshalJSON unmarshals json
@@ -104,8 +113,10 @@ func (m *scheduledtask) UnmarshalJSON(data []byte) error {
 	m.TimeUpdated = s.Model.TimeUpdated
 	m.LifecycleState = s.Model.LifecycleState
 	m.TaskStatus = s.Model.TaskStatus
+	m.PauseReason = s.Model.PauseReason
 	m.WorkRequestId = s.Model.WorkRequestId
 	m.NumOccurrences = s.Model.NumOccurrences
+	m.TimeOfNextExecution = s.Model.TimeOfNextExecution
 	m.FreeformTags = s.Model.FreeformTags
 	m.DefinedTags = s.Model.DefinedTags
 	m.Kind = s.Model.Kind
@@ -181,6 +192,11 @@ func (m scheduledtask) GetTaskStatus() ScheduledTaskTaskStatusEnum {
 	return m.TaskStatus
 }
 
+//GetPauseReason returns PauseReason
+func (m scheduledtask) GetPauseReason() ScheduledTaskPauseReasonEnum {
+	return m.PauseReason
+}
+
 //GetWorkRequestId returns WorkRequestId
 func (m scheduledtask) GetWorkRequestId() *string {
 	return m.WorkRequestId
@@ -189,6 +205,11 @@ func (m scheduledtask) GetWorkRequestId() *string {
 //GetNumOccurrences returns NumOccurrences
 func (m scheduledtask) GetNumOccurrences() *int64 {
 	return m.NumOccurrences
+}
+
+//GetTimeOfNextExecution returns TimeOfNextExecution
+func (m scheduledtask) GetTimeOfNextExecution() *common.SDKTime {
+	return m.TimeOfNextExecution
 }
 
 //GetFreeformTags returns FreeformTags
@@ -227,6 +248,37 @@ var mappingScheduledTaskTaskStatus = map[string]ScheduledTaskTaskStatusEnum{
 func GetScheduledTaskTaskStatusEnumValues() []ScheduledTaskTaskStatusEnum {
 	values := make([]ScheduledTaskTaskStatusEnum, 0)
 	for _, v := range mappingScheduledTaskTaskStatus {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ScheduledTaskPauseReasonEnum Enum with underlying type: string
+type ScheduledTaskPauseReasonEnum string
+
+// Set of constants representing the allowable values for ScheduledTaskPauseReasonEnum
+const (
+	ScheduledTaskPauseReasonMetricExtractionNotValid ScheduledTaskPauseReasonEnum = "METRIC_EXTRACTION_NOT_VALID"
+	ScheduledTaskPauseReasonSavedSearchNotValid      ScheduledTaskPauseReasonEnum = "SAVED_SEARCH_NOT_VALID"
+	ScheduledTaskPauseReasonSavedSearchNotFound      ScheduledTaskPauseReasonEnum = "SAVED_SEARCH_NOT_FOUND"
+	ScheduledTaskPauseReasonQueryStringNotValid      ScheduledTaskPauseReasonEnum = "QUERY_STRING_NOT_VALID"
+	ScheduledTaskPauseReasonUserAction               ScheduledTaskPauseReasonEnum = "USER_ACTION"
+	ScheduledTaskPauseReasonTenancyLifecycle         ScheduledTaskPauseReasonEnum = "TENANCY_LIFECYCLE"
+)
+
+var mappingScheduledTaskPauseReason = map[string]ScheduledTaskPauseReasonEnum{
+	"METRIC_EXTRACTION_NOT_VALID": ScheduledTaskPauseReasonMetricExtractionNotValid,
+	"SAVED_SEARCH_NOT_VALID":      ScheduledTaskPauseReasonSavedSearchNotValid,
+	"SAVED_SEARCH_NOT_FOUND":      ScheduledTaskPauseReasonSavedSearchNotFound,
+	"QUERY_STRING_NOT_VALID":      ScheduledTaskPauseReasonQueryStringNotValid,
+	"USER_ACTION":                 ScheduledTaskPauseReasonUserAction,
+	"TENANCY_LIFECYCLE":           ScheduledTaskPauseReasonTenancyLifecycle,
+}
+
+// GetScheduledTaskPauseReasonEnumValues Enumerates the set of values for ScheduledTaskPauseReasonEnum
+func GetScheduledTaskPauseReasonEnumValues() []ScheduledTaskPauseReasonEnum {
+	values := make([]ScheduledTaskPauseReasonEnum, 0)
+	for _, v := range mappingScheduledTaskPauseReason {
 		values = append(values, v)
 	}
 	return values

--- a/loganalytics/scheduled_task_summary.go
+++ b/loganalytics/scheduled_task_summary.go
@@ -43,6 +43,9 @@ type ScheduledTaskSummary struct {
 	// Status of the scheduled task.
 	TaskStatus ScheduledTaskSummaryTaskStatusEnum `mandatory:"false" json:"taskStatus,omitempty"`
 
+	// reason for taskStatus PAUSED.
+	PauseReason ScheduledTaskPauseReasonEnum `mandatory:"false" json:"pauseReason,omitempty"`
+
 	// most recent Work Request Identifier OCID  (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) for the asynchronous request.
 	WorkRequestId *string `mandatory:"false" json:"workRequestId"`
 

--- a/loganalytics/standard_task.go
+++ b/loganalytics/standard_task.go
@@ -46,6 +46,10 @@ type StandardTask struct {
 	// Number of execution occurrences.
 	NumOccurrences *int64 `mandatory:"false" json:"numOccurrences"`
 
+	// The date and time the scheduled task will execute next,
+	// in the format defined by RFC3339.
+	TimeOfNextExecution *common.SDKTime `mandatory:"false" json:"timeOfNextExecution"`
+
 	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
 	// Example: `{"bar-key": "value"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
@@ -65,6 +69,9 @@ type StandardTask struct {
 
 	// Status of the scheduled task.
 	TaskStatus ScheduledTaskTaskStatusEnum `mandatory:"false" json:"taskStatus,omitempty"`
+
+	// reason for taskStatus PAUSED.
+	PauseReason ScheduledTaskPauseReasonEnum `mandatory:"false" json:"pauseReason,omitempty"`
 
 	// The current state of the scheduled task.
 	LifecycleState ScheduledTaskLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
@@ -100,6 +107,11 @@ func (m StandardTask) GetTaskStatus() ScheduledTaskTaskStatusEnum {
 	return m.TaskStatus
 }
 
+//GetPauseReason returns PauseReason
+func (m StandardTask) GetPauseReason() ScheduledTaskPauseReasonEnum {
+	return m.PauseReason
+}
+
 //GetWorkRequestId returns WorkRequestId
 func (m StandardTask) GetWorkRequestId() *string {
 	return m.WorkRequestId
@@ -123,6 +135,11 @@ func (m StandardTask) GetTimeCreated() *common.SDKTime {
 //GetTimeUpdated returns TimeUpdated
 func (m StandardTask) GetTimeUpdated() *common.SDKTime {
 	return m.TimeUpdated
+}
+
+//GetTimeOfNextExecution returns TimeOfNextExecution
+func (m StandardTask) GetTimeOfNextExecution() *common.SDKTime {
+	return m.TimeOfNextExecution
 }
 
 //GetLifecycleState returns LifecycleState
@@ -162,8 +179,10 @@ func (m StandardTask) MarshalJSON() (buff []byte, e error) {
 func (m *StandardTask) UnmarshalJSON(data []byte) (e error) {
 	model := struct {
 		TaskStatus          ScheduledTaskTaskStatusEnum         `json:"taskStatus"`
+		PauseReason         ScheduledTaskPauseReasonEnum        `json:"pauseReason"`
 		WorkRequestId       *string                             `json:"workRequestId"`
 		NumOccurrences      *int64                              `json:"numOccurrences"`
+		TimeOfNextExecution *common.SDKTime                     `json:"timeOfNextExecution"`
 		FreeformTags        map[string]string                   `json:"freeformTags"`
 		DefinedTags         map[string]map[string]interface{}   `json:"definedTags"`
 		LastExecutionStatus StandardTaskLastExecutionStatusEnum `json:"lastExecutionStatus"`
@@ -186,9 +205,13 @@ func (m *StandardTask) UnmarshalJSON(data []byte) (e error) {
 	var nn interface{}
 	m.TaskStatus = model.TaskStatus
 
+	m.PauseReason = model.PauseReason
+
 	m.WorkRequestId = model.WorkRequestId
 
 	m.NumOccurrences = model.NumOccurrences
+
+	m.TimeOfNextExecution = model.TimeOfNextExecution
 
 	m.FreeformTags = model.FreeformTags
 

--- a/loganalytics/stream_action.go
+++ b/loganalytics/stream_action.go
@@ -21,6 +21,27 @@ type StreamAction struct {
 	SavedSearchId *string `mandatory:"false" json:"savedSearchId"`
 
 	MetricExtraction *MetricExtraction `mandatory:"false" json:"metricExtraction"`
+
+	// The duration of data to be searched for SAVED_SEARCH tasks,
+	// used when the task fires to calculate the query time range.
+	// Duration in ISO 8601 extended format as described in
+	// https://en.wikipedia.org/wiki/ISO_8601#Durations.
+	// The value should be positive.
+	// The largest supported unit (as opposed to value) is D, e.g.  P14D (not P2W).
+	// There are restrictions on the maximum duration value relative to the task schedule
+	// value as specified in the following table.
+	//    Schedule Interval Range          | Maximum Duration
+	// ----------------------------------- | -----------------
+	//   5 Minutes     to 30 Minutes       |   1 hour  "PT60M"
+	//  31 Minutes     to  1 Hour          |  12 hours "PT720M"
+	//  1 Hour+1Minute to  1 Day           |   1 day   "P1D"
+	//  1 Day+1Minute  to  1 Week-1Minute  |   7 days  "P7D"
+	//  1 Week         to  2 Weeks         |  14 days  "P14D"
+	//  greater than 2 Weeks               |  30 days  "P30D"
+	// If not specified, the duration will be based on the schedule. For example,
+	// if the schedule is every 5 minutes then the savedSearchDuration will be "PT5M";
+	// if the schedule is every 3 weeks then the savedSearchDuration will be "P21D".
+	SavedSearchDuration *string `mandatory:"false" json:"savedSearchDuration"`
 }
 
 func (m StreamAction) String() string {


### PR DESCRIPTION
### Added

- Support for configuration of autonomous database KMS keys in the Database service

- Support for creating database software images with any supported RUs in the Database service

- Support for creating database software images from an existing database home in the Database service

- Support for listing all NSGs associated with a given VLAN in the Networking service

- Support for a duration windows, task failure reasons, and next execution times on scheduled tasks in the Logging Analytics service 

- Support for calling Oracle Cloud Infrastructure services in the sa-vinhedo-1 region
