### PR TITLE
Releasing version 45.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## 45.2.0 - 2021-08-03
+### Added
+- Support for manually copying volume group backups across regions in the Block Volume service
+- Support for work requests for the copy volume backup and copy boot volume backup operations in the Block Volume service
+- Support for specifying external Hive metastores during application creation in the Data Flow service
+- Support for changing the compartment of a backup in the MySQL Database service
+- Support for model catalog features including provenance, metadata, schemas, and artifact introspection in the Data Science service
+- Support for Exadata system network bonding in the Database service
+- Support for creating autonomous databases with early patching enabled in the Database service
+
 ## 45.1.0 - 2021-07-27
 ### Added
 - Support for filtering by tag on capacity planning and SQL warehouse list operations in the Operations Insights service

--- a/common/version.go
+++ b/common/version.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	major = "45"
-	minor = "1"
+	minor = "2"
 	patch = "0"
 	tag   = ""
 )

--- a/core/copy_boot_volume_backup_request_response.go
+++ b/core/copy_boot_volume_backup_request_response.go
@@ -75,6 +75,16 @@ type CopyBootVolumeBackupResponse struct {
 	// Unique Oracle-assigned identifier for the request. If you need to contact
 	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// The OCID of the work request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+	// with this ID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Location of the resource.
+	Location *string `presentIn:"header" name:"location"`
+
+	// Location of the resource.
+	ContentLocation *string `presentIn:"header" name:"content-location"`
 }
 
 func (response CopyBootVolumeBackupResponse) String() string {

--- a/core/copy_volume_group_backup_details.go
+++ b/core/copy_volume_group_backup_details.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/v45/common"
+)
+
+// CopyVolumeGroupBackupDetails The representation of CopyVolumeGroupBackupDetails
+type CopyVolumeGroupBackupDetails struct {
+
+	// The name of the destination region.
+	// Example: `us-ashburn-1`
+	DestinationRegion *string `mandatory:"true" json:"destinationRegion"`
+
+	// A user-friendly name for the volume group backup. Does not have to be unique and it's changeable.
+	// Avoid entering confidential information.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// The OCID of the Key Management key in the destination region which will be the master encryption key
+	// for the copied volume group backup.
+	// If you do not specify this attribute the volume group backup will be encrypted with the Oracle-provided encryption
+	// key when it is copied to the destination region.
+	//
+	// For more information about the Key Management service and encryption keys, see
+	// Overview of Key Management (https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm) and
+	// Using Keys (https://docs.cloud.oracle.com/Content/KeyManagement/Tasks/usingkeys.htm).
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+}
+
+func (m CopyVolumeGroupBackupDetails) String() string {
+	return common.PointerString(m)
+}

--- a/core/copy_volume_group_backup_request_response.go
+++ b/core/copy_volume_group_backup_request_response.go
@@ -9,18 +9,18 @@ import (
 	"net/http"
 )
 
-// CopyVolumeBackupRequest wrapper for the CopyVolumeBackup operation
+// CopyVolumeGroupBackupRequest wrapper for the CopyVolumeGroupBackup operation
 //
 // See also
 //
-// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/CopyVolumeBackup.go.html to see an example of how to use CopyVolumeBackupRequest.
-type CopyVolumeBackupRequest struct {
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/CopyVolumeGroupBackup.go.html to see an example of how to use CopyVolumeGroupBackupRequest.
+type CopyVolumeGroupBackupRequest struct {
 
-	// The OCID of the volume backup.
-	VolumeBackupId *string `mandatory:"true" contributesTo:"path" name:"volumeBackupId"`
+	// The Oracle Cloud ID (OCID) that uniquely identifies the volume group backup.
+	VolumeGroupBackupId *string `mandatory:"true" contributesTo:"path" name:"volumeGroupBackupId"`
 
-	// Request to create a cross-region copy of given backup.
-	CopyVolumeBackupDetails `contributesTo:"body"`
+	// Request to create a cross-region copy of given volume group backup.
+	CopyVolumeGroupBackupDetails `contributesTo:"body"`
 
 	// A token that uniquely identifies a request so it can be retried in case of a timeout or
 	// server error without risk of executing that same action again. Retry tokens expire after 24
@@ -38,36 +38,36 @@ type CopyVolumeBackupRequest struct {
 	RequestMetadata common.RequestMetadata
 }
 
-func (request CopyVolumeBackupRequest) String() string {
+func (request CopyVolumeGroupBackupRequest) String() string {
 	return common.PointerString(request)
 }
 
 // HTTPRequest implements the OCIRequest interface
-func (request CopyVolumeBackupRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+func (request CopyVolumeGroupBackupRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
 
 	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
 }
 
 // BinaryRequestBody implements the OCIRequest interface
-func (request CopyVolumeBackupRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+func (request CopyVolumeGroupBackupRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
 
 	return nil, false
 
 }
 
 // RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
-func (request CopyVolumeBackupRequest) RetryPolicy() *common.RetryPolicy {
+func (request CopyVolumeGroupBackupRequest) RetryPolicy() *common.RetryPolicy {
 	return request.RequestMetadata.RetryPolicy
 }
 
-// CopyVolumeBackupResponse wrapper for the CopyVolumeBackup operation
-type CopyVolumeBackupResponse struct {
+// CopyVolumeGroupBackupResponse wrapper for the CopyVolumeGroupBackup operation
+type CopyVolumeGroupBackupResponse struct {
 
 	// The underlying http response
 	RawResponse *http.Response
 
-	// The VolumeBackup instance
-	VolumeBackup `presentIn:"body"`
+	// The VolumeGroupBackup instance
+	VolumeGroupBackup `presentIn:"body"`
 
 	// For optimistic concurrency control. See `if-match`.
 	Etag *string `presentIn:"header" name:"etag"`
@@ -75,23 +75,13 @@ type CopyVolumeBackupResponse struct {
 	// Unique Oracle-assigned identifier for the request. If you need to contact
 	// Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
-
-	// The OCID of the work request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
-	// with this ID to track the status of the request.
-	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
-
-	// Location of the resource.
-	Location *string `presentIn:"header" name:"location"`
-
-	// Location of the resource.
-	ContentLocation *string `presentIn:"header" name:"content-location"`
 }
 
-func (response CopyVolumeBackupResponse) String() string {
+func (response CopyVolumeGroupBackupResponse) String() string {
 	return common.PointerString(response)
 }
 
 // HTTPResponse implements the OCIResponse interface
-func (response CopyVolumeBackupResponse) HTTPResponse() *http.Response {
+func (response CopyVolumeGroupBackupResponse) HTTPResponse() *http.Response {
 	return response.RawResponse
 }

--- a/core/core_blockstorage_client.go
+++ b/core/core_blockstorage_client.go
@@ -547,6 +547,67 @@ func (client BlockstorageClient) copyVolumeBackup(ctx context.Context, request c
 	return response, err
 }
 
+// CopyVolumeGroupBackup Creates a volume group backup copy in specified region. For general information about volume group backups,
+// see Overview of Block Volume Service Backups (https://docs.cloud.oracle.com/Content/Block/Concepts/blockvolumebackups.htm)
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/CopyVolumeGroupBackup.go.html to see an example of how to use CopyVolumeGroupBackup API.
+func (client BlockstorageClient) CopyVolumeGroupBackup(ctx context.Context, request CopyVolumeGroupBackupRequest) (response CopyVolumeGroupBackupResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.copyVolumeGroupBackup, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CopyVolumeGroupBackupResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CopyVolumeGroupBackupResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CopyVolumeGroupBackupResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CopyVolumeGroupBackupResponse")
+	}
+	return
+}
+
+// copyVolumeGroupBackup implements the OCIOperation interface (enables retrying operations)
+func (client BlockstorageClient) copyVolumeGroupBackup(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/volumeGroupBackups/{volumeGroupBackupId}/actions/copy", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response CopyVolumeGroupBackupResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // CreateBootVolume Creates a new boot volume in the specified compartment from an existing boot volume or a boot volume backup.
 // For general information about boot volumes, see Boot Volumes (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/bootvolumes.htm).
 // You may optionally specify a *display name* for the volume, which is simply a friendly name or

--- a/core/instance_configuration_instance_source_via_image_details.go
+++ b/core/instance_configuration_instance_source_via_image_details.go
@@ -22,7 +22,7 @@ import (
 type InstanceConfigurationInstanceSourceViaImageDetails struct {
 
 	// The size of the boot volume in GBs. The minimum value is 50 GB and the maximum
-	// value is 16384 GB (16TB).
+	// value is 32,768 GB (32 TB).
 	BootVolumeSizeInGBs *int64 `mandatory:"false" json:"bootVolumeSizeInGBs"`
 
 	// The OCID of the image used to boot the instance.

--- a/core/instance_source_via_image_details.go
+++ b/core/instance_source_via_image_details.go
@@ -24,7 +24,7 @@ type InstanceSourceViaImageDetails struct {
 	// The OCID of the image used to boot the instance.
 	ImageId *string `mandatory:"true" json:"imageId"`
 
-	// The size of the boot volume in GBs. Minimum value is 50 GB and maximum value is 16384 GB (16TB).
+	// The size of the boot volume in GBs. Minimum value is 50 GB and maximum value is 32,768 GB (32 TB).
 	BootVolumeSizeInGBs *int64 `mandatory:"false" json:"bootVolumeSizeInGBs"`
 
 	// The OCID of the Key Management key to assign as the master encryption key for the boot volume.

--- a/database/autonomous_database.go
+++ b/database/autonomous_database.go
@@ -275,6 +275,10 @@ type AutonomousDatabase struct {
 
 	// The list of OCIDs (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of standby databases located in Autonomous Data Guard remote regions that are associated with the source database. Note that for shared Exadata infrastructure, standby databases located in the same region as the source primary database do not have OCIDs.
 	PeerDbIds []string `mandatory:"false" json:"peerDbIds"`
+
+	// The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+	// follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+	AutonomousMaintenanceScheduleType AutonomousDatabaseAutonomousMaintenanceScheduleTypeEnum `mandatory:"false" json:"autonomousMaintenanceScheduleType,omitempty"`
 }
 
 func (m AutonomousDatabase) String() string {
@@ -608,6 +612,29 @@ var mappingAutonomousDatabaseDataguardRegionType = map[string]AutonomousDatabase
 func GetAutonomousDatabaseDataguardRegionTypeEnumValues() []AutonomousDatabaseDataguardRegionTypeEnum {
 	values := make([]AutonomousDatabaseDataguardRegionTypeEnum, 0)
 	for _, v := range mappingAutonomousDatabaseDataguardRegionType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// AutonomousDatabaseAutonomousMaintenanceScheduleTypeEnum Enum with underlying type: string
+type AutonomousDatabaseAutonomousMaintenanceScheduleTypeEnum string
+
+// Set of constants representing the allowable values for AutonomousDatabaseAutonomousMaintenanceScheduleTypeEnum
+const (
+	AutonomousDatabaseAutonomousMaintenanceScheduleTypeEarly   AutonomousDatabaseAutonomousMaintenanceScheduleTypeEnum = "EARLY"
+	AutonomousDatabaseAutonomousMaintenanceScheduleTypeRegular AutonomousDatabaseAutonomousMaintenanceScheduleTypeEnum = "REGULAR"
+)
+
+var mappingAutonomousDatabaseAutonomousMaintenanceScheduleType = map[string]AutonomousDatabaseAutonomousMaintenanceScheduleTypeEnum{
+	"EARLY":   AutonomousDatabaseAutonomousMaintenanceScheduleTypeEarly,
+	"REGULAR": AutonomousDatabaseAutonomousMaintenanceScheduleTypeRegular,
+}
+
+// GetAutonomousDatabaseAutonomousMaintenanceScheduleTypeEnumValues Enumerates the set of values for AutonomousDatabaseAutonomousMaintenanceScheduleTypeEnum
+func GetAutonomousDatabaseAutonomousMaintenanceScheduleTypeEnumValues() []AutonomousDatabaseAutonomousMaintenanceScheduleTypeEnum {
+	values := make([]AutonomousDatabaseAutonomousMaintenanceScheduleTypeEnum, 0)
+	for _, v := range mappingAutonomousDatabaseAutonomousMaintenanceScheduleType {
 		values = append(values, v)
 	}
 	return values

--- a/database/autonomous_database_summary.go
+++ b/database/autonomous_database_summary.go
@@ -276,6 +276,10 @@ type AutonomousDatabaseSummary struct {
 
 	// The list of OCIDs (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of standby databases located in Autonomous Data Guard remote regions that are associated with the source database. Note that for shared Exadata infrastructure, standby databases located in the same region as the source primary database do not have OCIDs.
 	PeerDbIds []string `mandatory:"false" json:"peerDbIds"`
+
+	// The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+	// follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+	AutonomousMaintenanceScheduleType AutonomousDatabaseSummaryAutonomousMaintenanceScheduleTypeEnum `mandatory:"false" json:"autonomousMaintenanceScheduleType,omitempty"`
 }
 
 func (m AutonomousDatabaseSummary) String() string {
@@ -609,6 +613,29 @@ var mappingAutonomousDatabaseSummaryDataguardRegionType = map[string]AutonomousD
 func GetAutonomousDatabaseSummaryDataguardRegionTypeEnumValues() []AutonomousDatabaseSummaryDataguardRegionTypeEnum {
 	values := make([]AutonomousDatabaseSummaryDataguardRegionTypeEnum, 0)
 	for _, v := range mappingAutonomousDatabaseSummaryDataguardRegionType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// AutonomousDatabaseSummaryAutonomousMaintenanceScheduleTypeEnum Enum with underlying type: string
+type AutonomousDatabaseSummaryAutonomousMaintenanceScheduleTypeEnum string
+
+// Set of constants representing the allowable values for AutonomousDatabaseSummaryAutonomousMaintenanceScheduleTypeEnum
+const (
+	AutonomousDatabaseSummaryAutonomousMaintenanceScheduleTypeEarly   AutonomousDatabaseSummaryAutonomousMaintenanceScheduleTypeEnum = "EARLY"
+	AutonomousDatabaseSummaryAutonomousMaintenanceScheduleTypeRegular AutonomousDatabaseSummaryAutonomousMaintenanceScheduleTypeEnum = "REGULAR"
+)
+
+var mappingAutonomousDatabaseSummaryAutonomousMaintenanceScheduleType = map[string]AutonomousDatabaseSummaryAutonomousMaintenanceScheduleTypeEnum{
+	"EARLY":   AutonomousDatabaseSummaryAutonomousMaintenanceScheduleTypeEarly,
+	"REGULAR": AutonomousDatabaseSummaryAutonomousMaintenanceScheduleTypeRegular,
+}
+
+// GetAutonomousDatabaseSummaryAutonomousMaintenanceScheduleTypeEnumValues Enumerates the set of values for AutonomousDatabaseSummaryAutonomousMaintenanceScheduleTypeEnum
+func GetAutonomousDatabaseSummaryAutonomousMaintenanceScheduleTypeEnumValues() []AutonomousDatabaseSummaryAutonomousMaintenanceScheduleTypeEnum {
+	values := make([]AutonomousDatabaseSummaryAutonomousMaintenanceScheduleTypeEnum, 0)
+	for _, v := range mappingAutonomousDatabaseSummaryAutonomousMaintenanceScheduleType {
 		values = append(values, v)
 	}
 	return values

--- a/database/create_autonomous_database_base.go
+++ b/database/create_autonomous_database_base.go
@@ -158,40 +158,45 @@ type CreateAutonomousDatabaseBase interface {
 
 	// Customer Contacts.
 	GetCustomerContacts() []CustomerContact
+
+	// The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+	// follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+	GetAutonomousMaintenanceScheduleType() CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum
 }
 
 type createautonomousdatabasebase struct {
 	JsonData                                 []byte
-	CompartmentId                            *string                                      `mandatory:"true" json:"compartmentId"`
-	DbName                                   *string                                      `mandatory:"true" json:"dbName"`
-	CpuCoreCount                             *int                                         `mandatory:"false" json:"cpuCoreCount"`
-	OcpuCount                                *float32                                     `mandatory:"false" json:"ocpuCount"`
-	DbWorkload                               CreateAutonomousDatabaseBaseDbWorkloadEnum   `mandatory:"false" json:"dbWorkload,omitempty"`
-	DataStorageSizeInTBs                     *int                                         `mandatory:"false" json:"dataStorageSizeInTBs"`
-	DataStorageSizeInGBs                     *int                                         `mandatory:"false" json:"dataStorageSizeInGBs"`
-	IsFreeTier                               *bool                                        `mandatory:"false" json:"isFreeTier"`
-	KmsKeyId                                 *string                                      `mandatory:"false" json:"kmsKeyId"`
-	VaultId                                  *string                                      `mandatory:"false" json:"vaultId"`
-	AdminPassword                            *string                                      `mandatory:"false" json:"adminPassword"`
-	DisplayName                              *string                                      `mandatory:"false" json:"displayName"`
-	LicenseModel                             CreateAutonomousDatabaseBaseLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
-	IsPreviewVersionWithServiceTermsAccepted *bool                                        `mandatory:"false" json:"isPreviewVersionWithServiceTermsAccepted"`
-	IsAutoScalingEnabled                     *bool                                        `mandatory:"false" json:"isAutoScalingEnabled"`
-	IsDedicated                              *bool                                        `mandatory:"false" json:"isDedicated"`
-	AutonomousContainerDatabaseId            *string                                      `mandatory:"false" json:"autonomousContainerDatabaseId"`
-	IsAccessControlEnabled                   *bool                                        `mandatory:"false" json:"isAccessControlEnabled"`
-	WhitelistedIps                           []string                                     `mandatory:"false" json:"whitelistedIps"`
-	ArePrimaryWhitelistedIpsUsed             *bool                                        `mandatory:"false" json:"arePrimaryWhitelistedIpsUsed"`
-	StandbyWhitelistedIps                    []string                                     `mandatory:"false" json:"standbyWhitelistedIps"`
-	IsDataGuardEnabled                       *bool                                        `mandatory:"false" json:"isDataGuardEnabled"`
-	SubnetId                                 *string                                      `mandatory:"false" json:"subnetId"`
-	NsgIds                                   []string                                     `mandatory:"false" json:"nsgIds"`
-	PrivateEndpointLabel                     *string                                      `mandatory:"false" json:"privateEndpointLabel"`
-	FreeformTags                             map[string]string                            `mandatory:"false" json:"freeformTags"`
-	DefinedTags                              map[string]map[string]interface{}            `mandatory:"false" json:"definedTags"`
-	DbVersion                                *string                                      `mandatory:"false" json:"dbVersion"`
-	CustomerContacts                         []CustomerContact                            `mandatory:"false" json:"customerContacts"`
-	Source                                   string                                       `json:"source"`
+	CompartmentId                            *string                                                           `mandatory:"true" json:"compartmentId"`
+	DbName                                   *string                                                           `mandatory:"true" json:"dbName"`
+	CpuCoreCount                             *int                                                              `mandatory:"false" json:"cpuCoreCount"`
+	OcpuCount                                *float32                                                          `mandatory:"false" json:"ocpuCount"`
+	DbWorkload                               CreateAutonomousDatabaseBaseDbWorkloadEnum                        `mandatory:"false" json:"dbWorkload,omitempty"`
+	DataStorageSizeInTBs                     *int                                                              `mandatory:"false" json:"dataStorageSizeInTBs"`
+	DataStorageSizeInGBs                     *int                                                              `mandatory:"false" json:"dataStorageSizeInGBs"`
+	IsFreeTier                               *bool                                                             `mandatory:"false" json:"isFreeTier"`
+	KmsKeyId                                 *string                                                           `mandatory:"false" json:"kmsKeyId"`
+	VaultId                                  *string                                                           `mandatory:"false" json:"vaultId"`
+	AdminPassword                            *string                                                           `mandatory:"false" json:"adminPassword"`
+	DisplayName                              *string                                                           `mandatory:"false" json:"displayName"`
+	LicenseModel                             CreateAutonomousDatabaseBaseLicenseModelEnum                      `mandatory:"false" json:"licenseModel,omitempty"`
+	IsPreviewVersionWithServiceTermsAccepted *bool                                                             `mandatory:"false" json:"isPreviewVersionWithServiceTermsAccepted"`
+	IsAutoScalingEnabled                     *bool                                                             `mandatory:"false" json:"isAutoScalingEnabled"`
+	IsDedicated                              *bool                                                             `mandatory:"false" json:"isDedicated"`
+	AutonomousContainerDatabaseId            *string                                                           `mandatory:"false" json:"autonomousContainerDatabaseId"`
+	IsAccessControlEnabled                   *bool                                                             `mandatory:"false" json:"isAccessControlEnabled"`
+	WhitelistedIps                           []string                                                          `mandatory:"false" json:"whitelistedIps"`
+	ArePrimaryWhitelistedIpsUsed             *bool                                                             `mandatory:"false" json:"arePrimaryWhitelistedIpsUsed"`
+	StandbyWhitelistedIps                    []string                                                          `mandatory:"false" json:"standbyWhitelistedIps"`
+	IsDataGuardEnabled                       *bool                                                             `mandatory:"false" json:"isDataGuardEnabled"`
+	SubnetId                                 *string                                                           `mandatory:"false" json:"subnetId"`
+	NsgIds                                   []string                                                          `mandatory:"false" json:"nsgIds"`
+	PrivateEndpointLabel                     *string                                                           `mandatory:"false" json:"privateEndpointLabel"`
+	FreeformTags                             map[string]string                                                 `mandatory:"false" json:"freeformTags"`
+	DefinedTags                              map[string]map[string]interface{}                                 `mandatory:"false" json:"definedTags"`
+	DbVersion                                *string                                                           `mandatory:"false" json:"dbVersion"`
+	CustomerContacts                         []CustomerContact                                                 `mandatory:"false" json:"customerContacts"`
+	AutonomousMaintenanceScheduleType        CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum `mandatory:"false" json:"autonomousMaintenanceScheduleType,omitempty"`
+	Source                                   string                                                            `json:"source"`
 }
 
 // UnmarshalJSON unmarshals json
@@ -234,6 +239,7 @@ func (m *createautonomousdatabasebase) UnmarshalJSON(data []byte) error {
 	m.DefinedTags = s.Model.DefinedTags
 	m.DbVersion = s.Model.DbVersion
 	m.CustomerContacts = s.Model.CustomerContacts
+	m.AutonomousMaintenanceScheduleType = s.Model.AutonomousMaintenanceScheduleType
 	m.Source = s.Model.Source
 
 	return err
@@ -422,6 +428,11 @@ func (m createautonomousdatabasebase) GetCustomerContacts() []CustomerContact {
 	return m.CustomerContacts
 }
 
+//GetAutonomousMaintenanceScheduleType returns AutonomousMaintenanceScheduleType
+func (m createautonomousdatabasebase) GetAutonomousMaintenanceScheduleType() CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum {
+	return m.AutonomousMaintenanceScheduleType
+}
+
 func (m createautonomousdatabasebase) String() string {
 	return common.PointerString(m)
 }
@@ -471,6 +482,29 @@ var mappingCreateAutonomousDatabaseBaseLicenseModel = map[string]CreateAutonomou
 func GetCreateAutonomousDatabaseBaseLicenseModelEnumValues() []CreateAutonomousDatabaseBaseLicenseModelEnum {
 	values := make([]CreateAutonomousDatabaseBaseLicenseModelEnum, 0)
 	for _, v := range mappingCreateAutonomousDatabaseBaseLicenseModel {
+		values = append(values, v)
+	}
+	return values
+}
+
+// CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum Enum with underlying type: string
+type CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum string
+
+// Set of constants representing the allowable values for CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum
+const (
+	CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEarly   CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum = "EARLY"
+	CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeRegular CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum = "REGULAR"
+)
+
+var mappingCreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleType = map[string]CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum{
+	"EARLY":   CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEarly,
+	"REGULAR": CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeRegular,
+}
+
+// GetCreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnumValues Enumerates the set of values for CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum
+func GetCreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnumValues() []CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum {
+	values := make([]CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum, 0)
+	for _, v := range mappingCreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleType {
 		values = append(values, v)
 	}
 	return values

--- a/database/create_autonomous_database_clone_details.go
+++ b/database/create_autonomous_database_clone_details.go
@@ -159,6 +159,10 @@ type CreateAutonomousDatabaseCloneDetails struct {
 	// Note that when provisioning an Autonomous Database on dedicated Exadata infrastructure (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm), this attribute must be null because the attribute is already set at the
 	// Autonomous Exadata Infrastructure level. When using shared Exadata infrastructure (https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI), if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
 	LicenseModel CreateAutonomousDatabaseBaseLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
+
+	// The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+	// follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+	AutonomousMaintenanceScheduleType CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum `mandatory:"false" json:"autonomousMaintenanceScheduleType,omitempty"`
 }
 
 //GetCompartmentId returns CompartmentId
@@ -304,6 +308,11 @@ func (m CreateAutonomousDatabaseCloneDetails) GetDbVersion() *string {
 //GetCustomerContacts returns CustomerContacts
 func (m CreateAutonomousDatabaseCloneDetails) GetCustomerContacts() []CustomerContact {
 	return m.CustomerContacts
+}
+
+//GetAutonomousMaintenanceScheduleType returns AutonomousMaintenanceScheduleType
+func (m CreateAutonomousDatabaseCloneDetails) GetAutonomousMaintenanceScheduleType() CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum {
+	return m.AutonomousMaintenanceScheduleType
 }
 
 func (m CreateAutonomousDatabaseCloneDetails) String() string {

--- a/database/create_autonomous_database_details.go
+++ b/database/create_autonomous_database_details.go
@@ -153,6 +153,10 @@ type CreateAutonomousDatabaseDetails struct {
 	// Note that when provisioning an Autonomous Database on dedicated Exadata infrastructure (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm), this attribute must be null because the attribute is already set at the
 	// Autonomous Exadata Infrastructure level. When using shared Exadata infrastructure (https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI), if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
 	LicenseModel CreateAutonomousDatabaseBaseLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
+
+	// The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+	// follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+	AutonomousMaintenanceScheduleType CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum `mandatory:"false" json:"autonomousMaintenanceScheduleType,omitempty"`
 }
 
 //GetCompartmentId returns CompartmentId
@@ -298,6 +302,11 @@ func (m CreateAutonomousDatabaseDetails) GetDbVersion() *string {
 //GetCustomerContacts returns CustomerContacts
 func (m CreateAutonomousDatabaseDetails) GetCustomerContacts() []CustomerContact {
 	return m.CustomerContacts
+}
+
+//GetAutonomousMaintenanceScheduleType returns AutonomousMaintenanceScheduleType
+func (m CreateAutonomousDatabaseDetails) GetAutonomousMaintenanceScheduleType() CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum {
+	return m.AutonomousMaintenanceScheduleType
 }
 
 func (m CreateAutonomousDatabaseDetails) String() string {

--- a/database/create_autonomous_database_from_backup_details.go
+++ b/database/create_autonomous_database_from_backup_details.go
@@ -159,6 +159,10 @@ type CreateAutonomousDatabaseFromBackupDetails struct {
 	// Note that when provisioning an Autonomous Database on dedicated Exadata infrastructure (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm), this attribute must be null because the attribute is already set at the
 	// Autonomous Exadata Infrastructure level. When using shared Exadata infrastructure (https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI), if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
 	LicenseModel CreateAutonomousDatabaseBaseLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
+
+	// The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+	// follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+	AutonomousMaintenanceScheduleType CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum `mandatory:"false" json:"autonomousMaintenanceScheduleType,omitempty"`
 }
 
 //GetCompartmentId returns CompartmentId
@@ -304,6 +308,11 @@ func (m CreateAutonomousDatabaseFromBackupDetails) GetDbVersion() *string {
 //GetCustomerContacts returns CustomerContacts
 func (m CreateAutonomousDatabaseFromBackupDetails) GetCustomerContacts() []CustomerContact {
 	return m.CustomerContacts
+}
+
+//GetAutonomousMaintenanceScheduleType returns AutonomousMaintenanceScheduleType
+func (m CreateAutonomousDatabaseFromBackupDetails) GetAutonomousMaintenanceScheduleType() CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum {
+	return m.AutonomousMaintenanceScheduleType
 }
 
 func (m CreateAutonomousDatabaseFromBackupDetails) String() string {

--- a/database/create_autonomous_database_from_backup_timestamp_details.go
+++ b/database/create_autonomous_database_from_backup_timestamp_details.go
@@ -162,6 +162,10 @@ type CreateAutonomousDatabaseFromBackupTimestampDetails struct {
 	// Note that when provisioning an Autonomous Database on dedicated Exadata infrastructure (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm), this attribute must be null because the attribute is already set at the
 	// Autonomous Exadata Infrastructure level. When using shared Exadata infrastructure (https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI), if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
 	LicenseModel CreateAutonomousDatabaseBaseLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
+
+	// The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+	// follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+	AutonomousMaintenanceScheduleType CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum `mandatory:"false" json:"autonomousMaintenanceScheduleType,omitempty"`
 }
 
 //GetCompartmentId returns CompartmentId
@@ -307,6 +311,11 @@ func (m CreateAutonomousDatabaseFromBackupTimestampDetails) GetDbVersion() *stri
 //GetCustomerContacts returns CustomerContacts
 func (m CreateAutonomousDatabaseFromBackupTimestampDetails) GetCustomerContacts() []CustomerContact {
 	return m.CustomerContacts
+}
+
+//GetAutonomousMaintenanceScheduleType returns AutonomousMaintenanceScheduleType
+func (m CreateAutonomousDatabaseFromBackupTimestampDetails) GetAutonomousMaintenanceScheduleType() CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum {
+	return m.AutonomousMaintenanceScheduleType
 }
 
 func (m CreateAutonomousDatabaseFromBackupTimestampDetails) String() string {

--- a/database/create_cross_region_autonomous_database_data_guard_details.go
+++ b/database/create_cross_region_autonomous_database_data_guard_details.go
@@ -156,6 +156,10 @@ type CreateCrossRegionAutonomousDatabaseDataGuardDetails struct {
 	// Note that when provisioning an Autonomous Database on dedicated Exadata infrastructure (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm), this attribute must be null because the attribute is already set at the
 	// Autonomous Exadata Infrastructure level. When using shared Exadata infrastructure (https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI), if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
 	LicenseModel CreateAutonomousDatabaseBaseLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
+
+	// The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+	// follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+	AutonomousMaintenanceScheduleType CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum `mandatory:"false" json:"autonomousMaintenanceScheduleType,omitempty"`
 }
 
 //GetCompartmentId returns CompartmentId
@@ -301,6 +305,11 @@ func (m CreateCrossRegionAutonomousDatabaseDataGuardDetails) GetDbVersion() *str
 //GetCustomerContacts returns CustomerContacts
 func (m CreateCrossRegionAutonomousDatabaseDataGuardDetails) GetCustomerContacts() []CustomerContact {
 	return m.CustomerContacts
+}
+
+//GetAutonomousMaintenanceScheduleType returns AutonomousMaintenanceScheduleType
+func (m CreateCrossRegionAutonomousDatabaseDataGuardDetails) GetAutonomousMaintenanceScheduleType() CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum {
+	return m.AutonomousMaintenanceScheduleType
 }
 
 func (m CreateCrossRegionAutonomousDatabaseDataGuardDetails) String() string {

--- a/database/create_refreshable_autonomous_database_clone_details.go
+++ b/database/create_refreshable_autonomous_database_clone_details.go
@@ -159,6 +159,10 @@ type CreateRefreshableAutonomousDatabaseCloneDetails struct {
 	// Note that when provisioning an Autonomous Database on dedicated Exadata infrastructure (https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm), this attribute must be null because the attribute is already set at the
 	// Autonomous Exadata Infrastructure level. When using shared Exadata infrastructure (https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI), if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
 	LicenseModel CreateAutonomousDatabaseBaseLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
+
+	// The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+	// follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+	AutonomousMaintenanceScheduleType CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum `mandatory:"false" json:"autonomousMaintenanceScheduleType,omitempty"`
 }
 
 //GetCompartmentId returns CompartmentId
@@ -304,6 +308,11 @@ func (m CreateRefreshableAutonomousDatabaseCloneDetails) GetDbVersion() *string 
 //GetCustomerContacts returns CustomerContacts
 func (m CreateRefreshableAutonomousDatabaseCloneDetails) GetCustomerContacts() []CustomerContact {
 	return m.CustomerContacts
+}
+
+//GetAutonomousMaintenanceScheduleType returns AutonomousMaintenanceScheduleType
+func (m CreateRefreshableAutonomousDatabaseCloneDetails) GetAutonomousMaintenanceScheduleType() CreateAutonomousDatabaseBaseAutonomousMaintenanceScheduleTypeEnum {
+	return m.AutonomousMaintenanceScheduleType
 }
 
 func (m CreateRefreshableAutonomousDatabaseCloneDetails) String() string {

--- a/database/db_node.go
+++ b/database/db_node.go
@@ -34,6 +34,22 @@ type DbNode struct {
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup VNIC.
 	BackupVnicId *string `mandatory:"false" json:"backupVnicId"`
 
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the host IP address associated with the database node.
+	// **Note:** Applies only to Exadata Cloud Service.
+	HostIpId *string `mandatory:"false" json:"hostIpId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup IP address associated with the database node.
+	// **Note:** Applies only to Exadata Cloud Service.
+	BackupIpId *string `mandatory:"false" json:"backupIpId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the second VNIC.
+	// **Note:** Applies only to Exadata Cloud Service.
+	Vnic2Id *string `mandatory:"false" json:"vnic2Id"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the second backup VNIC.
+	// **Note:** Applies only to Exadata Cloud Service.
+	BackupVnic2Id *string `mandatory:"false" json:"backupVnic2Id"`
+
 	// The host name for the database node.
 	Hostname *string `mandatory:"false" json:"hostname"`
 

--- a/database/db_node_summary.go
+++ b/database/db_node_summary.go
@@ -36,6 +36,22 @@ type DbNodeSummary struct {
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup VNIC.
 	BackupVnicId *string `mandatory:"false" json:"backupVnicId"`
 
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the host IP address associated with the database node.
+	// **Note:** Applies only to Exadata Cloud Service.
+	HostIpId *string `mandatory:"false" json:"hostIpId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup IP address associated with the database node.
+	// **Note:** Applies only to Exadata Cloud Service.
+	BackupIpId *string `mandatory:"false" json:"backupIpId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the second VNIC.
+	// **Note:** Applies only to Exadata Cloud Service.
+	Vnic2Id *string `mandatory:"false" json:"vnic2Id"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the second backup VNIC.
+	// **Note:** Applies only to Exadata Cloud Service.
+	BackupVnic2Id *string `mandatory:"false" json:"backupVnic2Id"`
+
 	// The host name for the database node.
 	Hostname *string `mandatory:"false" json:"hostname"`
 

--- a/dataflow/application.go
+++ b/dataflow/application.go
@@ -105,6 +105,9 @@ type Application struct {
 	// See https://docs.cloud.oracle.com/iaas/Content/API/SDKDocs/hdfsconnector.htm#uriformat.
 	LogsBucketUri *string `mandatory:"false" json:"logsBucketUri"`
 
+	// The OCID of OCI Hive Metastore.
+	MetastoreId *string `mandatory:"false" json:"metastoreId"`
+
 	// The username of the user who created the resource.  If the username of the owner does not exist,
 	// `null` will be returned and the caller should refer to the ownerPrincipalId value instead.
 	OwnerUserName *string `mandatory:"false" json:"ownerUserName"`

--- a/dataflow/create_application_details.go
+++ b/dataflow/create_application_details.go
@@ -88,6 +88,9 @@ type CreateApplicationDetails struct {
 	// See https://docs.cloud.oracle.com/iaas/Content/API/SDKDocs/hdfsconnector.htm#uriformat.
 	LogsBucketUri *string `mandatory:"false" json:"logsBucketUri"`
 
+	// The OCID of OCI Hive Metastore.
+	MetastoreId *string `mandatory:"false" json:"metastoreId"`
+
 	// An array of name/value pairs used to fill placeholders found in properties like
 	// `Application.arguments`.  The name must be a string of one or more word characters
 	// (a-z, A-Z, 0-9, _).  The value can be a string of 0 or more characters of any kind.

--- a/dataflow/create_run_details.go
+++ b/dataflow/create_run_details.go
@@ -26,6 +26,7 @@ import (
 //   - executorShape
 //   - freeformTags
 //   - logsBucketUri
+//   - metastoreId
 //   - numExecutors
 //   - parameters
 //   - sparkVersion
@@ -100,6 +101,9 @@ type CreateRunDetails struct {
 	// An Oracle Cloud Infrastructure URI of the bucket where the Spark job logs are to be uploaded.
 	// See https://docs.cloud.oracle.com/iaas/Content/API/SDKDocs/hdfsconnector.htm#uriformat.
 	LogsBucketUri *string `mandatory:"false" json:"logsBucketUri"`
+
+	// The OCID of OCI Hive Metastore.
+	MetastoreId *string `mandatory:"false" json:"metastoreId"`
 
 	// The number of executor VMs requested.
 	NumExecutors *int `mandatory:"false" json:"numExecutors"`

--- a/dataflow/run.go
+++ b/dataflow/run.go
@@ -111,6 +111,9 @@ type Run struct {
 	// See https://docs.cloud.oracle.com/iaas/Content/API/SDKDocs/hdfsconnector.htm#uriformat.
 	LogsBucketUri *string `mandatory:"false" json:"logsBucketUri"`
 
+	// The OCID of OCI Hive Metastore.
+	MetastoreId *string `mandatory:"false" json:"metastoreId"`
+
 	// Unique Oracle assigned identifier for the request.
 	// If you need to contact Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `mandatory:"false" json:"opcRequestId"`

--- a/dataflow/update_application_details.go
+++ b/dataflow/update_application_details.go
@@ -82,6 +82,9 @@ type UpdateApplicationDetails struct {
 	// See https://docs.cloud.oracle.com/iaas/Content/API/SDKDocs/hdfsconnector.htm#uriformat.
 	LogsBucketUri *string `mandatory:"false" json:"logsBucketUri"`
 
+	// The OCID of OCI Hive Metastore.
+	MetastoreId *string `mandatory:"false" json:"metastoreId"`
+
 	// The number of executor VMs requested.
 	NumExecutors *int `mandatory:"false" json:"numExecutors"`
 

--- a/datascience/create_model_artifact_request_response.go
+++ b/datascience/create_model_artifact_request_response.go
@@ -32,7 +32,13 @@ type CreateModelArtifactRequest struct {
 	// A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again. Retry tokens expire after 24 hours, but can be invalidated before then due to conflicting operations. For example, if a resource has been deleted and purged from the system, then a retry of the original creation request might be rejected.
 	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
 
-	// The content disposition of the body.
+	// This header allows you to specify a filename during upload. This file name is used to dispose of the file contents
+	// while downloading the file. If this optional field is not populated in the request, then the OCID of the model is used for the file
+	// name when downloading.
+	// Example: `{"Content-Disposition": "attachment"
+	//            "filename"="model.tar.gz"
+	//            "Content-Length": "2347"
+	//            "Content-Type": "application/gzip"}`
 	ContentDisposition *string `mandatory:"false" contributesTo:"header" name:"content-disposition"`
 
 	// Metadata about the request. This information will not be transmitted to the service, but

--- a/datascience/create_model_details.go
+++ b/datascience/create_model_details.go
@@ -36,6 +36,18 @@ type CreateModelDetails struct {
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace. See Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// An array of custom metadata details for the model.
+	CustomMetadataList []Metadata `mandatory:"false" json:"customMetadataList"`
+
+	// An array of defined metadata details for the model.
+	DefinedMetadataList []Metadata `mandatory:"false" json:"definedMetadataList"`
+
+	// Input schema file content in String format
+	InputSchema *string `mandatory:"false" json:"inputSchema"`
+
+	// Output schema file content in String format
+	OutputSchema *string `mandatory:"false" json:"outputSchema"`
 }
 
 func (m CreateModelDetails) String() string {

--- a/datascience/create_model_provenance_details.go
+++ b/datascience/create_model_provenance_details.go
@@ -30,6 +30,9 @@ type CreateModelProvenanceDetails struct {
 
 	// For model reproducibility purposes. Path to the python script or notebook in which the model was trained."
 	TrainingScript *string `mandatory:"false" json:"trainingScript"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a training session(Job or NotebookSession) in which the model was trained. It is used for model reproducibility purposes.
+	TrainingId *string `mandatory:"false" json:"trainingId"`
 }
 
 func (m CreateModelProvenanceDetails) String() string {

--- a/datascience/datascience_client.go
+++ b/datascience/datascience_client.go
@@ -2283,10 +2283,10 @@ func (client DataScienceClient) updateModel(ctx context.Context, request common.
 	return response, err
 }
 
-// UpdateModelDeployment Updates the properties of a model deployment. Some of the properties of `modelDeploymentConfigurationDetails` or `CategoryLogDetails` can also be updated with zero down time when
-// the model deployment's lifecycle state is ACTIVE i.e `instanceShapeName` can be updated along with `modelId`, similarly `logId` can be updated along with `logGroupId`. But
-// `instanceShapeName` or `modelId` cannot be updated along with `logId` or `logGroupId`. All of the fields can be updated when the deployment is in the INACTIVE lifecycle state.
-// Changes will take effect the next time the model deployment is activated.
+// UpdateModelDeployment Updates the properties of a model deployment. Some of the properties of `modelDeploymentConfigurationDetails` or `CategoryLogDetails` can also be updated with zero down time
+// when the model deployment’s lifecycle state is ACTIVE or NEEDS_ATTENTION i.e `instanceShapeName`, `instanceCount` and `modelId`, separately `loadBalancerShape` or `CategoryLogDetails`
+// can also be updated independently. All of the fields can be updated when the deployment is in the INACTIVE lifecycle state. Changes will take effect the next time the model
+// deployment is activated.
 //
 // See also
 //

--- a/datascience/metadata.go
+++ b/datascience/metadata.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Data Science API
+//
+// Use the Data Science APIs to organize your data science work, access data and computing resources, and build, train, deploy, and manage models on Oracle Cloud.
+//
+
+package datascience
+
+import (
+	"github.com/oracle/oci-go-sdk/v45/common"
+)
+
+// Metadata Defines properties of each model metadata.
+type Metadata struct {
+
+	// Key of the model Metadata. The key can either be user defined or OCI defined.
+	//    List of OCI defined keys:
+	//          * useCaseType
+	//          * libraryName
+	//          * libraryVersion
+	//          * estimatorClass
+	//          * hyperParameters
+	//          * testartifactresults
+	Key *string `mandatory:"false" json:"key"`
+
+	// Allowed values for useCaseType:
+	//              binary_classification, regression, multinomial_classification, clustering, recommender,
+	//              dimensionality_reduction/representation, time_series_forecasting, anomaly_detection,
+	//              topic_modeling, ner, sentiment_analysis, image_classification, object_localization, other
+	// Allowed values for libraryName:
+	//              scikit-learn, xgboost, tensorflow, pytorch, mxnet, keras, lightGBM, pymc3, pyOD, spacy,
+	//              prophet, sktime, statsmodels, cuml, oracle_automl, h2o, transformers, nltk, emcee, pystan,
+	//              bert, gensim, flair, word2vec, ensemble, other
+	Value *string `mandatory:"false" json:"value"`
+
+	// Description of model metadata
+	Description *string `mandatory:"false" json:"description"`
+
+	// Category of model metadata which should be null for defined metadata.For custom metadata is should be one of the following values "Performance,Training Profile,Training and Validation Datasets,Training Environment,other".
+	Category *string `mandatory:"false" json:"category"`
+}
+
+func (m Metadata) String() string {
+	return common.PointerString(m)
+}

--- a/datascience/model.go
+++ b/datascience/model.go
@@ -48,6 +48,18 @@ type Model struct {
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace. See Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// An array of custom metadata details for the model.
+	CustomMetadataList []Metadata `mandatory:"false" json:"customMetadataList"`
+
+	// An array of defined metadata details for the model.
+	DefinedMetadataList []Metadata `mandatory:"false" json:"definedMetadataList"`
+
+	// Input schema file content in String format
+	InputSchema *string `mandatory:"false" json:"inputSchema"`
+
+	// Output schema file content in String format
+	OutputSchema *string `mandatory:"false" json:"outputSchema"`
 }
 
 func (m Model) String() string {

--- a/datascience/model_deployment.go
+++ b/datascience/model_deployment.go
@@ -14,7 +14,7 @@ import (
 	"github.com/oracle/oci-go-sdk/v45/common"
 )
 
-// ModelDeployment Model deployments are interactive coding environments for data scientists.
+// ModelDeployment Model deployments are used by data scientists to perform predictions from the model hosted on an HTTP server.
 type ModelDeployment struct {
 
 	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model deployment.

--- a/datascience/model_provenance.go
+++ b/datascience/model_provenance.go
@@ -30,6 +30,9 @@ type ModelProvenance struct {
 
 	// For model reproducibility purposes. Path to the python script or notebook in which the model was trained."
 	TrainingScript *string `mandatory:"false" json:"trainingScript"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a training session(Job or NotebookSession) in which the model was trained. It is used for model reproducibility purposes.
+	TrainingId *string `mandatory:"false" json:"trainingId"`
 }
 
 func (m ModelProvenance) String() string {

--- a/datascience/update_model_deployment_request_response.go
+++ b/datascience/update_model_deployment_request_response.go
@@ -19,10 +19,10 @@ type UpdateModelDeploymentRequest struct {
 	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model deployment.
 	ModelDeploymentId *string `mandatory:"true" contributesTo:"path" name:"modelDeploymentId"`
 
-	// Details for updating a model deployment. Some of the properties of `modelDeploymentConfigurationDetails` or `CategoryLogDetails` can also be updated with zero down time when
-	// the model deployment's lifecycle state is ACTIVE i.e `instanceShapeName` can be updated along with `modelId`, similarly `logId` can be updated along with `logGroupId`. But
-	// `instanceShapeName` or `modelId` cannot be updated along with `logId` or `logGroupId`. All of the fields can be updated when the deployment is in the INACTIVE lifecycle state.
-	// Changes will take effect the next time the model deployment is activated.
+	// Details for updating a model deployment. Some of the properties of `modelDeploymentConfigurationDetails` or `CategoryLogDetails` can also be updated with zero down time
+	// when the model deployment’s lifecycle state is ACTIVE or NEEDS_ATTENTION i.e `instanceShapeName`, `instanceCount` and `modelId`, separately `loadBalancerShape` or
+	// `CategoryLogDetails` can also be updated independently. All of the fields can be updated when the deployment is in the INACTIVE lifecycle state. Changes will take effect the next
+	// time the model deployment is activated.
 	UpdateModelDeploymentDetails `contributesTo:"body"`
 
 	// For optimistic concurrency control. In the PUT or DELETE call

--- a/datascience/update_model_details.go
+++ b/datascience/update_model_details.go
@@ -30,6 +30,12 @@ type UpdateModelDetails struct {
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace. See Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// An array of custom metadata details for the model.
+	CustomMetadataList []Metadata `mandatory:"false" json:"customMetadataList"`
+
+	// An array of defined metadata details for the model.
+	DefinedMetadataList []Metadata `mandatory:"false" json:"definedMetadataList"`
 }
 
 func (m UpdateModelDetails) String() string {

--- a/datascience/update_model_provenance_details.go
+++ b/datascience/update_model_provenance_details.go
@@ -30,6 +30,9 @@ type UpdateModelProvenanceDetails struct {
 
 	// For model reproducibility purposes. Path to the python script or notebook in which the model was trained."
 	TrainingScript *string `mandatory:"false" json:"trainingScript"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a training session(Job or NotebookSession) in which the model was trained. It is used for model reproducibility purposes.
+	TrainingId *string `mandatory:"false" json:"trainingId"`
 }
 
 func (m UpdateModelProvenanceDetails) String() string {

--- a/mysql/change_backup_compartment_details.go
+++ b/mysql/change_backup_compartment_details.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// MySQL Database Service API
+//
+// The API for the MySQL Database Service
+//
+
+package mysql
+
+import (
+	"github.com/oracle/oci-go-sdk/v45/common"
+)
+
+// ChangeBackupCompartmentDetails OCID of the target compartment for DB System Backup change compartment request.
+type ChangeBackupCompartmentDetails struct {
+
+	// OCID of the target compartment.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+}
+
+func (m ChangeBackupCompartmentDetails) String() string {
+	return common.PointerString(m)
+}

--- a/mysql/change_backup_compartment_request_response.go
+++ b/mysql/change_backup_compartment_request_response.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package mysql
+
+import (
+	"github.com/oracle/oci-go-sdk/v45/common"
+	"net/http"
+)
+
+// ChangeBackupCompartmentRequest wrapper for the ChangeBackupCompartment operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/mysql/ChangeBackupCompartment.go.html to see an example of how to use ChangeBackupCompartmentRequest.
+type ChangeBackupCompartmentRequest struct {
+
+	// The OCID of the Backup
+	BackupId *string `mandatory:"true" contributesTo:"path" name:"backupId"`
+
+	// Target compartment for a DB System Backup.
+	ChangeBackupCompartmentDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a
+	// resource, set the `If-Match` header to the value of the etag from a
+	// previous GET or POST response for that resource. The resource will be
+	// updated or deleted only if the etag you provide matches the resource's
+	// current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Customer-defined unique identifier for the request. If you need to
+	// contact Oracle about a specific request, please provide the request
+	// ID that you supplied in this header with the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token that uniquely identifies a request so it can be retried in case
+	// of a timeout or server error without risk of executing that same action
+	// again. Retry tokens expire after 24 hours, but can be invalidated before
+	// then due to conflicting operations (for example, if a resource has been
+	// deleted and purged from the system, then a retry of the original
+	// creation request may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ChangeBackupCompartmentRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ChangeBackupCompartmentRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ChangeBackupCompartmentRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ChangeBackupCompartmentRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ChangeBackupCompartmentResponse wrapper for the ChangeBackupCompartment operation
+type ChangeBackupCompartmentResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+}
+
+func (response ChangeBackupCompartmentResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ChangeBackupCompartmentResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/mysql/mysql_dbbackups_client.go
+++ b/mysql/mysql_dbbackups_client.go
@@ -79,6 +79,67 @@ func (client *DbBackupsClient) ConfigurationProvider() *common.ConfigurationProv
 	return client.config
 }
 
+// ChangeBackupCompartment Moves a DB System Backup into a different compartment.
+// When provided, If-Match is checked against ETag values of the Backup.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/mysql/ChangeBackupCompartment.go.html to see an example of how to use ChangeBackupCompartment API.
+func (client DbBackupsClient) ChangeBackupCompartment(ctx context.Context, request ChangeBackupCompartmentRequest) (response ChangeBackupCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.changeBackupCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ChangeBackupCompartmentResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ChangeBackupCompartmentResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeBackupCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeBackupCompartmentResponse")
+	}
+	return
+}
+
+// changeBackupCompartment implements the OCIOperation interface (enables retrying operations)
+func (client DbBackupsClient) changeBackupCompartment(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/backups/{backupId}/actions/changeCompartment", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeBackupCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // CreateBackup Create a backup of a DB System.
 //
 // See also


### PR DESCRIPTION
### Added

- Support for manually copying volume group backups across regions in the Block Volume service

- Support for work requests for the copy volume backup and copy boot volume backup operations in the Block Volume service

- Support for specifying external Hive metastores during application creation in the Data Flow service

- Support for changing the compartment of a backup in the MySQL Database service

- Support for model catalog features including provenance, metadata, schemas, and artifact introspection in the Data Science service

- Support for Exadata system network bonding in the Database service

- Support for creating autonomous databases with early patching enabled in the Database service