### PR TITLE
Improve user_data metadata example

### DIFF
--- a/core/instance_configuration_launch_instance_details.go
+++ b/core/instance_configuration_launch_instance_details.go
@@ -103,7 +103,7 @@ type InstanceConfigurationLaunchInstanceDetails struct {
 	//       "metadata" : {
 	//          "quake_bot_level" : "Severe",
 	//          "ssh_authorized_keys" : "ssh-rsa <your_public_SSH_key>== rsa-key-20160227",
-	//          "user_data" : "<your_public_SSH_key>=="
+	//          "user_data" : "<your_base64_encoded_user_data>=="
 	//       }
 	//  **Getting Metadata on the Instance**
 	//  To get information about your instance, connect to the instance using SSH and issue any of the

--- a/core/launch_instance_details.go
+++ b/core/launch_instance_details.go
@@ -142,7 +142,7 @@ type LaunchInstanceDetails struct {
 	//       "metadata" : {
 	//          "quake_bot_level" : "Severe",
 	//          "ssh_authorized_keys" : "ssh-rsa <your_public_SSH_key>== rsa-key-20160227",
-	//          "user_data" : "<your_public_SSH_key>=="
+	//          "user_data" : "<your_base64_encoded_user_data>=="
 	//       }
 	//  **Getting Metadata on the Instance**
 	//  To get information about your instance, connect to the instance using SSH and issue any of the


### PR DESCRIPTION
* Replace`<your_public_SSH_key>` with `<your_base64_encoded_user_data>` in `metadata.user_data` example.