### PR TITLE
Releasing version 46.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## 46.1.0 - 2021-08-24
+### Added
+- Support for generating recommended VM cluster networks in the Database service
+- Support for creating VM cluster networks with a specified listener port in the Database service
+
 ## 46.0.0 - 2021-08-17
 ### Added
 - Support for getting management agent hosts which are eligible to create Operations Insights host resources on, in the Operations Insights service

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ TARGETS_RELEASE= $(patsubst %,release-%, $(TARGETS))
 GOLINT=$(GOPATH)/bin/golint
 LINT_FLAGS=-min_confidence 0.9 -set_exit_status
 
+AUTOTEST_DIR = autotest
+
 # directories under gen targets which contains hand writen code
 EXCLUDED_CLEAN_DIRECTORIES = objectstorage/transfer*
 
@@ -24,7 +26,12 @@ build: lint $(TARGETS_BUILD)
 
 test: build $(TARGETS_TEST)
 
-test-integ: build $(TARGETS_INTEG_TEST)
+test-all: build build-autotest test test-integ
+
+test-integ: 
+	@if [ -d $(TARGETS_WITH_INTEG_TESTS) ]; then\
+		make build $(TARGETS_INTEG_TEST);\
+	fi
 
 lint: $(TARGETS_LINT)
 
@@ -77,3 +84,8 @@ gen-version:
 	go generate -x
 
 release: gen-version build pre-doc
+
+build-autotest:
+	@if [ -d $(AUTOTEST_DIR) ]; then\
+		(cd $(AUTOTEST_DIR) && gofmt -s -w . && go test -c);\
+	fi

--- a/common/version.go
+++ b/common/version.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	major = "46"
-	minor = "0"
+	minor = "1"
 	patch = "0"
 	tag   = ""
 )

--- a/database/generate_recommended_network_details.go
+++ b/database/generate_recommended_network_details.go
@@ -25,6 +25,12 @@ type GenerateRecommendedNetworkDetails struct {
 	// List of parameters for generation of the client and backup networks.
 	Networks []InfoForNetworkGenDetails `mandatory:"true" json:"networks"`
 
+	// The SCAN TCPIP port. Default is 1521.
+	ScanListenerPortTcp *int `mandatory:"false" json:"scanListenerPortTcp"`
+
+	// The SCAN TCPIP SSL port. Default is 2484.
+	ScanListenerPortTcpSsl *int `mandatory:"false" json:"scanListenerPortTcpSsl"`
+
 	// The list of DNS server IP addresses. Maximum of 3 allowed.
 	Dns []string `mandatory:"false" json:"dns"`
 

--- a/database/scan_details.go
+++ b/database/scan_details.go
@@ -24,6 +24,12 @@ type ScanDetails struct {
 
 	// The list of SCAN IP addresses. Three addresses should be provided.
 	Ips []string `mandatory:"true" json:"ips"`
+
+	// The SCAN TCPIP port. Default is 1521.
+	ScanListenerPortTcp *int `mandatory:"false" json:"scanListenerPortTcp"`
+
+	// The SCAN TCPIP SSL port. Default is 2484.
+	ScanListenerPortTcpSsl *int `mandatory:"false" json:"scanListenerPortTcpSsl"`
 }
 
 func (m ScanDetails) String() string {


### PR DESCRIPTION
### Added

- Support for generating recommended VM cluster networks in the Database service

- Support for creating VM cluster networks with a specified listener port in the Database service