### PR TITLE
Releasing version 49.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## 49.2.0 - 2021-10-19
+### Added
+- Support for creating database systems from backups with database software images in the Database service
+- Support for optionally providing a SID prefix during Exadata database creation in the Database service
+- Support for node subsetting on VM clusters in the Database service
+- Support for non-CDB to PDB conversion in the Database service
+- Support for default homepages, unprocessed data buckets, and parsing geostats in the Logging Analytics service
+- Support for creating instance principal delegation token in a specific region
+- Support for circuit breaker feature
+
 ## 49.1.0 - 2021-10-12
 ### Added
 - Support for the Data Labeling Service

--- a/README.md
+++ b/README.md
@@ -21,17 +21,19 @@ go get -u github.com/oracle/oci-go-sdk
 ```
 If you are using Go modules, you can install by running the following command within a folder containing a `go.mod` file:
 ```
-go get -d github.com/oracle/oci-go-sdk/@latest
+go get -d github.com/oracle/oci-go-sdk/v49@latest
 ```
-Alternatively, you can install a specific version(supported from `v25.0.0` on):
+The latest major version (for example `v49`) can be identified on the [Github releases page](https://github.com/oracle/oci-go-sdk/releases).
+
+Alternatively, you can install a specific version (supported from `v25.0.0` on):
 ```
-go get -d github.com/oracle/oci-go-sdk/@v41.0.0
+go get -d github.com/oracle/oci-go-sdk/v49@v49.1.0
 ```
 Run `go mod tidy`
 
 In your project, you also need to ensure the import paths contain the correct major-version:
 ```
-import "github.com/oracle/oci-go-sdk/v41/common"  // or whatever major version you're using
+import "github.com/oracle/oci-go-sdk/v49/common"  // or whatever major version you're using
 ```
 
 ## Working with the Go SDK
@@ -47,8 +49,8 @@ Once a config file has been setup, call `common.DefaultConfigProvider()` functio
  ```go
  // Import necessary packages
  import (
-	"github.com/oracle/oci-go-sdk/v41/common"
-	"github.com/oracle/oci-go-sdk/v41/identity" // Identity or any other service you wish to make requests to
+	"github.com/oracle/oci-go-sdk/v49/common"
+	"github.com/oracle/oci-go-sdk/v49/identity" // Identity or any other service you wish to make requests to
 )
  
  //...
@@ -103,9 +105,14 @@ if err != nil {
 fmt.Println("Group's name is:", response.Name)
 ```
 
-- *Expect header*: By default, "PUT/POST" request would add Expect 100-continue header, if it is not expected, please explicitly set the env var:
+- *Expect header*: Some services specified "PUT/POST" requests add Expect 100-continue header by default, if it is not expected, please explicitly set the env var:
 ```sh
 export OCI_GOSDK_USING_EXPECT_HEADER=FALSE
+```
+
+- *Circuit Breaker*: By default, circuit breaker feature is enabled, if it is not expected, please explicitly set the env var:
+```sh
+export OCI_SDK_DEFAULT_CIRCUITBREAKER_ENABLED=FALSE
 ```
 
 ## Organization of the SDK

--- a/aianomalydetection/aianomalydetection_anomalydetection_client.go
+++ b/aianomalydetection/aianomalydetection_anomalydetection_client.go
@@ -52,6 +52,9 @@ func NewAnomalyDetectionClientWithOboToken(configProvider common.ConfigurationPr
 }
 
 func newAnomalyDetectionClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client AnomalyDetectionClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = AnomalyDetectionClient{BaseClient: baseClient}
 	client.BasePath = "20210101"
 	err = client.setConfigurationProvider(configProvider)

--- a/ailanguage/ailanguage_aiservicelanguage_client.go
+++ b/ailanguage/ailanguage_aiservicelanguage_client.go
@@ -52,6 +52,9 @@ func NewAIServiceLanguageClientWithOboToken(configProvider common.ConfigurationP
 }
 
 func newAIServiceLanguageClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client AIServiceLanguageClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = AIServiceLanguageClient{BaseClient: baseClient}
 	client.BasePath = "20210101"
 	err = client.setConfigurationProvider(configProvider)

--- a/analytics/analytics_client.go
+++ b/analytics/analytics_client.go
@@ -50,6 +50,9 @@ func NewAnalyticsClientWithOboToken(configProvider common.ConfigurationProvider,
 }
 
 func newAnalyticsClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client AnalyticsClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = AnalyticsClient{BaseClient: baseClient}
 	client.BasePath = "20190331"
 	err = client.setConfigurationProvider(configProvider)

--- a/announcementsservice/announcementsservice_announcement_client.go
+++ b/announcementsservice/announcementsservice_announcement_client.go
@@ -50,6 +50,9 @@ func NewAnnouncementClientWithOboToken(configProvider common.ConfigurationProvid
 }
 
 func newAnnouncementClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client AnnouncementClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = AnnouncementClient{BaseClient: baseClient}
 	client.BasePath = "20180904"
 	err = client.setConfigurationProvider(configProvider)

--- a/announcementsservice/announcementsservice_announcementspreferences_client.go
+++ b/announcementsservice/announcementsservice_announcementspreferences_client.go
@@ -50,6 +50,9 @@ func NewAnnouncementsPreferencesClientWithOboToken(configProvider common.Configu
 }
 
 func newAnnouncementsPreferencesClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client AnnouncementsPreferencesClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = AnnouncementsPreferencesClient{BaseClient: baseClient}
 	client.BasePath = "20180904"
 	err = client.setConfigurationProvider(configProvider)

--- a/apigateway/apigateway_client.go
+++ b/apigateway/apigateway_client.go
@@ -52,6 +52,9 @@ func NewApiGatewayClientWithOboToken(configProvider common.ConfigurationProvider
 }
 
 func newApiGatewayClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ApiGatewayClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = ApiGatewayClient{BaseClient: baseClient}
 	client.BasePath = "20190501"
 	err = client.setConfigurationProvider(configProvider)

--- a/apigateway/apigateway_deployment_client.go
+++ b/apigateway/apigateway_deployment_client.go
@@ -52,6 +52,9 @@ func NewDeploymentClientWithOboToken(configProvider common.ConfigurationProvider
 }
 
 func newDeploymentClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client DeploymentClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = DeploymentClient{BaseClient: baseClient}
 	client.BasePath = "20190501"
 	err = client.setConfigurationProvider(configProvider)

--- a/apigateway/apigateway_gateway_client.go
+++ b/apigateway/apigateway_gateway_client.go
@@ -52,6 +52,9 @@ func NewGatewayClientWithOboToken(configProvider common.ConfigurationProvider, o
 }
 
 func newGatewayClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client GatewayClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = GatewayClient{BaseClient: baseClient}
 	client.BasePath = "20190501"
 	err = client.setConfigurationProvider(configProvider)

--- a/apigateway/apigateway_workrequests_client.go
+++ b/apigateway/apigateway_workrequests_client.go
@@ -52,6 +52,9 @@ func NewWorkRequestsClientWithOboToken(configProvider common.ConfigurationProvid
 }
 
 func newWorkRequestsClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client WorkRequestsClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = WorkRequestsClient{BaseClient: baseClient}
 	client.BasePath = "20190501"
 	err = client.setConfigurationProvider(configProvider)

--- a/apmconfig/apmconfig_config_client.go
+++ b/apmconfig/apmconfig_config_client.go
@@ -50,6 +50,9 @@ func NewConfigClientWithOboToken(configProvider common.ConfigurationProvider, ob
 }
 
 func newConfigClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ConfigClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = ConfigClient{BaseClient: baseClient}
 	client.BasePath = "20210201"
 	err = client.setConfigurationProvider(configProvider)

--- a/apmcontrolplane/apmcontrolplane_apmdomain_client.go
+++ b/apmcontrolplane/apmcontrolplane_apmdomain_client.go
@@ -51,6 +51,9 @@ func NewApmDomainClientWithOboToken(configProvider common.ConfigurationProvider,
 }
 
 func newApmDomainClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ApmDomainClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = ApmDomainClient{BaseClient: baseClient}
 	client.BasePath = "20200630"
 	err = client.setConfigurationProvider(configProvider)

--- a/apmsynthetics/apmsynthetics_apmsynthetic_client.go
+++ b/apmsynthetics/apmsynthetics_apmsynthetic_client.go
@@ -50,6 +50,9 @@ func NewApmSyntheticClientWithOboToken(configProvider common.ConfigurationProvid
 }
 
 func newApmSyntheticClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ApmSyntheticClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = ApmSyntheticClient{BaseClient: baseClient}
 	client.BasePath = "20200630"
 	err = client.setConfigurationProvider(configProvider)

--- a/apmtraces/apmtraces_query_client.go
+++ b/apmtraces/apmtraces_query_client.go
@@ -50,6 +50,9 @@ func NewQueryClientWithOboToken(configProvider common.ConfigurationProvider, obo
 }
 
 func newQueryClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client QueryClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = QueryClient{BaseClient: baseClient}
 	client.BasePath = "20200630"
 	err = client.setConfigurationProvider(configProvider)

--- a/apmtraces/apmtraces_trace_client.go
+++ b/apmtraces/apmtraces_trace_client.go
@@ -50,6 +50,9 @@ func NewTraceClientWithOboToken(configProvider common.ConfigurationProvider, obo
 }
 
 func newTraceClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client TraceClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = TraceClient{BaseClient: baseClient}
 	client.BasePath = "20200630"
 	err = client.setConfigurationProvider(configProvider)

--- a/applicationmigration/applicationmigration_client.go
+++ b/applicationmigration/applicationmigration_client.go
@@ -53,6 +53,9 @@ func NewApplicationMigrationClientWithOboToken(configProvider common.Configurati
 }
 
 func newApplicationMigrationClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ApplicationMigrationClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = ApplicationMigrationClient{BaseClient: baseClient}
 	client.BasePath = "20191031"
 	err = client.setConfigurationProvider(configProvider)

--- a/artifacts/artifacts_client.go
+++ b/artifacts/artifacts_client.go
@@ -51,6 +51,9 @@ func NewArtifactsClientWithOboToken(configProvider common.ConfigurationProvider,
 }
 
 func newArtifactsClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ArtifactsClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = ArtifactsClient{BaseClient: baseClient}
 	client.BasePath = "20160918"
 	err = client.setConfigurationProvider(configProvider)

--- a/audit/audit_client.go
+++ b/audit/audit_client.go
@@ -52,6 +52,9 @@ func NewAuditClientWithOboToken(configProvider common.ConfigurationProvider, obo
 }
 
 func newAuditClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client AuditClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = AuditClient{BaseClient: baseClient}
 	client.BasePath = "20190901"
 	err = client.setConfigurationProvider(configProvider)

--- a/autoscaling/autoscaling_client.go
+++ b/autoscaling/autoscaling_client.go
@@ -54,6 +54,9 @@ func NewAutoScalingClientWithOboToken(configProvider common.ConfigurationProvide
 }
 
 func newAutoScalingClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client AutoScalingClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = AutoScalingClient{BaseClient: baseClient}
 	client.BasePath = "20181001"
 	err = client.setConfigurationProvider(configProvider)

--- a/bastion/bastion_client.go
+++ b/bastion/bastion_client.go
@@ -50,6 +50,9 @@ func NewBastionClientWithOboToken(configProvider common.ConfigurationProvider, o
 }
 
 func newBastionClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client BastionClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = BastionClient{BaseClient: baseClient}
 	client.BasePath = "20210331"
 	err = client.setConfigurationProvider(configProvider)

--- a/bds/bds_client.go
+++ b/bds/bds_client.go
@@ -50,6 +50,9 @@ func NewBdsClientWithOboToken(configProvider common.ConfigurationProvider, oboTo
 }
 
 func newBdsClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client BdsClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = BdsClient{BaseClient: baseClient}
 	client.BasePath = "20190531"
 	err = client.setConfigurationProvider(configProvider)

--- a/blockchain/blockchain_blockchainplatform_client.go
+++ b/blockchain/blockchain_blockchainplatform_client.go
@@ -50,6 +50,9 @@ func NewBlockchainPlatformClientWithOboToken(configProvider common.Configuration
 }
 
 func newBlockchainPlatformClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client BlockchainPlatformClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = BlockchainPlatformClient{BaseClient: baseClient}
 	client.BasePath = "20191010"
 	err = client.setConfigurationProvider(configProvider)

--- a/budget/budget_client.go
+++ b/budget/budget_client.go
@@ -50,6 +50,9 @@ func NewBudgetClientWithOboToken(configProvider common.ConfigurationProvider, ob
 }
 
 func newBudgetClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client BudgetClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = BudgetClient{BaseClient: baseClient}
 	client.BasePath = "20190111"
 	err = client.setConfigurationProvider(configProvider)

--- a/cims/cims_incident_client.go
+++ b/cims/cims_incident_client.go
@@ -50,6 +50,9 @@ func NewIncidentClientWithOboToken(configProvider common.ConfigurationProvider, 
 }
 
 func newIncidentClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client IncidentClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = IncidentClient{BaseClient: baseClient}
 	client.BasePath = "20181231"
 	err = client.setConfigurationProvider(configProvider)

--- a/cims/cims_user_client.go
+++ b/cims/cims_user_client.go
@@ -50,6 +50,9 @@ func NewUserClientWithOboToken(configProvider common.ConfigurationProvider, oboT
 }
 
 func newUserClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client UserClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = UserClient{BaseClient: baseClient}
 	client.BasePath = "20181231"
 	err = client.setConfigurationProvider(configProvider)

--- a/cloudguard/cloudguard_client.go
+++ b/cloudguard/cloudguard_client.go
@@ -50,6 +50,9 @@ func NewCloudGuardClientWithOboToken(configProvider common.ConfigurationProvider
 }
 
 func newCloudGuardClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client CloudGuardClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = CloudGuardClient{BaseClient: baseClient}
 	client.BasePath = "20200131"
 	err = client.setConfigurationProvider(configProvider)

--- a/common/auth/instance_principal_delegation_token_provider_test.go
+++ b/common/auth/instance_principal_delegation_token_provider_test.go
@@ -4,17 +4,27 @@
 package auth
 
 import (
+	"github.com/oracle/oci-go-sdk/v49/common"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestInstancePrincipalDelegationTokenConfigurationProvider_ErrorInput(t *testing.T) {
 	delegationToken := ""
+	region := common.StringToRegion("us-ashburn-1")
 	configurationProvider, err := InstancePrincipalDelegationTokenConfigurationProvider(&delegationToken)
 	assert.Nil(t, configurationProvider)
 	assert.NotNil(t, err)
 
 	configurationProvider, err = InstancePrincipalDelegationTokenConfigurationProvider(nil)
 	assert.Nil(t, configurationProvider)
+	assert.NotNil(t, err)
+
+	configurationProviderForRegion, err := InstancePrincipalDelegationTokenConfigurationProviderForRegion(&delegationToken, region)
+	assert.Nil(t, configurationProviderForRegion)
+	assert.NotNil(t, err)
+
+	configurationProviderForRegionNotFound, err := InstancePrincipalDelegationTokenConfigurationProviderForRegion(&delegationToken, "")
+	assert.Nil(t, configurationProviderForRegionNotFound)
 	assert.NotNil(t, err)
 }

--- a/common/auth/utils.go
+++ b/common/auth/utils.go
@@ -83,6 +83,9 @@ func GetGenericConfigurationProvider(configProvider common.ConfigurationProvider
 	if authConfig, err := configProvider.AuthType(); err == nil && authConfig.IsFromConfigFile {
 		switch authConfig.AuthType {
 		case common.InstancePrincipalDelegationToken:
+			if region, err := configProvider.Region(); err == nil {
+				return InstancePrincipalDelegationTokenConfigurationProviderForRegion(authConfig.OboToken, common.StringToRegion(region))
+			}
 			return InstancePrincipalDelegationTokenConfigurationProvider(authConfig.OboToken)
 		case common.InstancePrincipal:
 			return InstancePrincipalConfigurationProvider()

--- a/common/circuit_breaker.go
+++ b/common/circuit_breaker.go
@@ -1,0 +1,234 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+package common
+
+import (
+	"fmt"
+	"github.com/sony/gobreaker"
+	"time"
+)
+
+const (
+	// CircuitBreakerDefaultFailureRateThreshold is the requests failure rate which calculates in at most 120 seconds, once reaches to this rate, the circuit breaker state changes from closed to open
+	CircuitBreakerDefaultFailureRateThreshold float64 = 0.80
+	// CircuitBreakerDefaultClosedWindow is the default value of closeStateWindow, which is the cyclic period of the closed state
+	CircuitBreakerDefaultClosedWindow time.Duration = 120 * time.Second
+	// CircuitBreakerDefaultResetTimeout is the default value of openStateWindow, which is the wait time before setting the breaker to halfOpen state from open state
+	CircuitBreakerDefaultResetTimeout time.Duration = 30 * time.Second
+	// CircuitBreakerDefaultVolumeThreshold is the default value of minimumRequests in closed status
+	CircuitBreakerDefaultVolumeThreshold uint32 = 10
+	// DefaultCircuitBreakerName is the name of the circuit breaker
+	DefaultCircuitBreakerName string = "DefaultCircuitBreaker"
+)
+
+// CircuitBreakerSetting wraps all exposed configurable params of circuit breaker
+type CircuitBreakerSetting struct {
+	// Name is the Circuit Breaker's identifier
+	name string
+	// isEnabled is the switch of the circuit breaker, used for disable circuit breaker
+	isEnabled bool
+	// closeStateWindow is the cyclic period of the closed state, the default value is 120 seconds
+	closeStateWindow time.Duration
+	// openStateWindow is the wait time before setting the breaker to halfOpen state from open state, the default value is 30 seconds
+	openStateWindow time.Duration
+	// failureRateThreshold is the failure rate which calculates in at most closeStateWindow seconds, once reaches to this rate, the circuit breaker state changes from closed to open
+	// the circuit will transition from closed to open, the default value is 80%
+	failureRateThreshold float64
+	// minimumRequests is the minimum number of counted requests in closed state, the default value is 10 requests
+	minimumRequests uint32
+	// successStatCodeMap is the error(s) of StatusCode returned from service, which should be considered as the success or failure accounted by circuit breaker
+	// successStatCodeMap and successStatErrCodeMap are combined to use, if both StatusCode and ErrorCode are required, no need to add it to successStatCodeMap,
+	// the default value is [429, 500, 502, 503, 504]
+	successStatCodeMap map[int]bool
+	// successStatErrCodeMap is the error(s) of StatusCode and ErrorCode returned from service, which should be considered
+	// as the success or failure accounted by circuit breaker
+	// the default value is {409, "IncorrectState"}
+	successStatErrCodeMap map[StatErrCode]bool
+}
+
+// Convert CircuitBreakerSetting to human-readable string representation
+func (cbst CircuitBreakerSetting) String() string {
+	return fmt.Sprintf("{name=%v, isEnabled=%v, closeStateWindow=%v, openStateWindow=%v, failureRateThreshold=%v, minimumRequests=%v, successStatCodeMap=%v, successStatErrCodeMap=%v}",
+		cbst.name, cbst.isEnabled, cbst.closeStateWindow, cbst.openStateWindow, cbst.failureRateThreshold, cbst.minimumRequests, cbst.successStatCodeMap, cbst.successStatErrCodeMap)
+}
+
+// CircuitBreakerOption is the type of the options for NewCircuitBreakerWithOptions.
+type CircuitBreakerOption func(cbst *CircuitBreakerSetting)
+
+// NewGoCircuitBreaker is a function to initialize a CircuitBreaker object with the specified configuration
+// Add the interface, to allow the user directly use the 3P gobreaker.Setting's params.
+func NewGoCircuitBreaker(st gobreaker.Settings) *gobreaker.CircuitBreaker {
+	return gobreaker.NewCircuitBreaker(st)
+}
+
+// DefaultCircuitBreakerSetting is used for set circuit breaker with default config
+func DefaultCircuitBreakerSetting() *CircuitBreakerSetting {
+	successStatErrCodeMap := map[StatErrCode]bool{
+		{409, "IncorrectState"}: false,
+	}
+	successStatCodeMap := map[int]bool{
+		429: false,
+		500: false,
+		502: false,
+		503: false,
+		504: false,
+	}
+	return newCircuitBreakerSetting(
+		WithName(DefaultCircuitBreakerName),
+		WithIsEnabled(true),
+		WithCloseStateWindow(CircuitBreakerDefaultClosedWindow),
+		WithOpenStateWindow(CircuitBreakerDefaultResetTimeout),
+		WithFailureRateThreshold(CircuitBreakerDefaultFailureRateThreshold),
+		WithMinimumRequests(CircuitBreakerDefaultVolumeThreshold),
+		WithSuccessStatErrCodeMap(successStatErrCodeMap),
+		WithSuccessStatCodeMap(successStatCodeMap))
+}
+
+// NoCircuitBreakerSetting is used for disable Circuit Breaker
+func NoCircuitBreakerSetting() *CircuitBreakerSetting {
+	return NewCircuitBreakerSettingWithOptions(WithIsEnabled(false))
+}
+
+// NewCircuitBreakerSettingWithOptions is a helper method to assemble a CircuitBreakerSetting object.
+// It starts out with the values returned by defaultCircuitBreakerSetting().
+func NewCircuitBreakerSettingWithOptions(opts ...CircuitBreakerOption) *CircuitBreakerSetting {
+	cbst := DefaultCircuitBreakerSetting()
+	// allow changing values
+	for _, opt := range opts {
+		opt(cbst)
+	}
+	if defaultLogger.LogLevel() == verboseLogging {
+		Debugf("Circuit Breaker setting: %s\n", cbst.String())
+	}
+
+	return cbst
+}
+
+// NewCircuitBreaker is used for initialing specified circuit breaker configuration with base client
+func NewCircuitBreaker(cbst *CircuitBreakerSetting) *gobreaker.CircuitBreaker {
+	if !cbst.isEnabled {
+		return nil
+	}
+	st := gobreaker.Settings{}
+	customizeGoBreakerSetting(&st, cbst)
+	return gobreaker.NewCircuitBreaker(st)
+}
+
+func newCircuitBreakerSetting(opts ...CircuitBreakerOption) *CircuitBreakerSetting {
+	cbSetting := CircuitBreakerSetting{}
+
+	// allow changing values
+	for _, opt := range opts {
+		opt(&cbSetting)
+	}
+	return &cbSetting
+}
+
+// customizeGoBreakerSetting is used for converting CircuitBreakerSetting to 3P gobreaker's setting type
+func customizeGoBreakerSetting(st *gobreaker.Settings, cbst *CircuitBreakerSetting) {
+	st.Name = cbst.name
+	st.Timeout = cbst.openStateWindow
+	st.Interval = cbst.closeStateWindow
+	st.ReadyToTrip = func(counts gobreaker.Counts) bool {
+		failureRatio := float64(counts.TotalFailures) / float64(counts.Requests)
+		return counts.Requests >= cbst.minimumRequests && failureRatio >= cbst.failureRateThreshold
+	}
+	st.IsSuccessful = func(err error) bool {
+		if serviceErr, ok := IsServiceError(err); ok {
+			if isSuccessful, ok := cbst.successStatCodeMap[serviceErr.GetHTTPStatusCode()]; ok {
+				return isSuccessful
+			}
+			if isSuccessful, ok := cbst.successStatErrCodeMap[StatErrCode{serviceErr.GetHTTPStatusCode(), serviceErr.GetCode()}]; ok {
+				return isSuccessful
+			}
+		}
+		return true
+	}
+}
+
+// WithName is the option for NewCircuitBreaker that sets the Name.
+func WithName(name string) CircuitBreakerOption {
+	// this is the CircuitBreakerOption function type
+	return func(cbst *CircuitBreakerSetting) {
+		cbst.name = name
+	}
+}
+
+// WithIsEnabled is the option for NewCircuitBreaker that sets the isEnabled.
+func WithIsEnabled(isEnabled bool) CircuitBreakerOption {
+	// this is the CircuitBreakerOption function type
+	return func(cbst *CircuitBreakerSetting) {
+		cbst.isEnabled = isEnabled
+	}
+}
+
+// WithCloseStateWindow is the option for NewCircuitBreaker that sets the closeStateWindow.
+func WithCloseStateWindow(window time.Duration) CircuitBreakerOption {
+	// this is the CircuitBreakerOption function type
+	return func(cbst *CircuitBreakerSetting) {
+		cbst.closeStateWindow = window
+	}
+}
+
+// WithOpenStateWindow is the option for NewCircuitBreaker that sets the openStateWindow.
+func WithOpenStateWindow(window time.Duration) CircuitBreakerOption {
+	// this is the CircuitBreakerOption function type
+	return func(cbst *CircuitBreakerSetting) {
+		cbst.openStateWindow = window
+	}
+}
+
+// WithFailureRateThreshold is the option for NewCircuitBreaker that sets the failureRateThreshold.
+func WithFailureRateThreshold(threshold float64) CircuitBreakerOption {
+	// this is the CircuitBreakerOption function type
+	return func(cbst *CircuitBreakerSetting) {
+		cbst.failureRateThreshold = threshold
+	}
+}
+
+// WithMinimumRequests is the option for NewCircuitBreaker that sets the minimumRequests.
+func WithMinimumRequests(num uint32) CircuitBreakerOption {
+	// this is the CircuitBreakerOption function type
+	return func(cbst *CircuitBreakerSetting) {
+		cbst.minimumRequests = num
+	}
+}
+
+// WithSuccessStatCodeMap is the option for NewCircuitBreaker that sets the successStatCodeMap.
+func WithSuccessStatCodeMap(successStatCodeMap map[int]bool) CircuitBreakerOption {
+	// this is the CircuitBreakerOption function type
+	return func(cbst *CircuitBreakerSetting) {
+		cbst.successStatCodeMap = successStatCodeMap
+	}
+}
+
+// WithSuccessStatErrCodeMap is the option for NewCircuitBreaker that sets the successStatErrCodeMap.
+func WithSuccessStatErrCodeMap(successStatErrCodeMap map[StatErrCode]bool) CircuitBreakerOption {
+	// this is the CircuitBreakerOption function type
+	return func(cbst *CircuitBreakerSetting) {
+		cbst.successStatErrCodeMap = successStatErrCodeMap
+	}
+}
+
+// GlobalCircuitBreakerSetting is global level circuit breaker setting, it would impact all services, the precedence is lower
+// than client level circuit breaker
+var GlobalCircuitBreakerSetting *CircuitBreakerSetting = nil
+
+// ConfigCircuitBreakerFromEnvVar is used for checking the circuit breaker environment variable setting, default value is nil
+func ConfigCircuitBreakerFromEnvVar(baseClient *BaseClient) {
+	if IsEnvVarTrue(isDefaultCircuitBreakerEnabled) {
+		baseClient.Configuration.CircuitBreaker = NewCircuitBreaker(DefaultCircuitBreakerSetting())
+		return
+	}
+	if IsEnvVarFalse(isDefaultCircuitBreakerEnabled) {
+		baseClient.Configuration.CircuitBreaker = nil
+	}
+}
+
+// ConfigCircuitBreakerFromGlobalVar is used for checking if global circuitBreakerSetting is configured, the priority is higher than cb env var
+func ConfigCircuitBreakerFromGlobalVar(baseClient *BaseClient) {
+	if GlobalCircuitBreakerSetting != nil {
+		baseClient.Configuration.CircuitBreaker = NewCircuitBreaker(GlobalCircuitBreakerSetting)
+	}
+}

--- a/common/circuit_breaker_test.go
+++ b/common/circuit_breaker_test.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+package common
+
+import (
+	"github.com/sony/gobreaker"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCircuitBreaker_ReadyToTrip(t *testing.T) {
+	type testData struct {
+		counts   gobreaker.Counts
+		expected bool
+	}
+	testDataSet := []testData{
+		{
+			counts: gobreaker.Counts{
+				Requests:             30,
+				TotalSuccesses:       3,
+				TotalFailures:        27,
+				ConsecutiveSuccesses: 1,
+				ConsecutiveFailures:  15,
+			},
+			expected: true,
+		},
+		{
+			counts: gobreaker.Counts{
+				Requests:             9,
+				TotalSuccesses:       0,
+				TotalFailures:        9,
+				ConsecutiveSuccesses: 0,
+				ConsecutiveFailures:  9,
+			},
+			expected: false,
+		},
+		{
+			counts: gobreaker.Counts{
+				Requests:             20,
+				TotalSuccesses:       18,
+				TotalFailures:        2,
+				ConsecutiveSuccesses: 17,
+				ConsecutiveFailures:  1,
+			},
+			expected: false,
+		},
+	}
+	st := gobreaker.Settings{}
+	st.ReadyToTrip = func(counts gobreaker.Counts) bool {
+		failureRatio := float64(counts.TotalFailures) / float64(counts.Requests)
+		return counts.Requests >= CircuitBreakerDefaultVolumeThreshold && failureRatio >= CircuitBreakerDefaultFailureRateThreshold
+	}
+	for _, testData := range testDataSet {
+		assert.Equal(t, testData.expected, st.ReadyToTrip(testData.counts))
+	}
+}
+
+func TestCircuitBreaker_IsSuccessful(t *testing.T) {
+	type testData struct {
+		err      servicefailure
+		expected bool
+	}
+
+	testDataSet := []testData{
+		{
+			err: servicefailure{
+				StatusCode: 409,
+				Code:       "IncorrectState",
+			},
+			expected: false,
+		},
+		{
+			err: servicefailure{
+				StatusCode: 409,
+				Code:       "otherErrorCode",
+			},
+			expected: true,
+		},
+		{
+			err: servicefailure{
+				StatusCode: 500,
+				Code:       "whatever",
+			},
+			expected: false,
+		},
+	}
+	st := gobreaker.Settings{}
+	successStatErrCodeMap := map[StatErrCode]bool{
+		{409, "IncorrectState"}: false,
+	}
+	successStatCodeMap := map[int]bool{
+		429: false,
+		500: false,
+		502: false,
+		503: false,
+		504: false,
+	}
+	st.IsSuccessful = func(err error) bool {
+		if serviceErr, ok := IsServiceError(err); ok {
+			if isSuccessful, ok := successStatCodeMap[serviceErr.GetHTTPStatusCode()]; ok {
+				return isSuccessful
+			}
+			if isSuccessful, ok := successStatErrCodeMap[StatErrCode{serviceErr.GetHTTPStatusCode(), serviceErr.GetCode()}]; ok {
+				return isSuccessful
+			}
+		}
+		return true
+	}
+	for _, testData := range testDataSet {
+		assert.Equal(t, testData.expected, st.IsSuccessful(testData.err))
+	}
+}
+
+func TestCircuitBreaker_CustomizeGoBreakerSetting(t *testing.T) {
+
+	cbSetting := DefaultCircuitBreakerSetting()
+	assert.True(t, cbSetting.isEnabled)
+	st := gobreaker.Settings{}
+
+	customizeGoBreakerSetting(&st, cbSetting)
+	assert.Equal(t, st.Name, DefaultCircuitBreakerName)
+	assert.Equal(t, st.Timeout, CircuitBreakerDefaultResetTimeout)
+	assert.Equal(t, st.Interval, CircuitBreakerDefaultClosedWindow)
+	assert.Equal(t, cbSetting.failureRateThreshold, CircuitBreakerDefaultFailureRateThreshold)
+	counts := gobreaker.Counts{
+		Requests:             12,
+		TotalSuccesses:       2,
+		TotalFailures:        10,
+		ConsecutiveSuccesses: 1,
+		ConsecutiveFailures:  6,
+	}
+	assert.True(t, st.ReadyToTrip(counts))
+
+	type testData struct {
+		err      servicefailure
+		expected bool
+	}
+	testDataSet := []testData{
+		{
+			err: servicefailure{
+				StatusCode: 400,
+				Code:       "InvalidParameter"},
+			expected: true,
+		},
+		{
+			err: servicefailure{
+				StatusCode: 409,
+				Code:       "IncorrectState"},
+			expected: false,
+		},
+		{
+			err: servicefailure{
+				StatusCode: 429,
+				Code:       "TooManyRequests"},
+			expected: false,
+		},
+		{
+			err: servicefailure{
+				StatusCode: 504,
+				Code:       "whatever"},
+			expected: false,
+		},
+	}
+
+	for _, testData := range testDataSet {
+		assert.Equal(t, testData.expected, st.IsSuccessful(testData.err))
+	}
+}

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -607,28 +607,6 @@ delegation_token_file=/nothingThere
 	assert.NoError(t, err)
 }
 
-func TestCustomProfileClient_CreateWithConfig(t *testing.T) {
-	dataTpl := `[DEFAULT]
-tenancy=sometenancy
-[PROFILE1]
-user=someuser
-fingerprint=somefingerprint
-key_file=%s
-region=us-ashburn-1
-`
-
-	keyFile := writeTempFile(testPrivateKeyConf)
-	data := fmt.Sprintf(dataTpl, keyFile)
-	tmpConfFile := writeTempFile(data)
-
-	defer removeFileFn(tmpConfFile)
-	defer removeFileFn(keyFile)
-	configurationProvider := CustomProfileConfigProvider(tmpConfFile, "PROFILE1")
-	client, err := NewClientWithConfig(configurationProvider)
-	assert.NotNil(t, client)
-	assert.NoError(t, err)
-}
-
 func TestBaseClient_CreateWithBadRegion(t *testing.T) {
 	dataTpl := `[DEFAULT]
 tenancy=sometenancy

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -286,8 +286,13 @@ func makeACopy(original []string) []string {
 
 // IsEnvVarFalse is used for checking if an environment variable is explicitly set to false, otherwise would set it true by default
 func IsEnvVarFalse(envVarKey string) bool {
-	if val, existed := os.LookupEnv(envVarKey); existed && strings.ToLower(val) == "false" {
-		return true
-	}
 	return false
+	val, existed := os.LookupEnv(envVarKey)
+	return existed && strings.ToLower(val) == "false"
+}
+
+// IsEnvVarTrue is used for checking if an environment variable is explicitly set to true, otherwise would set it true by default
+func IsEnvVarTrue(envVarKey string) bool {
+	val, existed := os.LookupEnv(envVarKey)
+	return existed && strings.ToLower(val) == "true"
 }

--- a/common/retry_test.go
+++ b/common/retry_test.go
@@ -182,6 +182,7 @@ func buildResponsesNoRetry(endOfWindowTime *time.Time, backoffScalingFactor floa
 		getMockedOCIOperationResponseWithErrorFull(422, "UnprocessableEntity", endOfWindowTime, backoffScalingFactor),
 		getMockedOCIOperationResponseWithErrorFull(431, "RequestHeaderFieldsTooLarge", endOfWindowTime, backoffScalingFactor),
 		getMockedOCIOperationResponseWithErrorFull(501, "MethodNotImplemented", endOfWindowTime, backoffScalingFactor),
+		getMockedOCIOperationResponseWithErrorFull(599, "Unknown 500 Error", endOfWindowTime, backoffScalingFactor),
 
 		getMockedOCIOperationResponse(200, 1),
 	}
@@ -195,7 +196,6 @@ func buildResponsesWantRetry(endOfWindowTime *time.Time, backoffScalingFactor fl
 		getMockedOCIOperationResponseWithErrorFull(500, "InternalServerError", endOfWindowTime, backoffScalingFactor),
 		getMockedOCIOperationResponseWithErrorFull(500, "OutOfCapacity", endOfWindowTime, backoffScalingFactor),
 		getMockedOCIOperationResponseWithErrorFull(503, "ServiceUnavailable", endOfWindowTime, backoffScalingFactor),
-		getMockedOCIOperationResponseWithErrorFull(599, "Unknown 500 Error", endOfWindowTime, backoffScalingFactor),
 	}
 	return responses
 }
@@ -236,7 +236,6 @@ func buildEcResponsesWantRetry(endOfWindowTime *time.Time, backoffScalingFactor 
 		getMockedOCIOperationResponseWithErrorFull(500, "InternalServerError", endOfWindowTime, backoffScalingFactor),
 		getMockedOCIOperationResponseWithErrorFull(500, "OutOfCapacity", endOfWindowTime, backoffScalingFactor),
 		getMockedOCIOperationResponseWithErrorFull(503, "ServiceUnavailable", endOfWindowTime, backoffScalingFactor),
-		getMockedOCIOperationResponseWithErrorFull(599, "Unknown 500 Error", endOfWindowTime, backoffScalingFactor),
 	}
 	return responses
 }

--- a/common/version.go
+++ b/common/version.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	major = "49"
-	minor = "1"
+	minor = "2"
 	patch = "0"
 	tag   = ""
 )

--- a/computeinstanceagent/computeinstanceagent_client.go
+++ b/computeinstanceagent/computeinstanceagent_client.go
@@ -51,6 +51,9 @@ func NewComputeInstanceAgentClientWithOboToken(configProvider common.Configurati
 }
 
 func newComputeInstanceAgentClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ComputeInstanceAgentClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = ComputeInstanceAgentClient{BaseClient: baseClient}
 	client.BasePath = "20180530"
 	err = client.setConfigurationProvider(configProvider)

--- a/computeinstanceagent/computeinstanceagent_plugin_client.go
+++ b/computeinstanceagent/computeinstanceagent_plugin_client.go
@@ -51,6 +51,9 @@ func NewPluginClientWithOboToken(configProvider common.ConfigurationProvider, ob
 }
 
 func newPluginClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client PluginClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = PluginClient{BaseClient: baseClient}
 	client.BasePath = "20180530"
 	err = client.setConfigurationProvider(configProvider)

--- a/computeinstanceagent/computeinstanceagent_pluginconfig_client.go
+++ b/computeinstanceagent/computeinstanceagent_pluginconfig_client.go
@@ -51,6 +51,9 @@ func NewPluginconfigClientWithOboToken(configProvider common.ConfigurationProvid
 }
 
 func newPluginconfigClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client PluginconfigClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = PluginconfigClient{BaseClient: baseClient}
 	client.BasePath = "20180530"
 	err = client.setConfigurationProvider(configProvider)

--- a/containerengine/containerengine_client.go
+++ b/containerengine/containerengine_client.go
@@ -52,6 +52,9 @@ func NewContainerEngineClientWithOboToken(configProvider common.ConfigurationPro
 }
 
 func newContainerEngineClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ContainerEngineClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = ContainerEngineClient{BaseClient: baseClient}
 	client.BasePath = "20180222"
 	err = client.setConfigurationProvider(configProvider)

--- a/core/core_blockstorage_client.go
+++ b/core/core_blockstorage_client.go
@@ -54,6 +54,9 @@ func NewBlockstorageClientWithOboToken(configProvider common.ConfigurationProvid
 }
 
 func newBlockstorageClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client BlockstorageClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = BlockstorageClient{BaseClient: baseClient}
 	client.BasePath = "20160918"
 	err = client.setConfigurationProvider(configProvider)

--- a/core/core_compute_client.go
+++ b/core/core_compute_client.go
@@ -54,6 +54,9 @@ func NewComputeClientWithOboToken(configProvider common.ConfigurationProvider, o
 }
 
 func newComputeClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ComputeClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = ComputeClient{BaseClient: baseClient}
 	client.BasePath = "20160918"
 	err = client.setConfigurationProvider(configProvider)

--- a/core/core_computemanagement_client.go
+++ b/core/core_computemanagement_client.go
@@ -54,6 +54,9 @@ func NewComputeManagementClientWithOboToken(configProvider common.ConfigurationP
 }
 
 func newComputeManagementClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ComputeManagementClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = ComputeManagementClient{BaseClient: baseClient}
 	client.BasePath = "20160918"
 	err = client.setConfigurationProvider(configProvider)

--- a/core/core_virtualnetwork_client.go
+++ b/core/core_virtualnetwork_client.go
@@ -54,6 +54,9 @@ func NewVirtualNetworkClientWithOboToken(configProvider common.ConfigurationProv
 }
 
 func newVirtualNetworkClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client VirtualNetworkClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = VirtualNetworkClient{BaseClient: baseClient}
 	client.BasePath = "20160918"
 	err = client.setConfigurationProvider(configProvider)

--- a/database/add_virtual_machine_to_vm_cluster_details.go
+++ b/database/add_virtual_machine_to_vm_cluster_details.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+)
+
+// AddVirtualMachineToVmClusterDetails Details of adding Virtual Machines to the VM Cluster. Applies to Exadata Cloud@Customer instances only.
+type AddVirtualMachineToVmClusterDetails struct {
+
+	// The list of Exacc DB servers for the cluster to be added.
+	DbServers []DbServerDetails `mandatory:"true" json:"dbServers"`
+}
+
+func (m AddVirtualMachineToVmClusterDetails) String() string {
+	return common.PointerString(m)
+}

--- a/database/add_virtual_machine_to_vm_cluster_request_response.go
+++ b/database/add_virtual_machine_to_vm_cluster_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+	"net/http"
+)
+
+// AddVirtualMachineToVmClusterRequest wrapper for the AddVirtualMachineToVmCluster operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/database/AddVirtualMachineToVmCluster.go.html to see an example of how to use AddVirtualMachineToVmClusterRequest.
+type AddVirtualMachineToVmClusterRequest struct {
+
+	// Request to add Virtual Machines to the VM cluster.
+	AddVirtualMachineToVmClusterDetails `contributesTo:"body"`
+
+	// The VM cluster OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	VmClusterId *string `mandatory:"true" contributesTo:"path" name:"vmClusterId"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request AddVirtualMachineToVmClusterRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request AddVirtualMachineToVmClusterRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request AddVirtualMachineToVmClusterRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request AddVirtualMachineToVmClusterRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// AddVirtualMachineToVmClusterResponse wrapper for the AddVirtualMachineToVmCluster operation
+type AddVirtualMachineToVmClusterResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The VmCluster instance
+	VmCluster `presentIn:"body"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request. Multiple OCID values are returned in a comma-separated list. Use GetWorkRequest with a work request OCID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response AddVirtualMachineToVmClusterResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response AddVirtualMachineToVmClusterResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/convert_to_pdb_details.go
+++ b/database/convert_to_pdb_details.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/v49/common"
+)
+
+// ConvertToPdbDetails Details for converting a non-container database to pluggable database.
+type ConvertToPdbDetails struct {
+
+	// The operations used to convert a non-container database to a pluggable database.
+	// - Use `PRECHECK` to run a pre-check operation on non-container database prior to converting it into a pluggable database.
+	// - Use `CONVERT` to convert a non-container database into a pluggable database.
+	// - Use `SYNC` if the non-container database was manually converted into a pluggable database using the dbcli command-line utility. Databases may need to be converted manually if the CONVERT action fails when converting a non-container database using the API.
+	// - Use `SYNC_ROLLBACK` if the conversion of a non-container database into a pluggable database was manually rolled back using the dbcli command line utility. Conversions may need to be manually rolled back if the CONVERT action fails when converting a non-container database using the API.
+	Action ConvertToPdbDetailsActionEnum `mandatory:"true" json:"action"`
+
+	ConvertToPdbTargetDetails ConvertToPdbTargetBase `mandatory:"false" json:"convertToPdbTargetDetails"`
+}
+
+func (m ConvertToPdbDetails) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *ConvertToPdbDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		ConvertToPdbTargetDetails converttopdbtargetbase        `json:"convertToPdbTargetDetails"`
+		Action                    ConvertToPdbDetailsActionEnum `json:"action"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	nn, e = model.ConvertToPdbTargetDetails.UnmarshalPolymorphicJSON(model.ConvertToPdbTargetDetails.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.ConvertToPdbTargetDetails = nn.(ConvertToPdbTargetBase)
+	} else {
+		m.ConvertToPdbTargetDetails = nil
+	}
+
+	m.Action = model.Action
+
+	return
+}
+
+// ConvertToPdbDetailsActionEnum Enum with underlying type: string
+type ConvertToPdbDetailsActionEnum string
+
+// Set of constants representing the allowable values for ConvertToPdbDetailsActionEnum
+const (
+	ConvertToPdbDetailsActionPrecheck     ConvertToPdbDetailsActionEnum = "PRECHECK"
+	ConvertToPdbDetailsActionConvert      ConvertToPdbDetailsActionEnum = "CONVERT"
+	ConvertToPdbDetailsActionSync         ConvertToPdbDetailsActionEnum = "SYNC"
+	ConvertToPdbDetailsActionSyncRollback ConvertToPdbDetailsActionEnum = "SYNC_ROLLBACK"
+)
+
+var mappingConvertToPdbDetailsAction = map[string]ConvertToPdbDetailsActionEnum{
+	"PRECHECK":      ConvertToPdbDetailsActionPrecheck,
+	"CONVERT":       ConvertToPdbDetailsActionConvert,
+	"SYNC":          ConvertToPdbDetailsActionSync,
+	"SYNC_ROLLBACK": ConvertToPdbDetailsActionSyncRollback,
+}
+
+// GetConvertToPdbDetailsActionEnumValues Enumerates the set of values for ConvertToPdbDetailsActionEnum
+func GetConvertToPdbDetailsActionEnumValues() []ConvertToPdbDetailsActionEnum {
+	values := make([]ConvertToPdbDetailsActionEnum, 0)
+	for _, v := range mappingConvertToPdbDetailsAction {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/convert_to_pdb_request_response.go
+++ b/database/convert_to_pdb_request_response.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+	"net/http"
+)
+
+// ConvertToPdbRequest wrapper for the ConvertToPdb operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/database/ConvertToPdb.go.html to see an example of how to use ConvertToPdbRequest.
+type ConvertToPdbRequest struct {
+
+	// The database OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	DatabaseId *string `mandatory:"true" contributesTo:"path" name:"databaseId"`
+
+	// Request to convert a non-container database to a pluggable database.
+	ConvertToPdbDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ConvertToPdbRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ConvertToPdbRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ConvertToPdbRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ConvertToPdbRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ConvertToPdbResponse wrapper for the ConvertToPdb operation
+type ConvertToPdbResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Database instance
+	Database `presentIn:"body"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request. Multiple OCID values are returned in a comma-separated list. Use GetWorkRequest with a work request OCID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ConvertToPdbResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ConvertToPdbResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/convert_to_pdb_target_base.go
+++ b/database/convert_to_pdb_target_base.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/v49/common"
+)
+
+// ConvertToPdbTargetBase Details of the container database in which the converted pluggable database will be located.
+type ConvertToPdbTargetBase interface {
+}
+
+type converttopdbtargetbase struct {
+	JsonData []byte
+	Target   string `json:"target"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *converttopdbtargetbase) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerconverttopdbtargetbase converttopdbtargetbase
+	s := struct {
+		Model Unmarshalerconverttopdbtargetbase
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Target = s.Model.Target
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *converttopdbtargetbase) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.Target {
+	case "NEW_DATABASE":
+		mm := PdbConversionToNewDatabaseDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+func (m converttopdbtargetbase) String() string {
+	return common.PointerString(m)
+}
+
+// ConvertToPdbTargetBaseTargetEnum Enum with underlying type: string
+type ConvertToPdbTargetBaseTargetEnum string
+
+// Set of constants representing the allowable values for ConvertToPdbTargetBaseTargetEnum
+const (
+	ConvertToPdbTargetBaseTargetNewDatabase ConvertToPdbTargetBaseTargetEnum = "NEW_DATABASE"
+)
+
+var mappingConvertToPdbTargetBaseTarget = map[string]ConvertToPdbTargetBaseTargetEnum{
+	"NEW_DATABASE": ConvertToPdbTargetBaseTargetNewDatabase,
+}
+
+// GetConvertToPdbTargetBaseTargetEnumValues Enumerates the set of values for ConvertToPdbTargetBaseTargetEnum
+func GetConvertToPdbTargetBaseTargetEnumValues() []ConvertToPdbTargetBaseTargetEnum {
+	values := make([]ConvertToPdbTargetBaseTargetEnum, 0)
+	for _, v := range mappingConvertToPdbTargetBaseTarget {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/create_data_guard_association_details.go
+++ b/database/create_data_guard_association_details.go
@@ -45,6 +45,12 @@ type CreateDataGuardAssociationDetails interface {
 
 	// The database software image OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm)
 	GetDatabaseSoftwareImageId() *string
+
+	// Specifies the `DB_UNIQUE_NAME` of the peer database to be created.
+	GetPeerDbUniqueName() *string
+
+	// Specifies a prefix for the `Oracle SID` of the database to be created.
+	GetPeerSidPrefix() *string
 }
 
 type createdataguardassociationdetails struct {
@@ -53,6 +59,8 @@ type createdataguardassociationdetails struct {
 	ProtectionMode          CreateDataGuardAssociationDetailsProtectionModeEnum `mandatory:"true" json:"protectionMode"`
 	TransportType           CreateDataGuardAssociationDetailsTransportTypeEnum  `mandatory:"true" json:"transportType"`
 	DatabaseSoftwareImageId *string                                             `mandatory:"false" json:"databaseSoftwareImageId"`
+	PeerDbUniqueName        *string                                             `mandatory:"false" json:"peerDbUniqueName"`
+	PeerSidPrefix           *string                                             `mandatory:"false" json:"peerSidPrefix"`
 	CreationType            string                                              `json:"creationType"`
 }
 
@@ -71,6 +79,8 @@ func (m *createdataguardassociationdetails) UnmarshalJSON(data []byte) error {
 	m.ProtectionMode = s.Model.ProtectionMode
 	m.TransportType = s.Model.TransportType
 	m.DatabaseSoftwareImageId = s.Model.DatabaseSoftwareImageId
+	m.PeerDbUniqueName = s.Model.PeerDbUniqueName
+	m.PeerSidPrefix = s.Model.PeerSidPrefix
 	m.CreationType = s.Model.CreationType
 
 	return err
@@ -120,6 +130,16 @@ func (m createdataguardassociationdetails) GetTransportType() CreateDataGuardAss
 //GetDatabaseSoftwareImageId returns DatabaseSoftwareImageId
 func (m createdataguardassociationdetails) GetDatabaseSoftwareImageId() *string {
 	return m.DatabaseSoftwareImageId
+}
+
+//GetPeerDbUniqueName returns PeerDbUniqueName
+func (m createdataguardassociationdetails) GetPeerDbUniqueName() *string {
+	return m.PeerDbUniqueName
+}
+
+//GetPeerSidPrefix returns PeerSidPrefix
+func (m createdataguardassociationdetails) GetPeerSidPrefix() *string {
+	return m.PeerSidPrefix
 }
 
 func (m createdataguardassociationdetails) String() string {

--- a/database/create_data_guard_association_to_existing_db_system_details.go
+++ b/database/create_data_guard_association_to_existing_db_system_details.go
@@ -30,6 +30,12 @@ type CreateDataGuardAssociationToExistingDbSystemDetails struct {
 	// The database software image OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm)
 	DatabaseSoftwareImageId *string `mandatory:"false" json:"databaseSoftwareImageId"`
 
+	// Specifies the `DB_UNIQUE_NAME` of the peer database to be created.
+	PeerDbUniqueName *string `mandatory:"false" json:"peerDbUniqueName"`
+
+	// Specifies a prefix for the `Oracle SID` of the database to be created.
+	PeerSidPrefix *string `mandatory:"false" json:"peerSidPrefix"`
+
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the DB system in which to create the standby database.
 	// You must supply this value if creationType is `ExistingDbSystem`.
 	PeerDbSystemId *string `mandatory:"false" json:"peerDbSystemId"`
@@ -73,6 +79,16 @@ func (m CreateDataGuardAssociationToExistingDbSystemDetails) GetProtectionMode()
 //GetTransportType returns TransportType
 func (m CreateDataGuardAssociationToExistingDbSystemDetails) GetTransportType() CreateDataGuardAssociationDetailsTransportTypeEnum {
 	return m.TransportType
+}
+
+//GetPeerDbUniqueName returns PeerDbUniqueName
+func (m CreateDataGuardAssociationToExistingDbSystemDetails) GetPeerDbUniqueName() *string {
+	return m.PeerDbUniqueName
+}
+
+//GetPeerSidPrefix returns PeerSidPrefix
+func (m CreateDataGuardAssociationToExistingDbSystemDetails) GetPeerSidPrefix() *string {
+	return m.PeerSidPrefix
 }
 
 func (m CreateDataGuardAssociationToExistingDbSystemDetails) String() string {

--- a/database/create_data_guard_association_to_existing_vm_cluster_details.go
+++ b/database/create_data_guard_association_to_existing_vm_cluster_details.go
@@ -29,6 +29,12 @@ type CreateDataGuardAssociationToExistingVmClusterDetails struct {
 	// The database software image OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm)
 	DatabaseSoftwareImageId *string `mandatory:"false" json:"databaseSoftwareImageId"`
 
+	// Specifies the `DB_UNIQUE_NAME` of the peer database to be created.
+	PeerDbUniqueName *string `mandatory:"false" json:"peerDbUniqueName"`
+
+	// Specifies a prefix for the `Oracle SID` of the database to be created.
+	PeerSidPrefix *string `mandatory:"false" json:"peerSidPrefix"`
+
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM Cluster in which to create the standby database.
 	// You must supply this value if creationType is `ExistingVmCluster`.
 	PeerVmClusterId *string `mandatory:"false" json:"peerVmClusterId"`
@@ -72,6 +78,16 @@ func (m CreateDataGuardAssociationToExistingVmClusterDetails) GetProtectionMode(
 //GetTransportType returns TransportType
 func (m CreateDataGuardAssociationToExistingVmClusterDetails) GetTransportType() CreateDataGuardAssociationDetailsTransportTypeEnum {
 	return m.TransportType
+}
+
+//GetPeerDbUniqueName returns PeerDbUniqueName
+func (m CreateDataGuardAssociationToExistingVmClusterDetails) GetPeerDbUniqueName() *string {
+	return m.PeerDbUniqueName
+}
+
+//GetPeerSidPrefix returns PeerSidPrefix
+func (m CreateDataGuardAssociationToExistingVmClusterDetails) GetPeerSidPrefix() *string {
+	return m.PeerSidPrefix
 }
 
 func (m CreateDataGuardAssociationToExistingVmClusterDetails) String() string {

--- a/database/create_data_guard_association_with_new_db_system_details.go
+++ b/database/create_data_guard_association_with_new_db_system_details.go
@@ -30,6 +30,12 @@ type CreateDataGuardAssociationWithNewDbSystemDetails struct {
 	// The database software image OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm)
 	DatabaseSoftwareImageId *string `mandatory:"false" json:"databaseSoftwareImageId"`
 
+	// Specifies the `DB_UNIQUE_NAME` of the peer database to be created.
+	PeerDbUniqueName *string `mandatory:"false" json:"peerDbUniqueName"`
+
+	// Specifies a prefix for the `Oracle SID` of the database to be created.
+	PeerSidPrefix *string `mandatory:"false" json:"peerSidPrefix"`
+
 	// The user-friendly name of the DB system that will contain the the standby database. The display name does not have to be unique.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
@@ -95,6 +101,16 @@ func (m CreateDataGuardAssociationWithNewDbSystemDetails) GetProtectionMode() Cr
 //GetTransportType returns TransportType
 func (m CreateDataGuardAssociationWithNewDbSystemDetails) GetTransportType() CreateDataGuardAssociationDetailsTransportTypeEnum {
 	return m.TransportType
+}
+
+//GetPeerDbUniqueName returns PeerDbUniqueName
+func (m CreateDataGuardAssociationWithNewDbSystemDetails) GetPeerDbUniqueName() *string {
+	return m.PeerDbUniqueName
+}
+
+//GetPeerSidPrefix returns PeerSidPrefix
+func (m CreateDataGuardAssociationWithNewDbSystemDetails) GetPeerSidPrefix() *string {
+	return m.PeerSidPrefix
 }
 
 func (m CreateDataGuardAssociationWithNewDbSystemDetails) String() string {

--- a/database/create_database_details.go
+++ b/database/create_database_details.go
@@ -56,6 +56,9 @@ type CreateDatabaseDetails struct {
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Specifies a prefix for the `Oracle SID` of the database to be created.
+	SidPrefix *string `mandatory:"false" json:"sidPrefix"`
 }
 
 func (m CreateDatabaseDetails) String() string {

--- a/database/create_database_from_backup_details.go
+++ b/database/create_database_from_backup_details.go
@@ -30,6 +30,9 @@ type CreateDatabaseFromBackupDetails struct {
 
 	// The display name of the database to be created from the backup. It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted.
 	DbName *string `mandatory:"false" json:"dbName"`
+
+	// Specifies a prefix for the `Oracle SID` of the database to be created.
+	SidPrefix *string `mandatory:"false" json:"sidPrefix"`
 }
 
 func (m CreateDatabaseFromBackupDetails) String() string {

--- a/database/create_db_home_from_backup_details.go
+++ b/database/create_db_home_from_backup_details.go
@@ -21,6 +21,9 @@ type CreateDbHomeFromBackupDetails struct {
 	// The user-provided name of the Database Home.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
+	// The database software image OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the image to be used to restore a database.
+	DatabaseSoftwareImageId *string `mandatory:"false" json:"databaseSoftwareImageId"`
+
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`

--- a/database/create_vm_cluster_details.go
+++ b/database/create_vm_cluster_details.go
@@ -59,6 +59,9 @@ type CreateVmClusterDetails struct {
 	// The time zone to use for the VM cluster. For details, see DB System Time Zones (https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
 	TimeZone *string `mandatory:"false" json:"timeZone"`
 
+	// The list of Db server.
+	DbServers []string `mandatory:"false" json:"dbServers"`
+
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`

--- a/database/database.go
+++ b/database/database.go
@@ -84,7 +84,13 @@ type Database struct {
 	// The database software image OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm)
 	DatabaseSoftwareImageId *string `mandatory:"false" json:"databaseSoftwareImageId"`
 
+	// True if the database is a container database.
+	IsCdb *bool `mandatory:"false" json:"isCdb"`
+
 	DatabaseManagementConfig *CloudDatabaseManagementConfig `mandatory:"false" json:"databaseManagementConfig"`
+
+	// Specifies a prefix for the `Oracle SID` of the database to be created.
+	SidPrefix *string `mandatory:"false" json:"sidPrefix"`
 }
 
 func (m Database) String() string {
@@ -101,6 +107,7 @@ const (
 	DatabaseLifecycleStateUpdating         DatabaseLifecycleStateEnum = "UPDATING"
 	DatabaseLifecycleStateBackupInProgress DatabaseLifecycleStateEnum = "BACKUP_IN_PROGRESS"
 	DatabaseLifecycleStateUpgrading        DatabaseLifecycleStateEnum = "UPGRADING"
+	DatabaseLifecycleStateConverting       DatabaseLifecycleStateEnum = "CONVERTING"
 	DatabaseLifecycleStateTerminating      DatabaseLifecycleStateEnum = "TERMINATING"
 	DatabaseLifecycleStateTerminated       DatabaseLifecycleStateEnum = "TERMINATED"
 	DatabaseLifecycleStateRestoreFailed    DatabaseLifecycleStateEnum = "RESTORE_FAILED"
@@ -113,6 +120,7 @@ var mappingDatabaseLifecycleState = map[string]DatabaseLifecycleStateEnum{
 	"UPDATING":           DatabaseLifecycleStateUpdating,
 	"BACKUP_IN_PROGRESS": DatabaseLifecycleStateBackupInProgress,
 	"UPGRADING":          DatabaseLifecycleStateUpgrading,
+	"CONVERTING":         DatabaseLifecycleStateConverting,
 	"TERMINATING":        DatabaseLifecycleStateTerminating,
 	"TERMINATED":         DatabaseLifecycleStateTerminated,
 	"RESTORE_FAILED":     DatabaseLifecycleStateRestoreFailed,

--- a/database/database_client.go
+++ b/database/database_client.go
@@ -50,6 +50,9 @@ func NewDatabaseClientWithOboToken(configProvider common.ConfigurationProvider, 
 }
 
 func newDatabaseClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client DatabaseClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = DatabaseClient{BaseClient: baseClient}
 	client.BasePath = "20160918"
 	err = client.setConfigurationProvider(configProvider)
@@ -187,6 +190,66 @@ func (client DatabaseClient) addStorageCapacityExadataInfrastructure(ctx context
 	}
 
 	var response AddStorageCapacityExadataInfrastructureResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// AddVirtualMachineToVmCluster Add Virtual Machines to the VM cluster. Applies to Exadata Cloud@Customer instances only.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/database/AddVirtualMachineToVmCluster.go.html to see an example of how to use AddVirtualMachineToVmCluster API.
+func (client DatabaseClient) AddVirtualMachineToVmCluster(ctx context.Context, request AddVirtualMachineToVmClusterRequest) (response AddVirtualMachineToVmClusterResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.addVirtualMachineToVmCluster, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = AddVirtualMachineToVmClusterResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = AddVirtualMachineToVmClusterResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(AddVirtualMachineToVmClusterResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into AddVirtualMachineToVmClusterResponse")
+	}
+	return
+}
+
+// addVirtualMachineToVmCluster implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) addVirtualMachineToVmCluster(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/vmClusters/{vmClusterId}/actions/addVirtualMachine", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AddVirtualMachineToVmClusterResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -1354,6 +1417,61 @@ func (client DatabaseClient) configureAutonomousDatabaseVaultKey(ctx context.Con
 	}
 
 	var response ConfigureAutonomousDatabaseVaultKeyResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ConvertToPdb Converts a non-container database to a pluggable database.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/database/ConvertToPdb.go.html to see an example of how to use ConvertToPdb API.
+func (client DatabaseClient) ConvertToPdb(ctx context.Context, request ConvertToPdbRequest) (response ConvertToPdbResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.convertToPdb, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ConvertToPdbResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ConvertToPdbResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ConvertToPdbResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ConvertToPdbResponse")
+	}
+	return
+}
+
+// convertToPdb implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) convertToPdb(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/databases/{databaseId}/actions/convertToPdb", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ConvertToPdbResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -6679,6 +6797,61 @@ func (client DatabaseClient) getDbNode(ctx context.Context, request common.OCIRe
 	return response, err
 }
 
+// GetDbServer Gets information about the Exadata Db server.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/database/GetDbServer.go.html to see an example of how to use GetDbServer API.
+func (client DatabaseClient) GetDbServer(ctx context.Context, request GetDbServerRequest) (response GetDbServerResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getDbServer, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetDbServerResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetDbServerResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetDbServerResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetDbServerResponse")
+	}
+	return
+}
+
+// getDbServer implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) getDbServer(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/dbServers/{dbServerId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetDbServerResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // GetDbSystem Gets information about the specified DB system.
 // **Note:** Deprecated for Exadata Cloud Service systems. Use the new resource model APIs (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/exaflexsystem.htm#exaflexsystem_topic-resource_model) instead.
 // For Exadata Cloud Service instances, support for this API will end on May 15th, 2021. See Switching an Exadata DB System to the New Resource Model and APIs (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/exaflexsystem_topic-resource_model_conversion.htm) for details on converting existing Exadata DB systems to the new resource model.
@@ -7392,6 +7565,61 @@ func (client DatabaseClient) getMaintenanceRun(ctx context.Context, request comm
 	}
 
 	var response GetMaintenanceRunResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetPdbConversionHistoryEntry Gets the details of operations performed to convert the specified database from non-container (non-CDB) to pluggable (PDB).
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/database/GetPdbConversionHistoryEntry.go.html to see an example of how to use GetPdbConversionHistoryEntry API.
+func (client DatabaseClient) GetPdbConversionHistoryEntry(ctx context.Context, request GetPdbConversionHistoryEntryRequest) (response GetPdbConversionHistoryEntryResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getPdbConversionHistoryEntry, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetPdbConversionHistoryEntryResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetPdbConversionHistoryEntryResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetPdbConversionHistoryEntryResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetPdbConversionHistoryEntryResponse")
+	}
+	return
+}
+
+// getPdbConversionHistoryEntry implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) getPdbConversionHistoryEntry(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/databases/{databaseId}/pdbConversionHistoryEntries/{pdbConversionHistoryEntryId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetPdbConversionHistoryEntryResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -9402,6 +9630,61 @@ func (client DatabaseClient) listDbNodes(ctx context.Context, request common.OCI
 	return response, err
 }
 
+// ListDbServers Lists the Exadata DB servers in the ExadataInfrastructureId and specified compartment.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/database/ListDbServers.go.html to see an example of how to use ListDbServers API.
+func (client DatabaseClient) ListDbServers(ctx context.Context, request ListDbServersRequest) (response ListDbServersResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listDbServers, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListDbServersResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListDbServersResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListDbServersResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListDbServersResponse")
+	}
+	return
+}
+
+// listDbServers implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) listDbServers(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/dbServers", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListDbServersResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // ListDbSystemPatchHistoryEntries Gets the history of the patch actions performed on the specified DB system.
 //
 // See also
@@ -10180,6 +10463,61 @@ func (client DatabaseClient) listMaintenanceRuns(ctx context.Context, request co
 	}
 
 	var response ListMaintenanceRunsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListPdbConversionHistoryEntries Gets the pluggable database conversion history for a specified database in a bare metal or virtual machine DB system.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/database/ListPdbConversionHistoryEntries.go.html to see an example of how to use ListPdbConversionHistoryEntries API.
+func (client DatabaseClient) ListPdbConversionHistoryEntries(ctx context.Context, request ListPdbConversionHistoryEntriesRequest) (response ListPdbConversionHistoryEntriesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listPdbConversionHistoryEntries, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListPdbConversionHistoryEntriesResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListPdbConversionHistoryEntriesResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListPdbConversionHistoryEntriesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListPdbConversionHistoryEntriesResponse")
+	}
+	return
+}
+
+// listPdbConversionHistoryEntries implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) listPdbConversionHistoryEntries(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/databases/{databaseId}/pdbConversionHistoryEntries", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListPdbConversionHistoryEntriesResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -11032,6 +11370,66 @@ func (client DatabaseClient) remoteClonePluggableDatabase(ctx context.Context, r
 	}
 
 	var response RemoteClonePluggableDatabaseResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// RemoveVirtualMachineFromVmCluster Remove Virtual Machines from the VM cluster. Applies to Exadata Cloud@Customer instances only.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/database/RemoveVirtualMachineFromVmCluster.go.html to see an example of how to use RemoveVirtualMachineFromVmCluster API.
+func (client DatabaseClient) RemoveVirtualMachineFromVmCluster(ctx context.Context, request RemoveVirtualMachineFromVmClusterRequest) (response RemoveVirtualMachineFromVmClusterResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.removeVirtualMachineFromVmCluster, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = RemoveVirtualMachineFromVmClusterResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = RemoveVirtualMachineFromVmClusterResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(RemoveVirtualMachineFromVmClusterResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into RemoveVirtualMachineFromVmClusterResponse")
+	}
+	return
+}
+
+// removeVirtualMachineFromVmCluster implements the OCIOperation interface (enables retrying operations)
+func (client DatabaseClient) removeVirtualMachineFromVmCluster(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/vmClusters/{vmClusterId}/actions/removeVirtualMachine", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response RemoveVirtualMachineFromVmClusterResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)

--- a/database/database_summary.go
+++ b/database/database_summary.go
@@ -86,7 +86,13 @@ type DatabaseSummary struct {
 	// The database software image OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm)
 	DatabaseSoftwareImageId *string `mandatory:"false" json:"databaseSoftwareImageId"`
 
+	// True if the database is a container database.
+	IsCdb *bool `mandatory:"false" json:"isCdb"`
+
 	DatabaseManagementConfig *CloudDatabaseManagementConfig `mandatory:"false" json:"databaseManagementConfig"`
+
+	// Specifies a prefix for the `Oracle SID` of the database to be created.
+	SidPrefix *string `mandatory:"false" json:"sidPrefix"`
 }
 
 func (m DatabaseSummary) String() string {
@@ -103,6 +109,7 @@ const (
 	DatabaseSummaryLifecycleStateUpdating         DatabaseSummaryLifecycleStateEnum = "UPDATING"
 	DatabaseSummaryLifecycleStateBackupInProgress DatabaseSummaryLifecycleStateEnum = "BACKUP_IN_PROGRESS"
 	DatabaseSummaryLifecycleStateUpgrading        DatabaseSummaryLifecycleStateEnum = "UPGRADING"
+	DatabaseSummaryLifecycleStateConverting       DatabaseSummaryLifecycleStateEnum = "CONVERTING"
 	DatabaseSummaryLifecycleStateTerminating      DatabaseSummaryLifecycleStateEnum = "TERMINATING"
 	DatabaseSummaryLifecycleStateTerminated       DatabaseSummaryLifecycleStateEnum = "TERMINATED"
 	DatabaseSummaryLifecycleStateRestoreFailed    DatabaseSummaryLifecycleStateEnum = "RESTORE_FAILED"
@@ -115,6 +122,7 @@ var mappingDatabaseSummaryLifecycleState = map[string]DatabaseSummaryLifecycleSt
 	"UPDATING":           DatabaseSummaryLifecycleStateUpdating,
 	"BACKUP_IN_PROGRESS": DatabaseSummaryLifecycleStateBackupInProgress,
 	"UPGRADING":          DatabaseSummaryLifecycleStateUpgrading,
+	"CONVERTING":         DatabaseSummaryLifecycleStateConverting,
 	"TERMINATING":        DatabaseSummaryLifecycleStateTerminating,
 	"TERMINATED":         DatabaseSummaryLifecycleStateTerminated,
 	"RESTORE_FAILED":     DatabaseSummaryLifecycleStateRestoreFailed,

--- a/database/db_node.go
+++ b/database/db_node.go
@@ -70,6 +70,18 @@ type DbNode struct {
 
 	// Additional information about the planned maintenance.
 	AdditionalDetails *string `mandatory:"false" json:"additionalDetails"`
+
+	// The number of CPU cores enabled on the Db node.
+	CpuCoreCount *int `mandatory:"false" json:"cpuCoreCount"`
+
+	// The allocated memory in GBs on the Db node.
+	MemorySizeInGBs *int `mandatory:"false" json:"memorySizeInGBs"`
+
+	// The allocated local node storage in GBs on the Db node.
+	DbNodeStorageSizeInGBs *int `mandatory:"false" json:"dbNodeStorageSizeInGBs"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exacc Db server associated with the database node.
+	DbServerId *string `mandatory:"false" json:"dbServerId"`
 }
 
 func (m DbNode) String() string {

--- a/database/db_node_summary.go
+++ b/database/db_node_summary.go
@@ -72,6 +72,18 @@ type DbNodeSummary struct {
 
 	// Additional information about the planned maintenance.
 	AdditionalDetails *string `mandatory:"false" json:"additionalDetails"`
+
+	// The number of CPU cores enabled on the Db node.
+	CpuCoreCount *int `mandatory:"false" json:"cpuCoreCount"`
+
+	// The allocated memory in GBs on the Db node.
+	MemorySizeInGBs *int `mandatory:"false" json:"memorySizeInGBs"`
+
+	// The allocated local node storage in GBs on the Db node.
+	DbNodeStorageSizeInGBs *int `mandatory:"false" json:"dbNodeStorageSizeInGBs"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exacc Db server associated with the database node.
+	DbServerId *string `mandatory:"false" json:"dbServerId"`
 }
 
 func (m DbNodeSummary) String() string {

--- a/database/db_server.go
+++ b/database/db_server.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+)
+
+// DbServer Details of the Exacc Db server resource. Applies to Exadata Cloud@Customer instances only.
+type DbServer struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exacc Db server.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The user-friendly name for the Db server. The name does not need to be unique.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+	ExadataInfrastructureId *string `mandatory:"false" json:"exadataInfrastructureId"`
+
+	// The number of CPU cores enabled on the Db server.
+	CpuCoreCount *int `mandatory:"false" json:"cpuCoreCount"`
+
+	// The allocated memory in GBs on the Db server.
+	MemorySizeInGBs *int `mandatory:"false" json:"memorySizeInGBs"`
+
+	// The allocated local node storage in GBs on the Db server.
+	DbNodeStorageSizeInGBs *int `mandatory:"false" json:"dbNodeStorageSizeInGBs"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM Clusters associated with the Db server.
+	VmClusterIds []string `mandatory:"false" json:"vmClusterIds"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Db nodes associated with the Db server.
+	DbNodeIds []string `mandatory:"false" json:"dbNodeIds"`
+
+	// The current state of the Db server.
+	LifecycleState DbServerLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Additional information about the current lifecycle state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The total number of CPU cores available.
+	MaxCpuCount *int `mandatory:"false" json:"maxCpuCount"`
+
+	// The total memory available in GBs.
+	MaxMemoryInGBs *int `mandatory:"false" json:"maxMemoryInGBs"`
+
+	// The total local node storage available in GBs.
+	MaxDbNodeStorageInGBs *int `mandatory:"false" json:"maxDbNodeStorageInGBs"`
+
+	// The date and time that the Db Server was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m DbServer) String() string {
+	return common.PointerString(m)
+}
+
+// DbServerLifecycleStateEnum Enum with underlying type: string
+type DbServerLifecycleStateEnum string
+
+// Set of constants representing the allowable values for DbServerLifecycleStateEnum
+const (
+	DbServerLifecycleStateCreating              DbServerLifecycleStateEnum = "CREATING"
+	DbServerLifecycleStateAvailable             DbServerLifecycleStateEnum = "AVAILABLE"
+	DbServerLifecycleStateUnavailable           DbServerLifecycleStateEnum = "UNAVAILABLE"
+	DbServerLifecycleStateDeleting              DbServerLifecycleStateEnum = "DELETING"
+	DbServerLifecycleStateDeleted               DbServerLifecycleStateEnum = "DELETED"
+	DbServerLifecycleStateMaintenanceInProgress DbServerLifecycleStateEnum = "MAINTENANCE_IN_PROGRESS"
+)
+
+var mappingDbServerLifecycleState = map[string]DbServerLifecycleStateEnum{
+	"CREATING":                DbServerLifecycleStateCreating,
+	"AVAILABLE":               DbServerLifecycleStateAvailable,
+	"UNAVAILABLE":             DbServerLifecycleStateUnavailable,
+	"DELETING":                DbServerLifecycleStateDeleting,
+	"DELETED":                 DbServerLifecycleStateDeleted,
+	"MAINTENANCE_IN_PROGRESS": DbServerLifecycleStateMaintenanceInProgress,
+}
+
+// GetDbServerLifecycleStateEnumValues Enumerates the set of values for DbServerLifecycleStateEnum
+func GetDbServerLifecycleStateEnumValues() []DbServerLifecycleStateEnum {
+	values := make([]DbServerLifecycleStateEnum, 0)
+	for _, v := range mappingDbServerLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/db_server_details.go
+++ b/database/db_server_details.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+)
+
+// DbServerDetails Details of the Exacc Db server. Applies to Exadata Cloud@Customer instances only.
+type DbServerDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of Exacc Db server.
+	DbServerId *string `mandatory:"true" json:"dbServerId"`
+}
+
+func (m DbServerDetails) String() string {
+	return common.PointerString(m)
+}

--- a/database/db_server_summary.go
+++ b/database/db_server_summary.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+)
+
+// DbServerSummary Details of the Exadata Cloud@Customer Db server.
+type DbServerSummary struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exacc Db server.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The user-friendly name for the Db server. The name does not need to be unique.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+	ExadataInfrastructureId *string `mandatory:"false" json:"exadataInfrastructureId"`
+
+	// The number of CPU cores enabled on the Db server.
+	CpuCoreCount *int `mandatory:"false" json:"cpuCoreCount"`
+
+	// The allocated memory in GBs on the Db server.
+	MemorySizeInGBs *int `mandatory:"false" json:"memorySizeInGBs"`
+
+	// The allocated local node storage in GBs on the Db server.
+	DbNodeStorageSizeInGBs *int `mandatory:"false" json:"dbNodeStorageSizeInGBs"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM Clusters associated with the Db server.
+	VmClusterIds []string `mandatory:"false" json:"vmClusterIds"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Db nodes associated with the Db server.
+	DbNodeIds []string `mandatory:"false" json:"dbNodeIds"`
+
+	// The current state of the Db server.
+	LifecycleState DbServerSummaryLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Additional information about the current lifecycle state.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The total number of CPU cores available.
+	MaxCpuCount *int `mandatory:"false" json:"maxCpuCount"`
+
+	// The total memory available in GBs.
+	MaxMemoryInGBs *int `mandatory:"false" json:"maxMemoryInGBs"`
+
+	// The total local node storage available in GBs.
+	MaxDbNodeStorageInGBs *int `mandatory:"false" json:"maxDbNodeStorageInGBs"`
+
+	// The date and time that the Db Server was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m DbServerSummary) String() string {
+	return common.PointerString(m)
+}
+
+// DbServerSummaryLifecycleStateEnum Enum with underlying type: string
+type DbServerSummaryLifecycleStateEnum string
+
+// Set of constants representing the allowable values for DbServerSummaryLifecycleStateEnum
+const (
+	DbServerSummaryLifecycleStateCreating              DbServerSummaryLifecycleStateEnum = "CREATING"
+	DbServerSummaryLifecycleStateAvailable             DbServerSummaryLifecycleStateEnum = "AVAILABLE"
+	DbServerSummaryLifecycleStateUnavailable           DbServerSummaryLifecycleStateEnum = "UNAVAILABLE"
+	DbServerSummaryLifecycleStateDeleting              DbServerSummaryLifecycleStateEnum = "DELETING"
+	DbServerSummaryLifecycleStateDeleted               DbServerSummaryLifecycleStateEnum = "DELETED"
+	DbServerSummaryLifecycleStateMaintenanceInProgress DbServerSummaryLifecycleStateEnum = "MAINTENANCE_IN_PROGRESS"
+)
+
+var mappingDbServerSummaryLifecycleState = map[string]DbServerSummaryLifecycleStateEnum{
+	"CREATING":                DbServerSummaryLifecycleStateCreating,
+	"AVAILABLE":               DbServerSummaryLifecycleStateAvailable,
+	"UNAVAILABLE":             DbServerSummaryLifecycleStateUnavailable,
+	"DELETING":                DbServerSummaryLifecycleStateDeleting,
+	"DELETED":                 DbServerSummaryLifecycleStateDeleted,
+	"MAINTENANCE_IN_PROGRESS": DbServerSummaryLifecycleStateMaintenanceInProgress,
+}
+
+// GetDbServerSummaryLifecycleStateEnumValues Enumerates the set of values for DbServerSummaryLifecycleStateEnum
+func GetDbServerSummaryLifecycleStateEnumValues() []DbServerSummaryLifecycleStateEnum {
+	values := make([]DbServerSummaryLifecycleStateEnum, 0)
+	for _, v := range mappingDbServerSummaryLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/get_db_server_request_response.go
+++ b/database/get_db_server_request_response.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+	"net/http"
+)
+
+// GetDbServerRequest wrapper for the GetDbServer operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/database/GetDbServer.go.html to see an example of how to use GetDbServerRequest.
+type GetDbServerRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the ExadataInfrastructure.
+	ExadataInfrastructureId *string `mandatory:"true" contributesTo:"query" name:"exadataInfrastructureId"`
+
+	// The DB server OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	DbServerId *string `mandatory:"true" contributesTo:"path" name:"dbServerId"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetDbServerRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetDbServerRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetDbServerRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetDbServerRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetDbServerResponse wrapper for the GetDbServer operation
+type GetDbServerResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The DbServer instance
+	DbServer `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetDbServerResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetDbServerResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/get_pdb_conversion_history_entry_request_response.go
+++ b/database/get_pdb_conversion_history_entry_request_response.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+	"net/http"
+)
+
+// GetPdbConversionHistoryEntryRequest wrapper for the GetPdbConversionHistoryEntry operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/database/GetPdbConversionHistoryEntry.go.html to see an example of how to use GetPdbConversionHistoryEntryRequest.
+type GetPdbConversionHistoryEntryRequest struct {
+
+	// The database OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	DatabaseId *string `mandatory:"true" contributesTo:"path" name:"databaseId"`
+
+	// The database conversion history OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	PdbConversionHistoryEntryId *string `mandatory:"true" contributesTo:"path" name:"pdbConversionHistoryEntryId"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetPdbConversionHistoryEntryRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetPdbConversionHistoryEntryRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetPdbConversionHistoryEntryRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetPdbConversionHistoryEntryRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetPdbConversionHistoryEntryResponse wrapper for the GetPdbConversionHistoryEntry operation
+type GetPdbConversionHistoryEntryResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The PdbConversionHistoryEntry instance
+	PdbConversionHistoryEntry `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetPdbConversionHistoryEntryResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetPdbConversionHistoryEntryResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/list_db_nodes_request_response.go
+++ b/database/list_db_nodes_request_response.go
@@ -40,6 +40,9 @@ type ListDbNodesRequest struct {
 	// A filter to return only resources that match the given lifecycle state exactly.
 	LifecycleState DbNodeSummaryLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exacc Db server.
+	DbServerId *string `mandatory:"false" contributesTo:"query" name:"dbServerId"`
+
 	// Unique Oracle-assigned identifier for the request.
 	// If you need to contact Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`

--- a/database/list_db_servers_request_response.go
+++ b/database/list_db_servers_request_response.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+	"net/http"
+)
+
+// ListDbServersRequest wrapper for the ListDbServers operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/database/ListDbServers.go.html to see an example of how to use ListDbServersRequest.
+type ListDbServersRequest struct {
+
+	// The compartment OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the ExadataInfrastructure.
+	ExadataInfrastructureId *string `mandatory:"true" contributesTo:"query" name:"exadataInfrastructureId"`
+
+	// The maximum number of items to return per page.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The pagination token to continue listing from.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+	SortOrder ListDbServersSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Sort by TIMECREATED.  Default order for TIMECREATED is descending.
+	SortBy ListDbServersSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// A filter to return only resources that match the given lifecycle state exactly.
+	LifecycleState DbServerSummaryLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+
+	// A filter to return only resources that match the entire display name given. The match is not case sensitive.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListDbServersRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListDbServersRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListDbServersRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListDbServersRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListDbServersResponse wrapper for the ListDbServers operation
+type ListDbServersResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []DbServerSummary instances
+	Items []DbServerSummary `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then there are additional items still to get. Include this value as the `page` parameter for the
+	// subsequent GET request. For information about pagination, see
+	// List Pagination (https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListDbServersResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListDbServersResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListDbServersSortOrderEnum Enum with underlying type: string
+type ListDbServersSortOrderEnum string
+
+// Set of constants representing the allowable values for ListDbServersSortOrderEnum
+const (
+	ListDbServersSortOrderAsc  ListDbServersSortOrderEnum = "ASC"
+	ListDbServersSortOrderDesc ListDbServersSortOrderEnum = "DESC"
+)
+
+var mappingListDbServersSortOrder = map[string]ListDbServersSortOrderEnum{
+	"ASC":  ListDbServersSortOrderAsc,
+	"DESC": ListDbServersSortOrderDesc,
+}
+
+// GetListDbServersSortOrderEnumValues Enumerates the set of values for ListDbServersSortOrderEnum
+func GetListDbServersSortOrderEnumValues() []ListDbServersSortOrderEnum {
+	values := make([]ListDbServersSortOrderEnum, 0)
+	for _, v := range mappingListDbServersSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListDbServersSortByEnum Enum with underlying type: string
+type ListDbServersSortByEnum string
+
+// Set of constants representing the allowable values for ListDbServersSortByEnum
+const (
+	ListDbServersSortByTimecreated ListDbServersSortByEnum = "TIMECREATED"
+)
+
+var mappingListDbServersSortBy = map[string]ListDbServersSortByEnum{
+	"TIMECREATED": ListDbServersSortByTimecreated,
+}
+
+// GetListDbServersSortByEnumValues Enumerates the set of values for ListDbServersSortByEnum
+func GetListDbServersSortByEnumValues() []ListDbServersSortByEnum {
+	values := make([]ListDbServersSortByEnum, 0)
+	for _, v := range mappingListDbServersSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/list_pdb_conversion_history_entries_request_response.go
+++ b/database/list_pdb_conversion_history_entries_request_response.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+	"net/http"
+)
+
+// ListPdbConversionHistoryEntriesRequest wrapper for the ListPdbConversionHistoryEntries operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/database/ListPdbConversionHistoryEntries.go.html to see an example of how to use ListPdbConversionHistoryEntriesRequest.
+type ListPdbConversionHistoryEntriesRequest struct {
+
+	// The database OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	DatabaseId *string `mandatory:"true" contributesTo:"path" name:"databaseId"`
+
+	// A filter to return only the pluggable database conversion history entries that match the specified conversion action. For example, you can use this filter to return only entries for the precheck operation.
+	PdbConversionAction PdbConversionHistoryEntrySummaryActionEnum `mandatory:"false" contributesTo:"query" name:"pdbConversionAction" omitEmpty:"true"`
+
+	// A filter to return only the pluggable database conversion history entries that match the specified lifecycle state. For example, you can use this filter to return only entries in the "failed" lifecycle state.
+	LifecycleState PdbConversionHistoryEntrySummaryLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+
+	// The field to sort by. You can provide one sort order (`sortOrder`). The default order for `TIMECREATED` is ascending.
+	SortBy ListPdbConversionHistoryEntriesSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+	SortOrder ListPdbConversionHistoryEntriesSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The maximum number of items to return per page.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The pagination token to continue listing from.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListPdbConversionHistoryEntriesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListPdbConversionHistoryEntriesRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListPdbConversionHistoryEntriesRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListPdbConversionHistoryEntriesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListPdbConversionHistoryEntriesResponse wrapper for the ListPdbConversionHistoryEntries operation
+type ListPdbConversionHistoryEntriesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []PdbConversionHistoryEntrySummary instances
+	Items []PdbConversionHistoryEntrySummary `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then there are additional items still to get. Include this value as the `page` parameter for the
+	// subsequent GET request. For information about pagination, see
+	// List Pagination (https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+}
+
+func (response ListPdbConversionHistoryEntriesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListPdbConversionHistoryEntriesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListPdbConversionHistoryEntriesSortByEnum Enum with underlying type: string
+type ListPdbConversionHistoryEntriesSortByEnum string
+
+// Set of constants representing the allowable values for ListPdbConversionHistoryEntriesSortByEnum
+const (
+	ListPdbConversionHistoryEntriesSortByTimestarted ListPdbConversionHistoryEntriesSortByEnum = "TIMESTARTED"
+)
+
+var mappingListPdbConversionHistoryEntriesSortBy = map[string]ListPdbConversionHistoryEntriesSortByEnum{
+	"TIMESTARTED": ListPdbConversionHistoryEntriesSortByTimestarted,
+}
+
+// GetListPdbConversionHistoryEntriesSortByEnumValues Enumerates the set of values for ListPdbConversionHistoryEntriesSortByEnum
+func GetListPdbConversionHistoryEntriesSortByEnumValues() []ListPdbConversionHistoryEntriesSortByEnum {
+	values := make([]ListPdbConversionHistoryEntriesSortByEnum, 0)
+	for _, v := range mappingListPdbConversionHistoryEntriesSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListPdbConversionHistoryEntriesSortOrderEnum Enum with underlying type: string
+type ListPdbConversionHistoryEntriesSortOrderEnum string
+
+// Set of constants representing the allowable values for ListPdbConversionHistoryEntriesSortOrderEnum
+const (
+	ListPdbConversionHistoryEntriesSortOrderAsc  ListPdbConversionHistoryEntriesSortOrderEnum = "ASC"
+	ListPdbConversionHistoryEntriesSortOrderDesc ListPdbConversionHistoryEntriesSortOrderEnum = "DESC"
+)
+
+var mappingListPdbConversionHistoryEntriesSortOrder = map[string]ListPdbConversionHistoryEntriesSortOrderEnum{
+	"ASC":  ListPdbConversionHistoryEntriesSortOrderAsc,
+	"DESC": ListPdbConversionHistoryEntriesSortOrderDesc,
+}
+
+// GetListPdbConversionHistoryEntriesSortOrderEnumValues Enumerates the set of values for ListPdbConversionHistoryEntriesSortOrderEnum
+func GetListPdbConversionHistoryEntriesSortOrderEnumValues() []ListPdbConversionHistoryEntriesSortOrderEnum {
+	values := make([]ListPdbConversionHistoryEntriesSortOrderEnum, 0)
+	for _, v := range mappingListPdbConversionHistoryEntriesSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/pdb_conversion_history_entry.go
+++ b/database/pdb_conversion_history_entry.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+)
+
+// PdbConversionHistoryEntry Details of operations performed to convert a non-container database to pluggable database.
+type PdbConversionHistoryEntry struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the database conversion history.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The operations used to convert a non-container database to a pluggable database.
+	// - Use `PRECHECK` to run a pre-check operation on non-container database prior to converting it into a pluggable database.
+	// - Use `CONVERT` to convert a non-container database into a pluggable database.
+	// - Use `SYNC` if the non-container database was manually converted into a pluggable database using the dbcli command-line utility. Databases may need to be converted manually if the CONVERT action fails when converting a non-container database using the API.
+	// - Use `SYNC_ROLLBACK` if the conversion of a non-container database into a pluggable database was manually rolled back using the dbcli command line utility. Conversions may need to be manually rolled back if the CONVERT action fails when converting a non-container database using the API.
+	Action PdbConversionHistoryEntryActionEnum `mandatory:"true" json:"action"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the database.
+	SourceDatabaseId *string `mandatory:"true" json:"sourceDatabaseId"`
+
+	// The database name. The name must begin with an alphabetic character and can contain a maximum of 8 alphanumeric characters. Special characters are not permitted. The database name must be unique in the tenancy.
+	CdbName *string `mandatory:"true" json:"cdbName"`
+
+	// Status of an operation performed during the conversion of a non-container database to a pluggable database.
+	LifecycleState PdbConversionHistoryEntryLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// The date and time when the database conversion operation started.
+	TimeStarted *common.SDKTime `mandatory:"true" json:"timeStarted"`
+
+	// The target container database of the pluggable database created by the database conversion operation. Currently, the database conversion operation only supports creating the pluggable database in a new container database.
+	//  - Use `NEW_DATABASE` to specify that the pluggable database be created within a new container database in the same database home.
+	Target PdbConversionHistoryEntryTargetEnum `mandatory:"false" json:"target,omitempty"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the database.
+	TargetDatabaseId *string `mandatory:"false" json:"targetDatabaseId"`
+
+	// Additional information about the current lifecycle state for the conversion operation.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The date and time when the database conversion operation ended.
+	TimeEnded *common.SDKTime `mandatory:"false" json:"timeEnded"`
+
+	// Additional container database parameter.
+	AdditionalCdbParams *string `mandatory:"false" json:"additionalCdbParams"`
+}
+
+func (m PdbConversionHistoryEntry) String() string {
+	return common.PointerString(m)
+}
+
+// PdbConversionHistoryEntryActionEnum Enum with underlying type: string
+type PdbConversionHistoryEntryActionEnum string
+
+// Set of constants representing the allowable values for PdbConversionHistoryEntryActionEnum
+const (
+	PdbConversionHistoryEntryActionPrecheck     PdbConversionHistoryEntryActionEnum = "PRECHECK"
+	PdbConversionHistoryEntryActionConvert      PdbConversionHistoryEntryActionEnum = "CONVERT"
+	PdbConversionHistoryEntryActionSync         PdbConversionHistoryEntryActionEnum = "SYNC"
+	PdbConversionHistoryEntryActionSyncRollback PdbConversionHistoryEntryActionEnum = "SYNC_ROLLBACK"
+)
+
+var mappingPdbConversionHistoryEntryAction = map[string]PdbConversionHistoryEntryActionEnum{
+	"PRECHECK":      PdbConversionHistoryEntryActionPrecheck,
+	"CONVERT":       PdbConversionHistoryEntryActionConvert,
+	"SYNC":          PdbConversionHistoryEntryActionSync,
+	"SYNC_ROLLBACK": PdbConversionHistoryEntryActionSyncRollback,
+}
+
+// GetPdbConversionHistoryEntryActionEnumValues Enumerates the set of values for PdbConversionHistoryEntryActionEnum
+func GetPdbConversionHistoryEntryActionEnumValues() []PdbConversionHistoryEntryActionEnum {
+	values := make([]PdbConversionHistoryEntryActionEnum, 0)
+	for _, v := range mappingPdbConversionHistoryEntryAction {
+		values = append(values, v)
+	}
+	return values
+}
+
+// PdbConversionHistoryEntryTargetEnum Enum with underlying type: string
+type PdbConversionHistoryEntryTargetEnum string
+
+// Set of constants representing the allowable values for PdbConversionHistoryEntryTargetEnum
+const (
+	PdbConversionHistoryEntryTargetNewDatabase PdbConversionHistoryEntryTargetEnum = "NEW_DATABASE"
+)
+
+var mappingPdbConversionHistoryEntryTarget = map[string]PdbConversionHistoryEntryTargetEnum{
+	"NEW_DATABASE": PdbConversionHistoryEntryTargetNewDatabase,
+}
+
+// GetPdbConversionHistoryEntryTargetEnumValues Enumerates the set of values for PdbConversionHistoryEntryTargetEnum
+func GetPdbConversionHistoryEntryTargetEnumValues() []PdbConversionHistoryEntryTargetEnum {
+	values := make([]PdbConversionHistoryEntryTargetEnum, 0)
+	for _, v := range mappingPdbConversionHistoryEntryTarget {
+		values = append(values, v)
+	}
+	return values
+}
+
+// PdbConversionHistoryEntryLifecycleStateEnum Enum with underlying type: string
+type PdbConversionHistoryEntryLifecycleStateEnum string
+
+// Set of constants representing the allowable values for PdbConversionHistoryEntryLifecycleStateEnum
+const (
+	PdbConversionHistoryEntryLifecycleStateSucceeded  PdbConversionHistoryEntryLifecycleStateEnum = "SUCCEEDED"
+	PdbConversionHistoryEntryLifecycleStateFailed     PdbConversionHistoryEntryLifecycleStateEnum = "FAILED"
+	PdbConversionHistoryEntryLifecycleStateInProgress PdbConversionHistoryEntryLifecycleStateEnum = "IN_PROGRESS"
+)
+
+var mappingPdbConversionHistoryEntryLifecycleState = map[string]PdbConversionHistoryEntryLifecycleStateEnum{
+	"SUCCEEDED":   PdbConversionHistoryEntryLifecycleStateSucceeded,
+	"FAILED":      PdbConversionHistoryEntryLifecycleStateFailed,
+	"IN_PROGRESS": PdbConversionHistoryEntryLifecycleStateInProgress,
+}
+
+// GetPdbConversionHistoryEntryLifecycleStateEnumValues Enumerates the set of values for PdbConversionHistoryEntryLifecycleStateEnum
+func GetPdbConversionHistoryEntryLifecycleStateEnumValues() []PdbConversionHistoryEntryLifecycleStateEnum {
+	values := make([]PdbConversionHistoryEntryLifecycleStateEnum, 0)
+	for _, v := range mappingPdbConversionHistoryEntryLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/pdb_conversion_history_entry_summary.go
+++ b/database/pdb_conversion_history_entry_summary.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+)
+
+// PdbConversionHistoryEntrySummary Details of operations performed to convert a non-container database to pluggable database.
+type PdbConversionHistoryEntrySummary struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the database conversion history.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The operations used to convert a non-container database to a pluggable database.
+	// - Use `PRECHECK` to run a pre-check operation on non-container database prior to converting it into a pluggable database.
+	// - Use `CONVERT` to convert a non-container database into a pluggable database.
+	// - Use `SYNC` if the non-container database was manually converted into a pluggable database using the dbcli command-line utility. Databases may need to be converted manually if the CONVERT action fails when converting a non-container database using the API.
+	// - Use `SYNC_ROLLBACK` if the conversion of a non-container database into a pluggable database was manually rolled back using the dbcli command line utility. Conversions may need to be manually rolled back if the CONVERT action fails when converting a non-container database using the API.
+	Action PdbConversionHistoryEntrySummaryActionEnum `mandatory:"true" json:"action"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the database.
+	SourceDatabaseId *string `mandatory:"true" json:"sourceDatabaseId"`
+
+	// The database name. The name must begin with an alphabetic character and can contain a maximum of 8 alphanumeric characters. Special characters are not permitted. The database name must be unique in the tenancy.
+	CdbName *string `mandatory:"true" json:"cdbName"`
+
+	// Status of an operation performed during the conversion of a non-container database to a pluggable database.
+	LifecycleState PdbConversionHistoryEntrySummaryLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// The date and time when the database conversion operation started.
+	TimeStarted *common.SDKTime `mandatory:"true" json:"timeStarted"`
+
+	// The target container database of the pluggable database created by the database conversion operation. Currently, the database conversion operation only supports creating the pluggable database in a new container database.
+	//  - Use `NEW_DATABASE` to specify that the pluggable database be created within a new container database in the same database home.
+	Target PdbConversionHistoryEntrySummaryTargetEnum `mandatory:"false" json:"target,omitempty"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the database.
+	TargetDatabaseId *string `mandatory:"false" json:"targetDatabaseId"`
+
+	// Additional information about the current lifecycle state for the conversion operation.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The date and time when the database conversion operation ended.
+	TimeEnded *common.SDKTime `mandatory:"false" json:"timeEnded"`
+
+	// Additional container database parameter.
+	AdditionalCdbParams *string `mandatory:"false" json:"additionalCdbParams"`
+}
+
+func (m PdbConversionHistoryEntrySummary) String() string {
+	return common.PointerString(m)
+}
+
+// PdbConversionHistoryEntrySummaryActionEnum Enum with underlying type: string
+type PdbConversionHistoryEntrySummaryActionEnum string
+
+// Set of constants representing the allowable values for PdbConversionHistoryEntrySummaryActionEnum
+const (
+	PdbConversionHistoryEntrySummaryActionPrecheck     PdbConversionHistoryEntrySummaryActionEnum = "PRECHECK"
+	PdbConversionHistoryEntrySummaryActionConvert      PdbConversionHistoryEntrySummaryActionEnum = "CONVERT"
+	PdbConversionHistoryEntrySummaryActionSync         PdbConversionHistoryEntrySummaryActionEnum = "SYNC"
+	PdbConversionHistoryEntrySummaryActionSyncRollback PdbConversionHistoryEntrySummaryActionEnum = "SYNC_ROLLBACK"
+)
+
+var mappingPdbConversionHistoryEntrySummaryAction = map[string]PdbConversionHistoryEntrySummaryActionEnum{
+	"PRECHECK":      PdbConversionHistoryEntrySummaryActionPrecheck,
+	"CONVERT":       PdbConversionHistoryEntrySummaryActionConvert,
+	"SYNC":          PdbConversionHistoryEntrySummaryActionSync,
+	"SYNC_ROLLBACK": PdbConversionHistoryEntrySummaryActionSyncRollback,
+}
+
+// GetPdbConversionHistoryEntrySummaryActionEnumValues Enumerates the set of values for PdbConversionHistoryEntrySummaryActionEnum
+func GetPdbConversionHistoryEntrySummaryActionEnumValues() []PdbConversionHistoryEntrySummaryActionEnum {
+	values := make([]PdbConversionHistoryEntrySummaryActionEnum, 0)
+	for _, v := range mappingPdbConversionHistoryEntrySummaryAction {
+		values = append(values, v)
+	}
+	return values
+}
+
+// PdbConversionHistoryEntrySummaryTargetEnum Enum with underlying type: string
+type PdbConversionHistoryEntrySummaryTargetEnum string
+
+// Set of constants representing the allowable values for PdbConversionHistoryEntrySummaryTargetEnum
+const (
+	PdbConversionHistoryEntrySummaryTargetNewDatabase PdbConversionHistoryEntrySummaryTargetEnum = "NEW_DATABASE"
+)
+
+var mappingPdbConversionHistoryEntrySummaryTarget = map[string]PdbConversionHistoryEntrySummaryTargetEnum{
+	"NEW_DATABASE": PdbConversionHistoryEntrySummaryTargetNewDatabase,
+}
+
+// GetPdbConversionHistoryEntrySummaryTargetEnumValues Enumerates the set of values for PdbConversionHistoryEntrySummaryTargetEnum
+func GetPdbConversionHistoryEntrySummaryTargetEnumValues() []PdbConversionHistoryEntrySummaryTargetEnum {
+	values := make([]PdbConversionHistoryEntrySummaryTargetEnum, 0)
+	for _, v := range mappingPdbConversionHistoryEntrySummaryTarget {
+		values = append(values, v)
+	}
+	return values
+}
+
+// PdbConversionHistoryEntrySummaryLifecycleStateEnum Enum with underlying type: string
+type PdbConversionHistoryEntrySummaryLifecycleStateEnum string
+
+// Set of constants representing the allowable values for PdbConversionHistoryEntrySummaryLifecycleStateEnum
+const (
+	PdbConversionHistoryEntrySummaryLifecycleStateSucceeded  PdbConversionHistoryEntrySummaryLifecycleStateEnum = "SUCCEEDED"
+	PdbConversionHistoryEntrySummaryLifecycleStateFailed     PdbConversionHistoryEntrySummaryLifecycleStateEnum = "FAILED"
+	PdbConversionHistoryEntrySummaryLifecycleStateInProgress PdbConversionHistoryEntrySummaryLifecycleStateEnum = "IN_PROGRESS"
+)
+
+var mappingPdbConversionHistoryEntrySummaryLifecycleState = map[string]PdbConversionHistoryEntrySummaryLifecycleStateEnum{
+	"SUCCEEDED":   PdbConversionHistoryEntrySummaryLifecycleStateSucceeded,
+	"FAILED":      PdbConversionHistoryEntrySummaryLifecycleStateFailed,
+	"IN_PROGRESS": PdbConversionHistoryEntrySummaryLifecycleStateInProgress,
+}
+
+// GetPdbConversionHistoryEntrySummaryLifecycleStateEnumValues Enumerates the set of values for PdbConversionHistoryEntrySummaryLifecycleStateEnum
+func GetPdbConversionHistoryEntrySummaryLifecycleStateEnumValues() []PdbConversionHistoryEntrySummaryLifecycleStateEnum {
+	values := make([]PdbConversionHistoryEntrySummaryLifecycleStateEnum, 0)
+	for _, v := range mappingPdbConversionHistoryEntrySummaryLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}

--- a/database/pdb_conversion_to_new_database_details.go
+++ b/database/pdb_conversion_to_new_database_details.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/v49/common"
+)
+
+// PdbConversionToNewDatabaseDetails Details of the new container database in which the converted pluggable database will be located.
+type PdbConversionToNewDatabaseDetails struct {
+
+	// The database name. The name must begin with an alphabetic character and can contain a maximum of 8 alphanumeric characters. Special characters are not permitted. The database name must be unique in the tenancy.
+	CdbName *string `mandatory:"true" json:"cdbName"`
+
+	// A strong password for SYS, SYSTEM, and the plugbable database ADMIN user of the container database after conversion. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numeric, and two special characters. The special characters must be _, \#, or -.
+	CdbAdminPassword *string `mandatory:"true" json:"cdbAdminPassword"`
+
+	// The existing TDE wallet password of the non-container database.
+	NonCdbTdeWalletPassword *string `mandatory:"true" json:"nonCdbTdeWalletPassword"`
+
+	// A strong password for plugbable database ADMIN user of the container database after conversion. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numeric, and two special characters. The special characters must be _, \#, or -.
+	PdbAdminPassword *string `mandatory:"false" json:"pdbAdminPassword"`
+
+	// The password to open the TDE wallet of the container database after conversion. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numeric, and two special characters. The special characters must be _, \#, or -.
+	CdbTdeWalletPassword *string `mandatory:"false" json:"cdbTdeWalletPassword"`
+
+	// Additional container database parameters.
+	// Example: "_pdb_name_case_sensitive=true"
+	AdditionalCdbParams *string `mandatory:"false" json:"additionalCdbParams"`
+}
+
+func (m PdbConversionToNewDatabaseDetails) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m PdbConversionToNewDatabaseDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypePdbConversionToNewDatabaseDetails PdbConversionToNewDatabaseDetails
+	s := struct {
+		DiscriminatorParam string `json:"target"`
+		MarshalTypePdbConversionToNewDatabaseDetails
+	}{
+		"NEW_DATABASE",
+		(MarshalTypePdbConversionToNewDatabaseDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/database/remove_virtual_machine_from_vm_cluster_details.go
+++ b/database/remove_virtual_machine_from_vm_cluster_details.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Database Service API
+//
+// The API for the Database Service. Use this API to manage resources such as databases and DB Systems. For more information, see Overview of the Database Service (https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/databaseoverview.htm).
+//
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+)
+
+// RemoveVirtualMachineFromVmClusterDetails Details of removing Virtual Machines from the VM Cluster. Applies to Exadata Cloud@Customer instances only.
+type RemoveVirtualMachineFromVmClusterDetails struct {
+
+	// The list of Exacc DB servers for the cluster to be removed.
+	DbServers []DbServerDetails `mandatory:"true" json:"dbServers"`
+}
+
+func (m RemoveVirtualMachineFromVmClusterDetails) String() string {
+	return common.PointerString(m)
+}

--- a/database/remove_virtual_machine_from_vm_cluster_request_response.go
+++ b/database/remove_virtual_machine_from_vm_cluster_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package database
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+	"net/http"
+)
+
+// RemoveVirtualMachineFromVmClusterRequest wrapper for the RemoveVirtualMachineFromVmCluster operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/database/RemoveVirtualMachineFromVmCluster.go.html to see an example of how to use RemoveVirtualMachineFromVmClusterRequest.
+type RemoveVirtualMachineFromVmClusterRequest struct {
+
+	// Request to remove Virtual Machines from the VM cluster.
+	RemoveVirtualMachineFromVmClusterDetails `contributesTo:"body"`
+
+	// The VM cluster OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	VmClusterId *string `mandatory:"true" contributesTo:"path" name:"vmClusterId"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique identifier for the request.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request RemoveVirtualMachineFromVmClusterRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request RemoveVirtualMachineFromVmClusterRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request RemoveVirtualMachineFromVmClusterRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request RemoveVirtualMachineFromVmClusterRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// RemoveVirtualMachineFromVmClusterResponse wrapper for the RemoveVirtualMachineFromVmCluster operation
+type RemoveVirtualMachineFromVmClusterResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The VmCluster instance
+	VmCluster `presentIn:"body"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request. Multiple OCID values are returned in a comma-separated list. Use GetWorkRequest with a work request OCID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response RemoveVirtualMachineFromVmClusterResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response RemoveVirtualMachineFromVmClusterResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/database/vm_cluster.go
+++ b/database/vm_cluster.go
@@ -79,6 +79,9 @@ type VmCluster struct {
 	// The Oracle license model that applies to the VM cluster. The default is LICENSE_INCLUDED.
 	LicenseModel VmClusterLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
 
+	// The list of Db server.
+	DbServers []string `mandatory:"false" json:"dbServers"`
+
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`

--- a/database/vm_cluster_summary.go
+++ b/database/vm_cluster_summary.go
@@ -79,6 +79,9 @@ type VmClusterSummary struct {
 	// The Oracle license model that applies to the VM cluster. The default is LICENSE_INCLUDED.
 	LicenseModel VmClusterSummaryLicenseModelEnum `mandatory:"false" json:"licenseModel,omitempty"`
 
+	// The list of Db server.
+	DbServers []string `mandatory:"false" json:"dbServers"`
+
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
 	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Department": "Finance"}`

--- a/databasemanagement/databasemanagement_dbmanagement_client.go
+++ b/databasemanagement/databasemanagement_dbmanagement_client.go
@@ -52,6 +52,9 @@ func NewDbManagementClientWithOboToken(configProvider common.ConfigurationProvid
 }
 
 func newDbManagementClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client DbManagementClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = DbManagementClient{BaseClient: baseClient}
 	client.BasePath = "20201101"
 	err = client.setConfigurationProvider(configProvider)

--- a/databasemigration/databasemigration_client.go
+++ b/databasemigration/databasemigration_client.go
@@ -50,6 +50,9 @@ func NewDatabaseMigrationClientWithOboToken(configProvider common.ConfigurationP
 }
 
 func newDatabaseMigrationClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client DatabaseMigrationClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = DatabaseMigrationClient{BaseClient: baseClient}
 	client.BasePath = "20210929"
 	err = client.setConfigurationProvider(configProvider)

--- a/datacatalog/datacatalog_client.go
+++ b/datacatalog/datacatalog_client.go
@@ -51,6 +51,9 @@ func NewDataCatalogClientWithOboToken(configProvider common.ConfigurationProvide
 }
 
 func newDataCatalogClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client DataCatalogClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = DataCatalogClient{BaseClient: baseClient}
 	client.BasePath = "20190325"
 	err = client.setConfigurationProvider(configProvider)

--- a/dataflow/dataflow_client.go
+++ b/dataflow/dataflow_client.go
@@ -50,6 +50,9 @@ func NewDataFlowClientWithOboToken(configProvider common.ConfigurationProvider, 
 }
 
 func newDataFlowClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client DataFlowClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = DataFlowClient{BaseClient: baseClient}
 	client.BasePath = "20200129"
 	err = client.setConfigurationProvider(configProvider)

--- a/dataintegration/dataintegration_client.go
+++ b/dataintegration/dataintegration_client.go
@@ -50,6 +50,9 @@ func NewDataIntegrationClientWithOboToken(configProvider common.ConfigurationPro
 }
 
 func newDataIntegrationClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client DataIntegrationClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = DataIntegrationClient{BaseClient: baseClient}
 	client.BasePath = "20200430"
 	err = client.setConfigurationProvider(configProvider)

--- a/datalabelingservice/datalabelingservice_datalabelingmanagement_client.go
+++ b/datalabelingservice/datalabelingservice_datalabelingmanagement_client.go
@@ -50,6 +50,9 @@ func NewDataLabelingManagementClientWithOboToken(configProvider common.Configura
 }
 
 func newDataLabelingManagementClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client DataLabelingManagementClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = DataLabelingManagementClient{BaseClient: baseClient}
 	client.BasePath = "20211001"
 	err = client.setConfigurationProvider(configProvider)

--- a/datalabelingservicedataplane/datalabelingservicedataplane_datalabeling_client.go
+++ b/datalabelingservicedataplane/datalabelingservicedataplane_datalabeling_client.go
@@ -50,6 +50,9 @@ func NewDataLabelingClientWithOboToken(configProvider common.ConfigurationProvid
 }
 
 func newDataLabelingClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client DataLabelingClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = DataLabelingClient{BaseClient: baseClient}
 	client.BasePath = "20211001"
 	err = client.setConfigurationProvider(configProvider)

--- a/datasafe/datasafe_client.go
+++ b/datasafe/datasafe_client.go
@@ -50,6 +50,9 @@ func NewDataSafeClientWithOboToken(configProvider common.ConfigurationProvider, 
 }
 
 func newDataSafeClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client DataSafeClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = DataSafeClient{BaseClient: baseClient}
 	client.BasePath = "20181201"
 	err = client.setConfigurationProvider(configProvider)

--- a/datascience/datascience_client.go
+++ b/datascience/datascience_client.go
@@ -50,6 +50,9 @@ func NewDataScienceClientWithOboToken(configProvider common.ConfigurationProvide
 }
 
 func newDataScienceClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client DataScienceClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = DataScienceClient{BaseClient: baseClient}
 	client.BasePath = "20190101"
 	err = client.setConfigurationProvider(configProvider)

--- a/devops/devops_client.go
+++ b/devops/devops_client.go
@@ -50,6 +50,9 @@ func NewDevopsClientWithOboToken(configProvider common.ConfigurationProvider, ob
 }
 
 func newDevopsClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client DevopsClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = DevopsClient{BaseClient: baseClient}
 	client.BasePath = "20210630"
 	err = client.setConfigurationProvider(configProvider)

--- a/dns/dns_client.go
+++ b/dns/dns_client.go
@@ -51,6 +51,9 @@ func NewDnsClientWithOboToken(configProvider common.ConfigurationProvider, oboTo
 }
 
 func newDnsClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client DnsClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = DnsClient{BaseClient: baseClient}
 	client.BasePath = "20180115"
 	err = client.setConfigurationProvider(configProvider)

--- a/dts/dts_applianceexportjob_client.go
+++ b/dts/dts_applianceexportjob_client.go
@@ -50,6 +50,9 @@ func NewApplianceExportJobClientWithOboToken(configProvider common.Configuration
 }
 
 func newApplianceExportJobClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ApplianceExportJobClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = ApplianceExportJobClient{BaseClient: baseClient}
 	client.BasePath = "20171001"
 	err = client.setConfigurationProvider(configProvider)

--- a/dts/dts_shippingvendors_client.go
+++ b/dts/dts_shippingvendors_client.go
@@ -50,6 +50,9 @@ func NewShippingVendorsClientWithOboToken(configProvider common.ConfigurationPro
 }
 
 func newShippingVendorsClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ShippingVendorsClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = ShippingVendorsClient{BaseClient: baseClient}
 	client.BasePath = "20171001"
 	err = client.setConfigurationProvider(configProvider)

--- a/dts/dts_transferappliance_client.go
+++ b/dts/dts_transferappliance_client.go
@@ -50,6 +50,9 @@ func NewTransferApplianceClientWithOboToken(configProvider common.ConfigurationP
 }
 
 func newTransferApplianceClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client TransferApplianceClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = TransferApplianceClient{BaseClient: baseClient}
 	client.BasePath = "20171001"
 	err = client.setConfigurationProvider(configProvider)

--- a/dts/dts_transferapplianceentitlement_client.go
+++ b/dts/dts_transferapplianceentitlement_client.go
@@ -50,6 +50,9 @@ func NewTransferApplianceEntitlementClientWithOboToken(configProvider common.Con
 }
 
 func newTransferApplianceEntitlementClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client TransferApplianceEntitlementClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = TransferApplianceEntitlementClient{BaseClient: baseClient}
 	client.BasePath = "20171001"
 	err = client.setConfigurationProvider(configProvider)

--- a/dts/dts_transferdevice_client.go
+++ b/dts/dts_transferdevice_client.go
@@ -50,6 +50,9 @@ func NewTransferDeviceClientWithOboToken(configProvider common.ConfigurationProv
 }
 
 func newTransferDeviceClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client TransferDeviceClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = TransferDeviceClient{BaseClient: baseClient}
 	client.BasePath = "20171001"
 	err = client.setConfigurationProvider(configProvider)

--- a/dts/dts_transferjob_client.go
+++ b/dts/dts_transferjob_client.go
@@ -50,6 +50,9 @@ func NewTransferJobClientWithOboToken(configProvider common.ConfigurationProvide
 }
 
 func newTransferJobClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client TransferJobClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = TransferJobClient{BaseClient: baseClient}
 	client.BasePath = "20171001"
 	err = client.setConfigurationProvider(configProvider)

--- a/dts/dts_transferpackage_client.go
+++ b/dts/dts_transferpackage_client.go
@@ -50,6 +50,9 @@ func NewTransferPackageClientWithOboToken(configProvider common.ConfigurationPro
 }
 
 func newTransferPackageClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client TransferPackageClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = TransferPackageClient{BaseClient: baseClient}
 	client.BasePath = "20171001"
 	err = client.setConfigurationProvider(configProvider)

--- a/email/email_client.go
+++ b/email/email_client.go
@@ -54,6 +54,9 @@ func NewEmailClientWithOboToken(configProvider common.ConfigurationProvider, obo
 }
 
 func newEmailClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client EmailClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = EmailClient{BaseClient: baseClient}
 	client.BasePath = "20170907"
 	err = client.setConfigurationProvider(configProvider)

--- a/events/events_client.go
+++ b/events/events_client.go
@@ -51,6 +51,9 @@ func NewEventsClientWithOboToken(configProvider common.ConfigurationProvider, ob
 }
 
 func newEventsClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client EventsClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = EventsClient{BaseClient: baseClient}
 	client.BasePath = "20181201"
 	err = client.setConfigurationProvider(configProvider)

--- a/example/example_circuitbreaker_test.go
+++ b/example/example_circuitbreaker_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+package example
+
+import (
+	"context"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v49/common"
+	"github.com/oracle/oci-go-sdk/v49/example/helpers"
+	"github.com/oracle/oci-go-sdk/v49/identity"
+	"time"
+)
+
+// Example shows how to configure circuit breaker
+func ExampleConfigureCircuitBreaker() {
+	// If need to disable all service default circuit breaker, there are two ways: set circuit breaker environment variable to false
+	// or use global variable.
+	// common.GlobalCircuitBreakerSetting = common.NoCircuitBreaker()
+
+	identityClient, err := identity.NewIdentityClientWithConfigurationProvider(common.DefaultConfigProvider())
+	helpers.FatalIfError(err)
+	// Add one more status code 404(compare with default circuit breaker setting) as the failure request in circuit breaker.
+	successStatCodeMap := map[int]bool{
+		429: false,
+		404: false,
+		500: false,
+		502: false,
+		503: false,
+		504: false,
+	}
+	// Configure CircuitBreaker
+	cbst := common.NewCircuitBreakerSettingWithOptions(
+		common.WithName("myCircuitBreaker"),
+		common.WithIsEnabled(true),
+		common.WithMinimumRequests(5),
+		common.WithCloseStateWindow(60*time.Second),
+		common.WithFailureRateThreshold(0.70),
+		common.WithSuccessStatCodeMap(successStatCodeMap))
+
+	// if prefer to use default circuit breaker, no need to define successStatCodeMap and cb, but directly call:
+	// cbst := common.DefaultCircuitBreakerSetting()
+
+	identityClient.BaseClient.Configuration.CircuitBreaker = common.NewCircuitBreaker(cbst)
+
+	// The OCID of the tenancy containing the compartment.
+	tenancyID, err := common.DefaultConfigProvider().TenancyOCID()
+	helpers.FatalIfError(err)
+
+	// make the tenancyOCID incorrect on purpose - testing
+	fakeTenancyID := tenancyID[1:len(tenancyID)-2] + "mm"
+
+	request := identity.ListAvailabilityDomainsRequest{
+		CompartmentId: &fakeTenancyID,
+	}
+
+	for i := 0; i < 5; i++ {
+		identityClient.ListAvailabilityDomains(context.Background(), request)
+		fmt.Println(i*10, "seconds CircuitBreaker state: "+identityClient.Configuration.CircuitBreaker.State().String())
+		time.Sleep(10 * time.Second)
+	}
+	time.Sleep(5 * time.Second)
+	fmt.Println("After 55s, CircuitBreaker current state: " + identityClient.Configuration.CircuitBreaker.State().String())
+
+	fmt.Println("Wait 30 sec...")
+	time.Sleep(30 * time.Second)
+	fmt.Println("Make a good API call")
+
+	request = identity.ListAvailabilityDomainsRequest{
+		CompartmentId: &tenancyID,
+	}
+	identityClient.ListAvailabilityDomains(context.Background(), request)
+	time.Sleep(10 * time.Second)
+	fmt.Println("check current CircuitBreaker state: " + identityClient.Configuration.CircuitBreaker.State().String())
+
+	// Output:
+	// 0 seconds CircuitBreaker state: closed
+	// 10 seconds CircuitBreaker state: closed
+	// 20 seconds CircuitBreaker state: closed
+	// 30 seconds CircuitBreaker state: closed
+	// 40 seconds CircuitBreaker state: open
+	// After 55s, CircuitBreaker current state: open
+	// Wait 30 sec...
+	// Make a good API call
+	// check current CircuitBreaker state: closed
+}

--- a/example/example_datalabelingservice_test.go
+++ b/example/example_datalabelingservice_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
 package example
 
 import (

--- a/example/example_retry_test.go
+++ b/example/example_retry_test.go
@@ -18,9 +18,35 @@ import (
 
 // ExampleRetry shows how to use default retry for Create and Delete groups, please
 // refer to example_core_test.go->ExampleLaunchInstance for more examples
+// The Retry behavior Precedence (Highest to lowest) is defined as below:
+//   Operation level retry policy - setting request.RequestMetadata
+//   Client level retry policy - setting client.SetCustomClientConfiguration
+//   Global level retry policy - setting common.GlobalRetry
+
 func ExampleRetry() {
+	// create global level user customized retry policy
+	// globalLevelPolicy := common.NewRetryPolicyWithOptions(
+	//	  common.WithMaximumNumberAttempts(5),
+	//    common.WithNextDuration(func(r common.OCIOperationResponse) time.Duration {
+	//    	return time.Duration(math.Pow(float64(2), float64(r.AttemptNumber-1))) * time.Second
+	//    }),
+	// )
+	// common.GlobalRetry = &globalLevelPolicy
+
 	// create and delete group with retry
 	client, clerr := identity.NewIdentityClientWithConfigurationProvider(common.DefaultConfigProvider())
+
+	// create a client level defined retry policy
+	// clientLevelPolicy := common.NewRetryPolicyWithOptions(
+	//	   common.WithMaximumNumberAttempts(6),
+	//	   common.WithNextDuration(func(r common.OCIOperationResponse) time.Duration {
+	//		   return time.Duration(math.Pow(float64(2), float64(r.AttemptNumber-1))) * time.Second
+	//	   }),
+	// )
+	// client.SetCustomClientConfiguration(common.CustomClientConfiguration{
+	//	  RetryPolicy: &clientLevelPolicy,
+	// })
+
 	ctx := context.Background()
 	helpers.FatalIfError(clerr)
 
@@ -32,7 +58,7 @@ func ExampleRetry() {
 	// use SDK's default retry policy which deals with eventual consistency
 	defaultRetryPolicy := common.DefaultRetryPolicy()
 
-	// create request metadata for retry
+	// create request metadata for retry(request level retry)
 	request.RequestMetadata = common.RequestMetadata{
 		RetryPolicy: &defaultRetryPolicy,
 	}

--- a/filestorage/filestorage_client.go
+++ b/filestorage/filestorage_client.go
@@ -50,6 +50,9 @@ func NewFileStorageClientWithOboToken(configProvider common.ConfigurationProvide
 }
 
 func newFileStorageClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client FileStorageClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = FileStorageClient{BaseClient: baseClient}
 	client.BasePath = "20171215"
 	err = client.setConfigurationProvider(configProvider)

--- a/functions/functions_functionsinvoke_client.go
+++ b/functions/functions_functionsinvoke_client.go
@@ -50,6 +50,9 @@ func NewFunctionsInvokeClientWithOboToken(configProvider common.ConfigurationPro
 }
 
 func newFunctionsInvokeClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider, endpoint string) (client FunctionsInvokeClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = FunctionsInvokeClient{BaseClient: baseClient}
 	client.BasePath = "20181201"
 	client.Host = endpoint

--- a/functions/functions_functionsmanagement_client.go
+++ b/functions/functions_functionsmanagement_client.go
@@ -50,6 +50,9 @@ func NewFunctionsManagementClientWithOboToken(configProvider common.Configuratio
 }
 
 func newFunctionsManagementClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client FunctionsManagementClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = FunctionsManagementClient{BaseClient: baseClient}
 	client.BasePath = "20181201"
 	err = client.setConfigurationProvider(configProvider)

--- a/genericartifactscontent/genericartifactscontent_client.go
+++ b/genericartifactscontent/genericartifactscontent_client.go
@@ -51,6 +51,9 @@ func NewGenericArtifactsContentClientWithOboToken(configProvider common.Configur
 }
 
 func newGenericArtifactsContentClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client GenericArtifactsContentClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = GenericArtifactsContentClient{BaseClient: baseClient}
 	client.BasePath = "20160918"
 	err = client.setConfigurationProvider(configProvider)

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/oracle/oci-go-sdk/v49
 
 go 1.13
 
-require github.com/stretchr/testify v1.6.1
+require (
+	github.com/sony/gobreaker v0.4.2-0.20210216022020-dd874f9dd33b
+	github.com/stretchr/testify v1.6.1
+)

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,11 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sony/gobreaker v0.4.2-0.20210216022020-dd874f9dd33b h1:br+bPNZsJWKicw/5rALEo67QHs5weyD5tf8WST+4sJ0=
+github.com/sony/gobreaker v0.4.2-0.20210216022020-dd874f9dd33b/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/goldengate/goldengate_client.go
+++ b/goldengate/goldengate_client.go
@@ -50,6 +50,9 @@ func NewGoldenGateClientWithOboToken(configProvider common.ConfigurationProvider
 }
 
 func newGoldenGateClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client GoldenGateClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = GoldenGateClient{BaseClient: baseClient}
 	client.BasePath = "20200407"
 	err = client.setConfigurationProvider(configProvider)

--- a/healthchecks/healthchecks_client.go
+++ b/healthchecks/healthchecks_client.go
@@ -52,6 +52,9 @@ func NewHealthChecksClientWithOboToken(configProvider common.ConfigurationProvid
 }
 
 func newHealthChecksClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client HealthChecksClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = HealthChecksClient{BaseClient: baseClient}
 	client.BasePath = "20180501"
 	err = client.setConfigurationProvider(configProvider)

--- a/identity/identity_client.go
+++ b/identity/identity_client.go
@@ -51,6 +51,9 @@ func NewIdentityClientWithOboToken(configProvider common.ConfigurationProvider, 
 }
 
 func newIdentityClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client IdentityClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = IdentityClient{BaseClient: baseClient}
 	client.BasePath = "20160918"
 	err = client.setConfigurationProvider(configProvider)

--- a/integration/integration_integrationinstance_client.go
+++ b/integration/integration_integrationinstance_client.go
@@ -50,6 +50,9 @@ func NewIntegrationInstanceClientWithOboToken(configProvider common.Configuratio
 }
 
 func newIntegrationInstanceClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client IntegrationInstanceClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = IntegrationInstanceClient{BaseClient: baseClient}
 	client.BasePath = "20190131"
 	err = client.setConfigurationProvider(configProvider)

--- a/jms/jms_javamanagementservice_client.go
+++ b/jms/jms_javamanagementservice_client.go
@@ -50,6 +50,9 @@ func NewJavaManagementServiceClientWithOboToken(configProvider common.Configurat
 }
 
 func newJavaManagementServiceClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client JavaManagementServiceClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = JavaManagementServiceClient{BaseClient: baseClient}
 	client.BasePath = "20210610"
 	err = client.setConfigurationProvider(configProvider)

--- a/keymanagement/keymanagement_kmscrypto_client.go
+++ b/keymanagement/keymanagement_kmscrypto_client.go
@@ -51,6 +51,9 @@ func NewKmsCryptoClientWithOboToken(configProvider common.ConfigurationProvider,
 }
 
 func newKmsCryptoClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider, endpoint string) (client KmsCryptoClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = KmsCryptoClient{BaseClient: baseClient}
 	client.BasePath = ""
 	client.Host = endpoint

--- a/keymanagement/keymanagement_kmsmanagement_client.go
+++ b/keymanagement/keymanagement_kmsmanagement_client.go
@@ -51,6 +51,9 @@ func NewKmsManagementClientWithOboToken(configProvider common.ConfigurationProvi
 }
 
 func newKmsManagementClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider, endpoint string) (client KmsManagementClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = KmsManagementClient{BaseClient: baseClient}
 	client.BasePath = ""
 	client.Host = endpoint

--- a/keymanagement/keymanagement_kmsvault_client.go
+++ b/keymanagement/keymanagement_kmsvault_client.go
@@ -51,6 +51,9 @@ func NewKmsVaultClientWithOboToken(configProvider common.ConfigurationProvider, 
 }
 
 func newKmsVaultClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client KmsVaultClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = KmsVaultClient{BaseClient: baseClient}
 	client.BasePath = ""
 	err = client.setConfigurationProvider(configProvider)

--- a/limits/limits_client.go
+++ b/limits/limits_client.go
@@ -50,6 +50,9 @@ func NewLimitsClientWithOboToken(configProvider common.ConfigurationProvider, ob
 }
 
 func newLimitsClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client LimitsClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = LimitsClient{BaseClient: baseClient}
 	client.BasePath = ""
 	err = client.setConfigurationProvider(configProvider)

--- a/limits/limits_quotas_client.go
+++ b/limits/limits_quotas_client.go
@@ -50,6 +50,9 @@ func NewQuotasClientWithOboToken(configProvider common.ConfigurationProvider, ob
 }
 
 func newQuotasClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client QuotasClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = QuotasClient{BaseClient: baseClient}
 	client.BasePath = ""
 	err = client.setConfigurationProvider(configProvider)

--- a/loadbalancer/loadbalancer_client.go
+++ b/loadbalancer/loadbalancer_client.go
@@ -51,6 +51,9 @@ func NewLoadBalancerClientWithOboToken(configProvider common.ConfigurationProvid
 }
 
 func newLoadBalancerClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client LoadBalancerClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = LoadBalancerClient{BaseClient: baseClient}
 	client.BasePath = "20170115"
 	err = client.setConfigurationProvider(configProvider)

--- a/loganalytics/abstract_column.go
+++ b/loganalytics/abstract_column.go
@@ -32,6 +32,9 @@ type AbstractColumn interface {
 	// Identifies if this column allows multiple values to exist in a single row.
 	GetIsMultiValued() *bool
 
+	// A flag indicating whether or not the field is a case sensitive field.  Only applies to string fields.
+	GetIsCaseSensitive() *bool
+
 	// Identifies if this column can be used as a grouping field in any grouping command.
 	GetIsGroupable() *bool
 
@@ -55,6 +58,7 @@ type abstractcolumn struct {
 	Values              []FieldValue      `mandatory:"false" json:"values"`
 	IsListOfValues      *bool             `mandatory:"false" json:"isListOfValues"`
 	IsMultiValued       *bool             `mandatory:"false" json:"isMultiValued"`
+	IsCaseSensitive     *bool             `mandatory:"false" json:"isCaseSensitive"`
 	IsGroupable         *bool             `mandatory:"false" json:"isGroupable"`
 	IsEvaluable         *bool             `mandatory:"false" json:"isEvaluable"`
 	ValueType           ValueTypeEnum     `mandatory:"false" json:"valueType,omitempty"`
@@ -79,6 +83,7 @@ func (m *abstractcolumn) UnmarshalJSON(data []byte) error {
 	m.Values = s.Model.Values
 	m.IsListOfValues = s.Model.IsListOfValues
 	m.IsMultiValued = s.Model.IsMultiValued
+	m.IsCaseSensitive = s.Model.IsCaseSensitive
 	m.IsGroupable = s.Model.IsGroupable
 	m.IsEvaluable = s.Model.IsEvaluable
 	m.ValueType = s.Model.ValueType
@@ -150,6 +155,11 @@ func (m abstractcolumn) GetIsListOfValues() *bool {
 //GetIsMultiValued returns IsMultiValued
 func (m abstractcolumn) GetIsMultiValued() *bool {
 	return m.IsMultiValued
+}
+
+//GetIsCaseSensitive returns IsCaseSensitive
+func (m abstractcolumn) GetIsCaseSensitive() *bool {
+	return m.IsCaseSensitive
 }
 
 //GetIsGroupable returns IsGroupable

--- a/loganalytics/abstract_command_descriptor.go
+++ b/loganalytics/abstract_command_descriptor.go
@@ -38,8 +38,8 @@ type abstractcommanddescriptor struct {
 	DisplayQueryString  *string         `mandatory:"true" json:"displayQueryString"`
 	InternalQueryString *string         `mandatory:"true" json:"internalQueryString"`
 	Category            *string         `mandatory:"false" json:"category"`
-	ReferencedFields    []AbstractField `mandatory:"false" json:"referencedFields"`
-	DeclaredFields      []AbstractField `mandatory:"false" json:"declaredFields"`
+	ReferencedFields    json.RawMessage `mandatory:"false" json:"referencedFields"`
+	DeclaredFields      json.RawMessage `mandatory:"false" json:"declaredFields"`
 	Name                string          `json:"name"`
 }
 
@@ -119,6 +119,10 @@ func (m *abstractcommanddescriptor) UnmarshalPolymorphicJSON(data []byte) (inter
 		return mm, err
 	case "FIELD_SUMMARY":
 		mm := FieldSummaryCommandDescriptor{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "GEO_STATS":
+		mm := GeoStatsCommandDescriptor{}
 		err = json.Unmarshal(data, &mm)
 		return mm, err
 	case "MAP":
@@ -262,12 +266,12 @@ func (m abstractcommanddescriptor) GetCategory() *string {
 }
 
 //GetReferencedFields returns ReferencedFields
-func (m abstractcommanddescriptor) GetReferencedFields() []AbstractField {
+func (m abstractcommanddescriptor) GetReferencedFields() json.RawMessage {
 	return m.ReferencedFields
 }
 
 //GetDeclaredFields returns DeclaredFields
-func (m abstractcommanddescriptor) GetDeclaredFields() []AbstractField {
+func (m abstractcommanddescriptor) GetDeclaredFields() json.RawMessage {
 	return m.DeclaredFields
 }
 
@@ -283,6 +287,7 @@ const (
 	AbstractCommandDescriptorNameCommand         AbstractCommandDescriptorNameEnum = "COMMAND"
 	AbstractCommandDescriptorNameSearch          AbstractCommandDescriptorNameEnum = "SEARCH"
 	AbstractCommandDescriptorNameStats           AbstractCommandDescriptorNameEnum = "STATS"
+	AbstractCommandDescriptorNameGeoStats        AbstractCommandDescriptorNameEnum = "GEO_STATS"
 	AbstractCommandDescriptorNameTimeStats       AbstractCommandDescriptorNameEnum = "TIME_STATS"
 	AbstractCommandDescriptorNameSort            AbstractCommandDescriptorNameEnum = "SORT"
 	AbstractCommandDescriptorNameFields          AbstractCommandDescriptorNameEnum = "FIELDS"
@@ -328,6 +333,7 @@ var mappingAbstractCommandDescriptorName = map[string]AbstractCommandDescriptorN
 	"COMMAND":          AbstractCommandDescriptorNameCommand,
 	"SEARCH":           AbstractCommandDescriptorNameSearch,
 	"STATS":            AbstractCommandDescriptorNameStats,
+	"GEO_STATS":        AbstractCommandDescriptorNameGeoStats,
 	"TIME_STATS":       AbstractCommandDescriptorNameTimeStats,
 	"SORT":             AbstractCommandDescriptorNameSort,
 	"FIELDS":           AbstractCommandDescriptorNameFields,

--- a/loganalytics/append_lookup_data_request_response.go
+++ b/loganalytics/append_lookup_data_request_response.go
@@ -49,6 +49,11 @@ type AppendLookupDataRequest struct {
 	// provide matches the resource's current etag value.
 	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
 
+	// A value of `100-continue` requests preliminary verification of the request method, path, and headers before the request body is sent.
+	// If no error results from such verification, the server will send a 100 (Continue) interim response to indicate readiness for the request body.
+	// The only allowed value for this parameter is "100-Continue" (case-insensitive).
+	Expect *string `mandatory:"false" contributesTo:"header" name:"expect"`
+
 	// Metadata about the request. This information will not be transmitted to the service, but
 	// represents information that the SDK will consume to drive retry behavior.
 	RequestMetadata common.RequestMetadata

--- a/loganalytics/chart_column.go
+++ b/loganalytics/chart_column.go
@@ -29,6 +29,9 @@ type ChartColumn struct {
 	// Identifies if this column allows multiple values to exist in a single row.
 	IsMultiValued *bool `mandatory:"false" json:"isMultiValued"`
 
+	// A flag indicating whether or not the field is a case sensitive field.  Only applies to string fields.
+	IsCaseSensitive *bool `mandatory:"false" json:"isCaseSensitive"`
+
 	// Identifies if this column can be used as a grouping field in any grouping command.
 	IsGroupable *bool `mandatory:"false" json:"isGroupable"`
 
@@ -83,6 +86,11 @@ func (m ChartColumn) GetIsListOfValues() *bool {
 //GetIsMultiValued returns IsMultiValued
 func (m ChartColumn) GetIsMultiValued() *bool {
 	return m.IsMultiValued
+}
+
+//GetIsCaseSensitive returns IsCaseSensitive
+func (m ChartColumn) GetIsCaseSensitive() *bool {
+	return m.IsCaseSensitive
 }
 
 //GetIsGroupable returns IsGroupable

--- a/loganalytics/chart_data_column.go
+++ b/loganalytics/chart_data_column.go
@@ -29,6 +29,9 @@ type ChartDataColumn struct {
 	// Identifies if this column allows multiple values to exist in a single row.
 	IsMultiValued *bool `mandatory:"false" json:"isMultiValued"`
 
+	// A flag indicating whether or not the field is a case sensitive field.  Only applies to string fields.
+	IsCaseSensitive *bool `mandatory:"false" json:"isCaseSensitive"`
+
 	// Identifies if this column can be used as a grouping field in any grouping command.
 	IsGroupable *bool `mandatory:"false" json:"isGroupable"`
 
@@ -77,6 +80,11 @@ func (m ChartDataColumn) GetIsListOfValues() *bool {
 //GetIsMultiValued returns IsMultiValued
 func (m ChartDataColumn) GetIsMultiValued() *bool {
 	return m.IsMultiValued
+}
+
+//GetIsCaseSensitive returns IsCaseSensitive
+func (m ChartDataColumn) GetIsCaseSensitive() *bool {
+	return m.IsCaseSensitive
 }
 
 //GetIsGroupable returns IsGroupable

--- a/loganalytics/classify_column.go
+++ b/loganalytics/classify_column.go
@@ -29,6 +29,9 @@ type ClassifyColumn struct {
 	// Identifies if this column allows multiple values to exist in a single row.
 	IsMultiValued *bool `mandatory:"false" json:"isMultiValued"`
 
+	// A flag indicating whether or not the field is a case sensitive field.  Only applies to string fields.
+	IsCaseSensitive *bool `mandatory:"false" json:"isCaseSensitive"`
+
 	// Identifies if this column can be used as a grouping field in any grouping command.
 	IsGroupable *bool `mandatory:"false" json:"isGroupable"`
 
@@ -94,6 +97,11 @@ func (m ClassifyColumn) GetIsMultiValued() *bool {
 	return m.IsMultiValued
 }
 
+//GetIsCaseSensitive returns IsCaseSensitive
+func (m ClassifyColumn) GetIsCaseSensitive() *bool {
+	return m.IsCaseSensitive
+}
+
 //GetIsGroupable returns IsGroupable
 func (m ClassifyColumn) GetIsGroupable() *bool {
 	return m.IsGroupable
@@ -145,6 +153,7 @@ func (m *ClassifyColumn) UnmarshalJSON(data []byte) (e error) {
 		Values                        []FieldValue             `json:"values"`
 		IsListOfValues                *bool                    `json:"isListOfValues"`
 		IsMultiValued                 *bool                    `json:"isMultiValued"`
+		IsCaseSensitive               *bool                    `json:"isCaseSensitive"`
 		IsGroupable                   *bool                    `json:"isGroupable"`
 		IsEvaluable                   *bool                    `json:"isEvaluable"`
 		ValueType                     ValueTypeEnum            `json:"valueType"`
@@ -176,6 +185,8 @@ func (m *ClassifyColumn) UnmarshalJSON(data []byte) (e error) {
 	m.IsListOfValues = model.IsListOfValues
 
 	m.IsMultiValued = model.IsMultiValued
+
+	m.IsCaseSensitive = model.IsCaseSensitive
 
 	m.IsGroupable = model.IsGroupable
 

--- a/loganalytics/column.go
+++ b/loganalytics/column.go
@@ -29,6 +29,9 @@ type Column struct {
 	// Identifies if this column allows multiple values to exist in a single row.
 	IsMultiValued *bool `mandatory:"false" json:"isMultiValued"`
 
+	// A flag indicating whether or not the field is a case sensitive field.  Only applies to string fields.
+	IsCaseSensitive *bool `mandatory:"false" json:"isCaseSensitive"`
+
 	// Identifies if this column can be used as a grouping field in any grouping command.
 	IsGroupable *bool `mandatory:"false" json:"isGroupable"`
 
@@ -71,6 +74,11 @@ func (m Column) GetIsListOfValues() *bool {
 //GetIsMultiValued returns IsMultiValued
 func (m Column) GetIsMultiValued() *bool {
 	return m.IsMultiValued
+}
+
+//GetIsCaseSensitive returns IsCaseSensitive
+func (m Column) GetIsCaseSensitive() *bool {
+	return m.IsCaseSensitive
 }
 
 //GetIsGroupable returns IsGroupable

--- a/loganalytics/create_log_analytics_object_collection_rule_details.go
+++ b/loganalytics/create_log_analytics_object_collection_rule_details.go
@@ -68,6 +68,11 @@ type CreateLogAnalyticsObjectCollectionRuleDetails struct {
 	// Supported matchType for override are "contains".
 	Overrides map[string][]PropertyOverride `mandatory:"false" json:"overrides"`
 
+	// When the filters are provided, only the objects matching the filters are picked up for processing.
+	// The matchType supported is exact match and accommodates wildcard "*".
+	// For more information on filters, see Event Filters (https://docs.oracle.com/en-us/iaas/Content/Events/Concepts/filterevents.htm).
+	ObjectNameFilters []string `mandatory:"false" json:"objectNameFilters"`
+
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// Example: `{"foo-namespace": {"bar-key": "value"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`

--- a/loganalytics/extract_log_header_results.go
+++ b/loganalytics/extract_log_header_results.go
@@ -21,6 +21,9 @@ type ExtractLogHeaderResults struct {
 
 	// The log field or log header values.
 	XmlPaths []string `mandatory:"false" json:"xmlPaths"`
+
+	// The log header values.
+	HeaderPaths []string `mandatory:"false" json:"headerPaths"`
 }
 
 func (m ExtractLogHeaderResults) String() string {

--- a/loganalytics/extract_structured_log_field_paths_request_response.go
+++ b/loganalytics/extract_structured_log_field_paths_request_response.go
@@ -89,13 +89,15 @@ type ExtractStructuredLogFieldPathsParserTypeEnum string
 
 // Set of constants representing the allowable values for ExtractStructuredLogFieldPathsParserTypeEnum
 const (
-	ExtractStructuredLogFieldPathsParserTypeXml  ExtractStructuredLogFieldPathsParserTypeEnum = "XML"
-	ExtractStructuredLogFieldPathsParserTypeJson ExtractStructuredLogFieldPathsParserTypeEnum = "JSON"
+	ExtractStructuredLogFieldPathsParserTypeXml       ExtractStructuredLogFieldPathsParserTypeEnum = "XML"
+	ExtractStructuredLogFieldPathsParserTypeJson      ExtractStructuredLogFieldPathsParserTypeEnum = "JSON"
+	ExtractStructuredLogFieldPathsParserTypeDelimited ExtractStructuredLogFieldPathsParserTypeEnum = "DELIMITED"
 )
 
 var mappingExtractStructuredLogFieldPathsParserType = map[string]ExtractStructuredLogFieldPathsParserTypeEnum{
-	"XML":  ExtractStructuredLogFieldPathsParserTypeXml,
-	"JSON": ExtractStructuredLogFieldPathsParserTypeJson,
+	"XML":       ExtractStructuredLogFieldPathsParserTypeXml,
+	"JSON":      ExtractStructuredLogFieldPathsParserTypeJson,
+	"DELIMITED": ExtractStructuredLogFieldPathsParserTypeDelimited,
 }
 
 // GetExtractStructuredLogFieldPathsParserTypeEnumValues Enumerates the set of values for ExtractStructuredLogFieldPathsParserTypeEnum

--- a/loganalytics/extract_structured_log_header_paths_request_response.go
+++ b/loganalytics/extract_structured_log_header_paths_request_response.go
@@ -89,13 +89,15 @@ type ExtractStructuredLogHeaderPathsParserTypeEnum string
 
 // Set of constants representing the allowable values for ExtractStructuredLogHeaderPathsParserTypeEnum
 const (
-	ExtractStructuredLogHeaderPathsParserTypeXml  ExtractStructuredLogHeaderPathsParserTypeEnum = "XML"
-	ExtractStructuredLogHeaderPathsParserTypeJson ExtractStructuredLogHeaderPathsParserTypeEnum = "JSON"
+	ExtractStructuredLogHeaderPathsParserTypeXml       ExtractStructuredLogHeaderPathsParserTypeEnum = "XML"
+	ExtractStructuredLogHeaderPathsParserTypeJson      ExtractStructuredLogHeaderPathsParserTypeEnum = "JSON"
+	ExtractStructuredLogHeaderPathsParserTypeDelimited ExtractStructuredLogHeaderPathsParserTypeEnum = "DELIMITED"
 )
 
 var mappingExtractStructuredLogHeaderPathsParserType = map[string]ExtractStructuredLogHeaderPathsParserTypeEnum{
-	"XML":  ExtractStructuredLogHeaderPathsParserTypeXml,
-	"JSON": ExtractStructuredLogHeaderPathsParserTypeJson,
+	"XML":       ExtractStructuredLogHeaderPathsParserTypeXml,
+	"JSON":      ExtractStructuredLogHeaderPathsParserTypeJson,
+	"DELIMITED": ExtractStructuredLogHeaderPathsParserTypeDelimited,
 }
 
 // GetExtractStructuredLogHeaderPathsParserTypeEnumValues Enumerates the set of values for ExtractStructuredLogHeaderPathsParserTypeEnum

--- a/loganalytics/geo_stats_command_descriptor.go
+++ b/loganalytics/geo_stats_command_descriptor.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// LogAnalytics API
+//
+// The LogAnalytics API for the LogAnalytics service.
+//
+
+package loganalytics
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/v49/common"
+)
+
+// GeoStatsCommandDescriptor Command descriptor for querylanguage GEOSTATS command.  This is similiar to STATS with some built in functions for City, State and Country by Coordinates.
+type GeoStatsCommandDescriptor struct {
+
+	// Command fragment display string from user specified query string formatted by query builder.
+	DisplayQueryString *string `mandatory:"true" json:"displayQueryString"`
+
+	// Command fragment internal string from user specified query string formatted by query builder.
+	InternalQueryString *string `mandatory:"true" json:"internalQueryString"`
+
+	// querylanguage command designation for example; reporting vs filtering
+	Category *string `mandatory:"false" json:"category"`
+
+	// Fields referenced in command fragment from user specified query string.
+	ReferencedFields []AbstractField `mandatory:"false" json:"referencedFields"`
+
+	// Fields declared in command fragment from user specified query string.
+	DeclaredFields []AbstractField `mandatory:"false" json:"declaredFields"`
+
+	// Group by fields if specified in the query string.
+	GroupByFields []AbstractField `mandatory:"false" json:"groupByFields"`
+
+	// Statistical functions specified in the query string. Atleast 1 is required for a GEOSTATS command.
+	Functions []FunctionField `mandatory:"false" json:"functions"`
+
+	// Indicates which coordinates to show.  Either client, server or both.  Defaults to client.
+	Include GeoStatsCommandDescriptorIncludeEnum `mandatory:"false" json:"include,omitempty"`
+}
+
+//GetDisplayQueryString returns DisplayQueryString
+func (m GeoStatsCommandDescriptor) GetDisplayQueryString() *string {
+	return m.DisplayQueryString
+}
+
+//GetInternalQueryString returns InternalQueryString
+func (m GeoStatsCommandDescriptor) GetInternalQueryString() *string {
+	return m.InternalQueryString
+}
+
+//GetCategory returns Category
+func (m GeoStatsCommandDescriptor) GetCategory() *string {
+	return m.Category
+}
+
+//GetReferencedFields returns ReferencedFields
+func (m GeoStatsCommandDescriptor) GetReferencedFields() []AbstractField {
+	return m.ReferencedFields
+}
+
+//GetDeclaredFields returns DeclaredFields
+func (m GeoStatsCommandDescriptor) GetDeclaredFields() []AbstractField {
+	return m.DeclaredFields
+}
+
+func (m GeoStatsCommandDescriptor) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m GeoStatsCommandDescriptor) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeGeoStatsCommandDescriptor GeoStatsCommandDescriptor
+	s := struct {
+		DiscriminatorParam string `json:"name"`
+		MarshalTypeGeoStatsCommandDescriptor
+	}{
+		"GEO_STATS",
+		(MarshalTypeGeoStatsCommandDescriptor)(m),
+	}
+
+	return json.Marshal(&s)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *GeoStatsCommandDescriptor) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Category            *string                              `json:"category"`
+		ReferencedFields    []abstractfield                      `json:"referencedFields"`
+		DeclaredFields      []abstractfield                      `json:"declaredFields"`
+		Include             GeoStatsCommandDescriptorIncludeEnum `json:"include"`
+		GroupByFields       []abstractfield                      `json:"groupByFields"`
+		Functions           []FunctionField                      `json:"functions"`
+		DisplayQueryString  *string                              `json:"displayQueryString"`
+		InternalQueryString *string                              `json:"internalQueryString"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Category = model.Category
+
+	m.ReferencedFields = make([]AbstractField, len(model.ReferencedFields))
+	for i, n := range model.ReferencedFields {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.ReferencedFields[i] = nn.(AbstractField)
+		} else {
+			m.ReferencedFields[i] = nil
+		}
+	}
+
+	m.DeclaredFields = make([]AbstractField, len(model.DeclaredFields))
+	for i, n := range model.DeclaredFields {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.DeclaredFields[i] = nn.(AbstractField)
+		} else {
+			m.DeclaredFields[i] = nil
+		}
+	}
+
+	m.Include = model.Include
+
+	m.GroupByFields = make([]AbstractField, len(model.GroupByFields))
+	for i, n := range model.GroupByFields {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.GroupByFields[i] = nn.(AbstractField)
+		} else {
+			m.GroupByFields[i] = nil
+		}
+	}
+
+	m.Functions = make([]FunctionField, len(model.Functions))
+	for i, n := range model.Functions {
+		m.Functions[i] = n
+	}
+
+	m.DisplayQueryString = model.DisplayQueryString
+
+	m.InternalQueryString = model.InternalQueryString
+
+	return
+}
+
+// GeoStatsCommandDescriptorIncludeEnum Enum with underlying type: string
+type GeoStatsCommandDescriptorIncludeEnum string
+
+// Set of constants representing the allowable values for GeoStatsCommandDescriptorIncludeEnum
+const (
+	GeoStatsCommandDescriptorIncludeClient          GeoStatsCommandDescriptorIncludeEnum = "CLIENT"
+	GeoStatsCommandDescriptorIncludeServer          GeoStatsCommandDescriptorIncludeEnum = "SERVER"
+	GeoStatsCommandDescriptorIncludeClientAndServer GeoStatsCommandDescriptorIncludeEnum = "CLIENT_AND_SERVER"
+)
+
+var mappingGeoStatsCommandDescriptorInclude = map[string]GeoStatsCommandDescriptorIncludeEnum{
+	"CLIENT":            GeoStatsCommandDescriptorIncludeClient,
+	"SERVER":            GeoStatsCommandDescriptorIncludeServer,
+	"CLIENT_AND_SERVER": GeoStatsCommandDescriptorIncludeClientAndServer,
+}
+
+// GetGeoStatsCommandDescriptorIncludeEnumValues Enumerates the set of values for GeoStatsCommandDescriptorIncludeEnum
+func GetGeoStatsCommandDescriptorIncludeEnumValues() []GeoStatsCommandDescriptorIncludeEnum {
+	values := make([]GeoStatsCommandDescriptorIncludeEnum, 0)
+	for _, v := range mappingGeoStatsCommandDescriptorInclude {
+		values = append(values, v)
+	}
+	return values
+}

--- a/loganalytics/get_preferences_request_response.go
+++ b/loganalytics/get_preferences_request_response.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package loganalytics
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+	"net/http"
+)
+
+// GetPreferencesRequest wrapper for the GetPreferences operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/loganalytics/GetPreferences.go.html to see an example of how to use GetPreferencesRequest.
+type GetPreferencesRequest struct {
+
+	// The Logging Analytics namespace used for the request.
+	NamespaceName *string `mandatory:"true" contributesTo:"path" name:"namespaceName"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+	SortOrder GetPreferencesSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The attribute used to sort the returned preferences.
+	SortBy GetPreferencesSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The maximum number of items to return.
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetPreferencesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetPreferencesRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetPreferencesRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetPreferencesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetPreferencesResponse wrapper for the GetPreferences operation
+type GetPreferencesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of LogAnalyticsPreferenceCollection instances
+	LogAnalyticsPreferenceCollection `presentIn:"body"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then additional items may be available on the previous page of the list. Include this value as the `page` parameter for the
+	// subsequent request to get the previous batch of items.
+	OpcPrevPage *string `presentIn:"header" name:"opc-prev-page"`
+
+	// For pagination of a list of items. When paging through a list, if this header appears in the response,
+	// then additional items may be available on the next page of the list. Include this value as the `page` parameter for the
+	// subsequent request to get the next batch of items.
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetPreferencesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetPreferencesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// GetPreferencesSortOrderEnum Enum with underlying type: string
+type GetPreferencesSortOrderEnum string
+
+// Set of constants representing the allowable values for GetPreferencesSortOrderEnum
+const (
+	GetPreferencesSortOrderAsc  GetPreferencesSortOrderEnum = "ASC"
+	GetPreferencesSortOrderDesc GetPreferencesSortOrderEnum = "DESC"
+)
+
+var mappingGetPreferencesSortOrder = map[string]GetPreferencesSortOrderEnum{
+	"ASC":  GetPreferencesSortOrderAsc,
+	"DESC": GetPreferencesSortOrderDesc,
+}
+
+// GetGetPreferencesSortOrderEnumValues Enumerates the set of values for GetPreferencesSortOrderEnum
+func GetGetPreferencesSortOrderEnumValues() []GetPreferencesSortOrderEnum {
+	values := make([]GetPreferencesSortOrderEnum, 0)
+	for _, v := range mappingGetPreferencesSortOrder {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetPreferencesSortByEnum Enum with underlying type: string
+type GetPreferencesSortByEnum string
+
+// Set of constants representing the allowable values for GetPreferencesSortByEnum
+const (
+	GetPreferencesSortByName GetPreferencesSortByEnum = "name"
+)
+
+var mappingGetPreferencesSortBy = map[string]GetPreferencesSortByEnum{
+	"name": GetPreferencesSortByName,
+}
+
+// GetGetPreferencesSortByEnumValues Enumerates the set of values for GetPreferencesSortByEnum
+func GetGetPreferencesSortByEnumValues() []GetPreferencesSortByEnum {
+	values := make([]GetPreferencesSortByEnum, 0)
+	for _, v := range mappingGetPreferencesSortBy {
+		values = append(values, v)
+	}
+	return values
+}

--- a/loganalytics/get_unprocessed_data_bucket_request_response.go
+++ b/loganalytics/get_unprocessed_data_bucket_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package loganalytics
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+	"net/http"
+)
+
+// GetUnprocessedDataBucketRequest wrapper for the GetUnprocessedDataBucket operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/loganalytics/GetUnprocessedDataBucket.go.html to see an example of how to use GetUnprocessedDataBucketRequest.
+type GetUnprocessedDataBucketRequest struct {
+
+	// The Logging Analytics namespace used for the request.
+	NamespaceName *string `mandatory:"true" contributesTo:"path" name:"namespaceName"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetUnprocessedDataBucketRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetUnprocessedDataBucketRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetUnprocessedDataBucketRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetUnprocessedDataBucketRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetUnprocessedDataBucketResponse wrapper for the GetUnprocessedDataBucket operation
+type GetUnprocessedDataBucketResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The UnprocessedDataBucket instance
+	UnprocessedDataBucket `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetUnprocessedDataBucketResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetUnprocessedDataBucketResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/loganalytics/highlight_groups_command_descriptor.go
+++ b/loganalytics/highlight_groups_command_descriptor.go
@@ -38,6 +38,9 @@ type HighlightGroupsCommandDescriptor struct {
 	// User specified priority assigned to highlighted matches if found.
 	Priority *string `mandatory:"false" json:"priority"`
 
+	// List of fields to search for terms or phrases to highlight.  If not specified all string fields are scanned.
+	MatchOnly []string `mandatory:"false" json:"matchOnly"`
+
 	// List of fields to search for terms or phrases to highlight.
 	Fields []string `mandatory:"false" json:"fields"`
 
@@ -99,6 +102,7 @@ func (m *HighlightGroupsCommandDescriptor) UnmarshalJSON(data []byte) (e error) 
 		DeclaredFields      []abstractfield    `json:"declaredFields"`
 		Color               *string            `json:"color"`
 		Priority            *string            `json:"priority"`
+		MatchOnly           []string           `json:"matchOnly"`
 		Fields              []string           `json:"fields"`
 		Keywords            []string           `json:"keywords"`
 		SubQueries          []ParseQueryOutput `json:"subQueries"`
@@ -142,6 +146,11 @@ func (m *HighlightGroupsCommandDescriptor) UnmarshalJSON(data []byte) (e error) 
 	m.Color = model.Color
 
 	m.Priority = model.Priority
+
+	m.MatchOnly = make([]string, len(model.MatchOnly))
+	for i, n := range model.MatchOnly {
+		m.MatchOnly[i] = n
+	}
 
 	m.Fields = make([]string, len(model.Fields))
 	for i, n := range model.Fields {

--- a/loganalytics/import_custom_content_request_response.go
+++ b/loganalytics/import_custom_content_request_response.go
@@ -37,6 +37,11 @@ type ImportCustomContentRequest struct {
 	// The client request ID for tracing.
 	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
 
+	// A value of `100-continue` requests preliminary verification of the request method, path, and headers before the request body is sent.
+	// If no error results from such verification, the server will send a 100 (Continue) interim response to indicate readiness for the request body.
+	// The only allowed value for this parameter is "100-Continue" (case-insensitive).
+	Expect *string `mandatory:"false" contributesTo:"header" name:"expect"`
+
 	// Metadata about the request. This information will not be transmitted to the service, but
 	// represents information that the SDK will consume to drive retry behavior.
 	RequestMetadata common.RequestMetadata

--- a/loganalytics/log_analytics_object_collection_rule.go
+++ b/loganalytics/log_analytics_object_collection_rule.go
@@ -83,6 +83,11 @@ type LogAnalyticsObjectCollectionRule struct {
 	// A detailed status of the life cycle state.
 	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
 
+	// When the filters are provided, only the objects matching the filters are picked up for processing.
+	// The matchType supported is exact match and accommodates wildcard "*".
+	// For more information on filters, see Event Filters (https://docs.oracle.com/en-us/iaas/Content/Events/Concepts/filterevents.htm).
+	ObjectNameFilters []string `mandatory:"false" json:"objectNameFilters"`
+
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// Example: `{"foo-namespace": {"bar-key": "value"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`

--- a/loganalytics/log_analytics_object_collection_rule_summary.go
+++ b/loganalytics/log_analytics_object_collection_rule_summary.go
@@ -53,6 +53,11 @@ type LogAnalyticsObjectCollectionRuleSummary struct {
 	// A detailed status of the life cycle state.
 	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
 
+	// When the filters are provided, only the objects matching the filters are picked up for processing.
+	// The matchType supported is exact match and accommodates wildcard "*".
+	// For more information on filters, see Event Filters (https://docs.oracle.com/en-us/iaas/Content/Events/Concepts/filterevents.htm).
+	ObjectNameFilters []string `mandatory:"false" json:"objectNameFilters"`
+
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// Example: `{"foo-namespace": {"bar-key": "value"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`

--- a/loganalytics/log_analytics_parser.go
+++ b/loganalytics/log_analytics_parser.go
@@ -108,6 +108,9 @@ type LogAnalyticsParser struct {
 
 	// A flag indicating whether or not the parser has been deleted.
 	IsUserDeleted *bool `mandatory:"false" json:"isUserDeleted"`
+
+	// A flag indicating whether the XML parser should consider the namespace(s) while processing the log data.
+	IsNamespaceAware *bool `mandatory:"false" json:"isNamespaceAware"`
 }
 
 func (m LogAnalyticsParser) String() string {

--- a/loganalytics/log_analytics_parser_summary.go
+++ b/loganalytics/log_analytics_parser_summary.go
@@ -108,6 +108,9 @@ type LogAnalyticsParserSummary struct {
 
 	// A flag indicating whether or not the parser has been deleted.
 	IsUserDeleted *bool `mandatory:"false" json:"isUserDeleted"`
+
+	// A flag indicating whether the XML parser should consider the namespace(s) while processing the log data.
+	IsNamespaceAware *bool `mandatory:"false" json:"isNamespaceAware"`
 }
 
 func (m LogAnalyticsParserSummary) String() string {

--- a/loganalytics/log_analytics_preference.go
+++ b/loganalytics/log_analytics_preference.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// LogAnalytics API
+//
+// The LogAnalytics API for the LogAnalytics service.
+//
+
+package loganalytics
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+)
+
+// LogAnalyticsPreference The preference information
+type LogAnalyticsPreference struct {
+
+	// The preference name. Currently, only "DEFAULT_HOMEPAGE" is supported.
+	Name *string `mandatory:"false" json:"name"`
+
+	// The preference value.
+	Value *string `mandatory:"false" json:"value"`
+}
+
+func (m LogAnalyticsPreference) String() string {
+	return common.PointerString(m)
+}

--- a/loganalytics/log_analytics_preference_collection.go
+++ b/loganalytics/log_analytics_preference_collection.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// LogAnalytics API
+//
+// The LogAnalytics API for the LogAnalytics service.
+//
+
+package loganalytics
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+)
+
+// LogAnalyticsPreferenceCollection A collection of preference information.
+type LogAnalyticsPreferenceCollection struct {
+
+	// An array of tenant preferences.
+	Items []LogAnalyticsPreference `mandatory:"false" json:"items"`
+}
+
+func (m LogAnalyticsPreferenceCollection) String() string {
+	return common.PointerString(m)
+}

--- a/loganalytics/log_analytics_preference_details.go
+++ b/loganalytics/log_analytics_preference_details.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// LogAnalytics API
+//
+// The LogAnalytics API for the LogAnalytics service.
+//
+
+package loganalytics
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+)
+
+// LogAnalyticsPreferenceDetails Preference information used to update preference settings.
+type LogAnalyticsPreferenceDetails struct {
+
+	// An array of tenant preference details.
+	Items []LogAnalyticsPreference `mandatory:"false" json:"items"`
+}
+
+func (m LogAnalyticsPreferenceDetails) String() string {
+	return common.PointerString(m)
+}

--- a/loganalytics/log_analytics_source_function.go
+++ b/loganalytics/log_analytics_source_function.go
@@ -33,6 +33,9 @@ type LogAnalyticsSourceFunction struct {
 	// The source unique identifier as a string.
 	SourceReference *string `mandatory:"false" json:"sourceReference"`
 
+	// Features of the source function to use for enrichment.
+	Features []string `mandatory:"false" json:"features"`
+
 	// The source function unique identifier.
 	FunctionId *int64 `mandatory:"false" json:"functionId"`
 

--- a/loganalytics/loganalytics_client.go
+++ b/loganalytics/loganalytics_client.go
@@ -50,6 +50,9 @@ func NewLogAnalyticsClientWithOboToken(configProvider common.ConfigurationProvid
 }
 
 func newLogAnalyticsClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client LogAnalyticsClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = LogAnalyticsClient{BaseClient: baseClient}
 	client.BasePath = "20200601"
 	err = client.setConfigurationProvider(configProvider)
@@ -3966,6 +3969,61 @@ func (client LogAnalyticsClient) getParserSummary(ctx context.Context, request c
 	return response, err
 }
 
+// GetPreferences Lists the preferences of the tenant. Currently, only "DEFAULT_HOMEPAGE" is supported.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/loganalytics/GetPreferences.go.html to see an example of how to use GetPreferences API.
+func (client LogAnalyticsClient) GetPreferences(ctx context.Context, request GetPreferencesRequest) (response GetPreferencesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getPreferences, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetPreferencesResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetPreferencesResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetPreferencesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetPreferencesResponse")
+	}
+	return
+}
+
+// getPreferences implements the OCIOperation interface (enables retrying operations)
+func (client LogAnalyticsClient) getPreferences(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/namespaces/{namespaceName}/preferences", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetPreferencesResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // GetQueryResult Returns the intermediate results for a query that was specified to run asynchronously if the query has not completed,
 // otherwise the final query results identified by a queryWorkRequestId returned when submitting the query execute asynchronously.
 //
@@ -4397,6 +4455,61 @@ func (client LogAnalyticsClient) getStorageWorkRequest(ctx context.Context, requ
 	}
 
 	var response GetStorageWorkRequestResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetUnprocessedDataBucket This API retrieves details of the configured bucket that stores unprocessed payloads.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/loganalytics/GetUnprocessedDataBucket.go.html to see an example of how to use GetUnprocessedDataBucket API.
+func (client LogAnalyticsClient) GetUnprocessedDataBucket(ctx context.Context, request GetUnprocessedDataBucketRequest) (response GetUnprocessedDataBucketResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getUnprocessedDataBucket, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetUnprocessedDataBucketResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetUnprocessedDataBucketResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetUnprocessedDataBucketResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetUnprocessedDataBucketResponse")
+	}
+	return
+}
+
+// getUnprocessedDataBucket implements the OCIOperation interface (enables retrying operations)
+func (client LogAnalyticsClient) getUnprocessedDataBucket(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/namespaces/{namespaceName}/unprocessedDataBucket", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetUnprocessedDataBucketResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -7603,6 +7716,68 @@ func (client LogAnalyticsClient) removeEntityAssociations(ctx context.Context, r
 	return response, err
 }
 
+// RemovePreferences Removes the tenant preferences. Currently, only "DEFAULT_HOMEPAGE" is supported.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/loganalytics/RemovePreferences.go.html to see an example of how to use RemovePreferences API.
+func (client LogAnalyticsClient) RemovePreferences(ctx context.Context, request RemovePreferencesRequest) (response RemovePreferencesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.removePreferences, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = RemovePreferencesResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = RemovePreferencesResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(RemovePreferencesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into RemovePreferencesResponse")
+	}
+	return
+}
+
+// removePreferences implements the OCIOperation interface (enables retrying operations)
+func (client LogAnalyticsClient) removePreferences(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+	if !common.IsEnvVarFalse(common.UsingExpectHeaderEnvVar) {
+		extraHeaders["Expect"] = "100-continue"
+	}
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/namespaces/{namespaceName}/preferences/actions/removePreferences", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response RemovePreferencesResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // RemoveSourceEventTypes Remove one or more event types from a source.
 //
 // See also
@@ -7770,6 +7945,63 @@ func (client LogAnalyticsClient) run(ctx context.Context, request common.OCIRequ
 	}
 
 	var response RunResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// SetUnprocessedDataBucket This API configures a bucket to store unprocessed payloads.
+// While processing there could be reasons a payload cannot be processed (mismatched structure, corrupted archive format, etc),
+// if configured the payload would be uploaded to the bucket for verification.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/loganalytics/SetUnprocessedDataBucket.go.html to see an example of how to use SetUnprocessedDataBucket API.
+func (client LogAnalyticsClient) SetUnprocessedDataBucket(ctx context.Context, request SetUnprocessedDataBucketRequest) (response SetUnprocessedDataBucketResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.setUnprocessedDataBucket, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = SetUnprocessedDataBucketResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = SetUnprocessedDataBucketResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(SetUnprocessedDataBucketResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into SetUnprocessedDataBucketResponse")
+	}
+	return
+}
+
+// setUnprocessedDataBucket implements the OCIOperation interface (enables retrying operations)
+func (client LogAnalyticsClient) setUnprocessedDataBucket(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/namespaces/{namespaceName}/actions/setUnprocessedDataBucket", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response SetUnprocessedDataBucketResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -8422,6 +8654,68 @@ func (client LogAnalyticsClient) updateLookupData(ctx context.Context, request c
 	}
 
 	var response UpdateLookupDataResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdatePreferences Updates the tenant preferences. Currently, only "DEFAULT_HOMEPAGE" is supported.
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/loganalytics/UpdatePreferences.go.html to see an example of how to use UpdatePreferences API.
+func (client LogAnalyticsClient) UpdatePreferences(ctx context.Context, request UpdatePreferencesRequest) (response UpdatePreferencesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.updatePreferences, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdatePreferencesResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdatePreferencesResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdatePreferencesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdatePreferencesResponse")
+	}
+	return
+}
+
+// updatePreferences implements the OCIOperation interface (enables retrying operations)
+func (client LogAnalyticsClient) updatePreferences(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+	if !common.IsEnvVarFalse(common.UsingExpectHeaderEnvVar) {
+		extraHeaders["Expect"] = "100-continue"
+	}
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/namespaces/{namespaceName}/preferences/actions/updatePreferences", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdatePreferencesResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)

--- a/loganalytics/register_lookup_request_response.go
+++ b/loganalytics/register_lookup_request_response.go
@@ -49,6 +49,11 @@ type RegisterLookupRequest struct {
 	// The client request ID for tracing.
 	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
 
+	// A value of `100-continue` requests preliminary verification of the request method, path, and headers before the request body is sent.
+	// If no error results from such verification, the server will send a 100 (Continue) interim response to indicate readiness for the request body.
+	// The only allowed value for this parameter is "100-Continue" (case-insensitive).
+	Expect *string `mandatory:"false" contributesTo:"header" name:"expect"`
+
 	// Metadata about the request. This information will not be transmitted to the service, but
 	// represents information that the SDK will consume to drive retry behavior.
 	RequestMetadata common.RequestMetadata

--- a/loganalytics/remove_preferences_request_response.go
+++ b/loganalytics/remove_preferences_request_response.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package loganalytics
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+	"net/http"
+)
+
+// RemovePreferencesRequest wrapper for the RemovePreferences operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/loganalytics/RemovePreferences.go.html to see an example of how to use RemovePreferencesRequest.
+type RemovePreferencesRequest struct {
+
+	// The Logging Analytics namespace used for the request.
+	NamespaceName *string `mandatory:"true" contributesTo:"path" name:"namespaceName"`
+
+	// Details of the tenant preferences to delete.
+	RemovePreferencesDetails LogAnalyticsPreferenceDetails `contributesTo:"body"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// might be rejected.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request RemovePreferencesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request RemovePreferencesRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request RemovePreferencesRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request RemovePreferencesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// RemovePreferencesResponse wrapper for the RemovePreferences operation
+type RemovePreferencesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response RemovePreferencesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response RemovePreferencesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/loganalytics/scheduled_task.go
+++ b/loganalytics/scheduled_task.go
@@ -77,7 +77,7 @@ type scheduledtask struct {
 	DisplayName         *string                           `mandatory:"true" json:"displayName"`
 	TaskType            TaskTypeEnum                      `mandatory:"true" json:"taskType"`
 	Schedules           json.RawMessage                   `mandatory:"true" json:"schedules"`
-	Action              json.RawMessage                   `mandatory:"true" json:"action"`
+	Action              Action                            `mandatory:"true" json:"action"`
 	CompartmentId       *string                           `mandatory:"true" json:"compartmentId"`
 	TimeCreated         *common.SDKTime                   `mandatory:"true" json:"timeCreated"`
 	TimeUpdated         *common.SDKTime                   `mandatory:"true" json:"timeUpdated"`
@@ -163,7 +163,7 @@ func (m scheduledtask) GetSchedules() json.RawMessage {
 }
 
 //GetAction returns Action
-func (m scheduledtask) GetAction() json.RawMessage {
+func (m scheduledtask) GetAction() Action {
 	return m.Action
 }
 

--- a/loganalytics/set_unprocessed_data_bucket_request_response.go
+++ b/loganalytics/set_unprocessed_data_bucket_request_response.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package loganalytics
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+	"net/http"
+)
+
+// SetUnprocessedDataBucketRequest wrapper for the SetUnprocessedDataBucket operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/loganalytics/SetUnprocessedDataBucket.go.html to see an example of how to use SetUnprocessedDataBucketRequest.
+type SetUnprocessedDataBucketRequest struct {
+
+	// The Logging Analytics namespace used for the request.
+	NamespaceName *string `mandatory:"true" contributesTo:"path" name:"namespaceName"`
+
+	// Name of the Object Storage bucket.
+	BucketName *string `mandatory:"true" contributesTo:"query" name:"bucketName"`
+
+	// The enabled flag used for filtering.  Only items with the specified enabled value
+	// will be returned.
+	IsEnabled *bool `mandatory:"false" contributesTo:"query" name:"isEnabled"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request SetUnprocessedDataBucketRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request SetUnprocessedDataBucketRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request SetUnprocessedDataBucketRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request SetUnprocessedDataBucketRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// SetUnprocessedDataBucketResponse wrapper for the SetUnprocessedDataBucket operation
+type SetUnprocessedDataBucketResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The UnprocessedDataBucket instance
+	UnprocessedDataBucket `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response SetUnprocessedDataBucketResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response SetUnprocessedDataBucketResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/loganalytics/test_parser_payload_details.go
+++ b/loganalytics/test_parser_payload_details.go
@@ -93,6 +93,9 @@ type TestParserPayloadDetails struct {
 
 	// The parser type.  Default value is REGEX.
 	Type TestParserPayloadDetailsTypeEnum `mandatory:"false" json:"type,omitempty"`
+
+	// A flag indicating whether the XML parser should consider the namespace(s) while processing the log data.
+	IsNamespaceAware *bool `mandatory:"false" json:"isNamespaceAware"`
 }
 
 func (m TestParserPayloadDetails) String() string {

--- a/loganalytics/time_column.go
+++ b/loganalytics/time_column.go
@@ -29,6 +29,9 @@ type TimeColumn struct {
 	// Identifies if this column allows multiple values to exist in a single row.
 	IsMultiValued *bool `mandatory:"false" json:"isMultiValued"`
 
+	// A flag indicating whether or not the field is a case sensitive field.  Only applies to string fields.
+	IsCaseSensitive *bool `mandatory:"false" json:"isCaseSensitive"`
+
 	// Identifies if this column can be used as a grouping field in any grouping command.
 	IsGroupable *bool `mandatory:"false" json:"isGroupable"`
 
@@ -77,6 +80,11 @@ func (m TimeColumn) GetIsListOfValues() *bool {
 //GetIsMultiValued returns IsMultiValued
 func (m TimeColumn) GetIsMultiValued() *bool {
 	return m.IsMultiValued
+}
+
+//GetIsCaseSensitive returns IsCaseSensitive
+func (m TimeColumn) GetIsCaseSensitive() *bool {
+	return m.IsCaseSensitive
 }
 
 //GetIsGroupable returns IsGroupable

--- a/loganalytics/trend_column.go
+++ b/loganalytics/trend_column.go
@@ -29,6 +29,9 @@ type TrendColumn struct {
 	// Identifies if this column allows multiple values to exist in a single row.
 	IsMultiValued *bool `mandatory:"false" json:"isMultiValued"`
 
+	// A flag indicating whether or not the field is a case sensitive field.  Only applies to string fields.
+	IsCaseSensitive *bool `mandatory:"false" json:"isCaseSensitive"`
+
 	// Identifies if this column can be used as a grouping field in any grouping command.
 	IsGroupable *bool `mandatory:"false" json:"isGroupable"`
 
@@ -86,6 +89,11 @@ func (m TrendColumn) GetIsListOfValues() *bool {
 //GetIsMultiValued returns IsMultiValued
 func (m TrendColumn) GetIsMultiValued() *bool {
 	return m.IsMultiValued
+}
+
+//GetIsCaseSensitive returns IsCaseSensitive
+func (m TrendColumn) GetIsCaseSensitive() *bool {
+	return m.IsCaseSensitive
 }
 
 //GetIsGroupable returns IsGroupable

--- a/loganalytics/unprocessed_data_bucket.go
+++ b/loganalytics/unprocessed_data_bucket.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// LogAnalytics API
+//
+// The LogAnalytics API for the LogAnalytics service.
+//
+
+package loganalytics
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+)
+
+// UnprocessedDataBucket Configuration details of the bucket that stores unprocessed payloads.
+type UnprocessedDataBucket struct {
+
+	// Object Storage namespace.
+	Namespace *string `mandatory:"true" json:"namespace"`
+
+	// Name of the Object Storage bucket.
+	BucketName *string `mandatory:"true" json:"bucketName"`
+
+	// Flag that specifies if this configuration is enabled or not.
+	IsEnabled *bool `mandatory:"false" json:"isEnabled"`
+
+	// The time when this record is created. An RFC3339 formatted datetime string.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The latest time when this record is updated. An RFC3339 formatted datetime string.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+}
+
+func (m UnprocessedDataBucket) String() string {
+	return common.PointerString(m)
+}

--- a/loganalytics/update_log_analytics_object_collection_rule_details.go
+++ b/loganalytics/update_log_analytics_object_collection_rule_details.go
@@ -43,6 +43,11 @@ type UpdateLogAnalyticsObjectCollectionRuleDetails struct {
 	// Supported matchType for override are "contains".
 	Overrides map[string][]PropertyOverride `mandatory:"false" json:"overrides"`
 
+	// When the filters are provided, only the objects matching the filters are picked up for processing.
+	// The matchType supported is exact match and accommodates wildcard "*".
+	// For more information on filters, see Event Filters (https://docs.oracle.com/en-us/iaas/Content/Events/Concepts/filterevents.htm).
+	ObjectNameFilters []string `mandatory:"false" json:"objectNameFilters"`
+
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// Example: `{"foo-namespace": {"bar-key": "value"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`

--- a/loganalytics/update_lookup_data_request_response.go
+++ b/loganalytics/update_lookup_data_request_response.go
@@ -49,6 +49,11 @@ type UpdateLookupDataRequest struct {
 	// provide matches the resource's current etag value.
 	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
 
+	// A value of `100-continue` requests preliminary verification of the request method, path, and headers before the request body is sent.
+	// If no error results from such verification, the server will send a 100 (Continue) interim response to indicate readiness for the request body.
+	// The only allowed value for this parameter is "100-Continue" (case-insensitive).
+	Expect *string `mandatory:"false" contributesTo:"header" name:"expect"`
+
 	// Metadata about the request. This information will not be transmitted to the service, but
 	// represents information that the SDK will consume to drive retry behavior.
 	RequestMetadata common.RequestMetadata

--- a/loganalytics/update_preferences_request_response.go
+++ b/loganalytics/update_preferences_request_response.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2016, 2018, 2021, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package loganalytics
+
+import (
+	"github.com/oracle/oci-go-sdk/v49/common"
+	"net/http"
+)
+
+// UpdatePreferencesRequest wrapper for the UpdatePreferences operation
+//
+// See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/loganalytics/UpdatePreferences.go.html to see an example of how to use UpdatePreferencesRequest.
+type UpdatePreferencesRequest struct {
+
+	// The Logging Analytics namespace used for the request.
+	NamespaceName *string `mandatory:"true" contributesTo:"path" name:"namespaceName"`
+
+	// Details of the tenant preferences to update.
+	UpdatePreferencesDetails LogAnalyticsPreferenceDetails `contributesTo:"body"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// might be rejected.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// The client request ID for tracing.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdatePreferencesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdatePreferencesRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request UpdatePreferencesRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdatePreferencesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdatePreferencesResponse wrapper for the UpdatePreferences operation
+type UpdatePreferencesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdatePreferencesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdatePreferencesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/loganalytics/update_scheduled_task_details.go
+++ b/loganalytics/update_scheduled_task_details.go
@@ -41,7 +41,7 @@ type updatescheduledtaskdetails struct {
 	DisplayName  *string                           `mandatory:"false" json:"displayName"`
 	FreeformTags map[string]string                 `mandatory:"false" json:"freeformTags"`
 	DefinedTags  map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
-	Schedules    []Schedule                        `mandatory:"false" json:"schedules"`
+	Schedules    json.RawMessage                   `mandatory:"false" json:"schedules"`
 	Kind         string                            `json:"kind"`
 }
 
@@ -99,7 +99,7 @@ func (m updatescheduledtaskdetails) GetDefinedTags() map[string]map[string]inter
 }
 
 //GetSchedules returns Schedules
-func (m updatescheduledtaskdetails) GetSchedules() []Schedule {
+func (m updatescheduledtaskdetails) GetSchedules() json.RawMessage {
 	return m.Schedules
 }
 

--- a/loganalytics/upload_log_events_file_request_response.go
+++ b/loganalytics/upload_log_events_file_request_response.go
@@ -49,6 +49,11 @@ type UploadLogEventsFileRequest struct {
 	// might be rejected.
 	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
 
+	// A value of `100-continue` requests preliminary verification of the request method, path, and headers before the request body is sent.
+	// If no error results from such verification, the server will send a 100 (Continue) interim response to indicate readiness for the request body.
+	// The only allowed value for this parameter is "100-Continue" (case-insensitive).
+	Expect *string `mandatory:"false" contributesTo:"header" name:"expect"`
+
 	// Metadata about the request. This information will not be transmitted to the service, but
 	// represents information that the SDK will consume to drive retry behavior.
 	RequestMetadata common.RequestMetadata

--- a/loganalytics/upload_log_file_request_response.go
+++ b/loganalytics/upload_log_file_request_response.go
@@ -76,6 +76,11 @@ type UploadLogFileRequest struct {
 	// The log set that gets associated with the uploaded logs.
 	LogSet *string `mandatory:"false" contributesTo:"query" name:"logSet"`
 
+	// A value of `100-continue` requests preliminary verification of the request method, path, and headers before the request body is sent.
+	// If no error results from such verification, the server will send a 100 (Continue) interim response to indicate readiness for the request body.
+	// The only allowed value for this parameter is "100-Continue" (case-insensitive).
+	Expect *string `mandatory:"false" contributesTo:"header" name:"expect"`
+
 	// Metadata about the request. This information will not be transmitted to the service, but
 	// represents information that the SDK will consume to drive retry behavior.
 	RequestMetadata common.RequestMetadata

--- a/loganalytics/upsert_log_analytics_parser_details.go
+++ b/loganalytics/upsert_log_analytics_parser_details.go
@@ -88,6 +88,9 @@ type UpsertLogAnalyticsParserDetails struct {
 
 	// The parser type.  Default value is REGEX.
 	Type UpsertLogAnalyticsParserDetailsTypeEnum `mandatory:"false" json:"type,omitempty"`
+
+	// A flag indicating whether the XML parser should consider the namespace(s) while processing the log data.
+	IsNamespaceAware *bool `mandatory:"false" json:"isNamespaceAware"`
 }
 
 func (m UpsertLogAnalyticsParserDetails) String() string {

--- a/logging/logging_loggingmanagement_client.go
+++ b/logging/logging_loggingmanagement_client.go
@@ -50,6 +50,9 @@ func NewLoggingManagementClientWithOboToken(configProvider common.ConfigurationP
 }
 
 func newLoggingManagementClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client LoggingManagementClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = LoggingManagementClient{BaseClient: baseClient}
 	client.BasePath = "20200531"
 	err = client.setConfigurationProvider(configProvider)

--- a/loggingingestion/loggingingestion_logging_client.go
+++ b/loggingingestion/loggingingestion_logging_client.go
@@ -50,6 +50,9 @@ func NewLoggingClientWithOboToken(configProvider common.ConfigurationProvider, o
 }
 
 func newLoggingClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client LoggingClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = LoggingClient{BaseClient: baseClient}
 	client.BasePath = "20200831"
 	err = client.setConfigurationProvider(configProvider)

--- a/loggingsearch/loggingsearch_logsearch_client.go
+++ b/loggingsearch/loggingsearch_logsearch_client.go
@@ -50,6 +50,9 @@ func NewLogSearchClientWithOboToken(configProvider common.ConfigurationProvider,
 }
 
 func newLogSearchClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client LogSearchClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = LogSearchClient{BaseClient: baseClient}
 	client.BasePath = "20190909"
 	err = client.setConfigurationProvider(configProvider)

--- a/managementagent/managementagent_client.go
+++ b/managementagent/managementagent_client.go
@@ -50,6 +50,9 @@ func NewManagementAgentClientWithOboToken(configProvider common.ConfigurationPro
 }
 
 func newManagementAgentClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ManagementAgentClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = ManagementAgentClient{BaseClient: baseClient}
 	client.BasePath = "20200202"
 	err = client.setConfigurationProvider(configProvider)

--- a/managementdashboard/managementdashboard_dashxapis_client.go
+++ b/managementdashboard/managementdashboard_dashxapis_client.go
@@ -51,6 +51,9 @@ func NewDashxApisClientWithOboToken(configProvider common.ConfigurationProvider,
 }
 
 func newDashxApisClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client DashxApisClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = DashxApisClient{BaseClient: baseClient}
 	client.BasePath = "20200901"
 	err = client.setConfigurationProvider(configProvider)

--- a/marketplace/marketplace_account_client.go
+++ b/marketplace/marketplace_account_client.go
@@ -50,6 +50,9 @@ func NewAccountClientWithOboToken(configProvider common.ConfigurationProvider, o
 }
 
 func newAccountClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client AccountClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = AccountClient{BaseClient: baseClient}
 	client.BasePath = "20181001"
 	err = client.setConfigurationProvider(configProvider)

--- a/marketplace/marketplace_client.go
+++ b/marketplace/marketplace_client.go
@@ -50,6 +50,9 @@ func NewMarketplaceClientWithOboToken(configProvider common.ConfigurationProvide
 }
 
 func newMarketplaceClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client MarketplaceClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = MarketplaceClient{BaseClient: baseClient}
 	client.BasePath = "20181001"
 	err = client.setConfigurationProvider(configProvider)

--- a/monitoring/monitoring_client.go
+++ b/monitoring/monitoring_client.go
@@ -52,6 +52,9 @@ func NewMonitoringClientWithOboToken(configProvider common.ConfigurationProvider
 }
 
 func newMonitoringClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client MonitoringClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = MonitoringClient{BaseClient: baseClient}
 	client.BasePath = "20180401"
 	err = client.setConfigurationProvider(configProvider)

--- a/mysql/mysql_channels_client.go
+++ b/mysql/mysql_channels_client.go
@@ -50,6 +50,9 @@ func NewChannelsClientWithOboToken(configProvider common.ConfigurationProvider, 
 }
 
 func newChannelsClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ChannelsClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = ChannelsClient{BaseClient: baseClient}
 	client.BasePath = "20190415"
 	err = client.setConfigurationProvider(configProvider)

--- a/mysql/mysql_dbbackups_client.go
+++ b/mysql/mysql_dbbackups_client.go
@@ -50,6 +50,9 @@ func NewDbBackupsClientWithOboToken(configProvider common.ConfigurationProvider,
 }
 
 func newDbBackupsClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client DbBackupsClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = DbBackupsClient{BaseClient: baseClient}
 	client.BasePath = "20190415"
 	err = client.setConfigurationProvider(configProvider)

--- a/mysql/mysql_dbsystem_client.go
+++ b/mysql/mysql_dbsystem_client.go
@@ -50,6 +50,9 @@ func NewDbSystemClientWithOboToken(configProvider common.ConfigurationProvider, 
 }
 
 func newDbSystemClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client DbSystemClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = DbSystemClient{BaseClient: baseClient}
 	client.BasePath = "20190415"
 	err = client.setConfigurationProvider(configProvider)

--- a/mysql/mysql_mysqlaas_client.go
+++ b/mysql/mysql_mysqlaas_client.go
@@ -50,6 +50,9 @@ func NewMysqlaasClientWithOboToken(configProvider common.ConfigurationProvider, 
 }
 
 func newMysqlaasClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client MysqlaasClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = MysqlaasClient{BaseClient: baseClient}
 	client.BasePath = "20190415"
 	err = client.setConfigurationProvider(configProvider)

--- a/mysql/mysql_workrequests_client.go
+++ b/mysql/mysql_workrequests_client.go
@@ -50,6 +50,9 @@ func NewWorkRequestsClientWithOboToken(configProvider common.ConfigurationProvid
 }
 
 func newWorkRequestsClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client WorkRequestsClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = WorkRequestsClient{BaseClient: baseClient}
 	client.BasePath = "20190415"
 	err = client.setConfigurationProvider(configProvider)

--- a/networkloadbalancer/networkloadbalancer_client.go
+++ b/networkloadbalancer/networkloadbalancer_client.go
@@ -50,6 +50,9 @@ func NewNetworkLoadBalancerClientWithOboToken(configProvider common.Configuratio
 }
 
 func newNetworkLoadBalancerClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client NetworkLoadBalancerClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = NetworkLoadBalancerClient{BaseClient: baseClient}
 	client.BasePath = "20200501"
 	err = client.setConfigurationProvider(configProvider)

--- a/nosql/nosql_client.go
+++ b/nosql/nosql_client.go
@@ -53,6 +53,9 @@ func NewNosqlClientWithOboToken(configProvider common.ConfigurationProvider, obo
 }
 
 func newNosqlClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client NosqlClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = NosqlClient{BaseClient: baseClient}
 	client.BasePath = "20190828"
 	err = client.setConfigurationProvider(configProvider)

--- a/objectstorage/objectstorage_client.go
+++ b/objectstorage/objectstorage_client.go
@@ -52,6 +52,9 @@ func NewObjectStorageClientWithOboToken(configProvider common.ConfigurationProvi
 }
 
 func newObjectStorageClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ObjectStorageClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = ObjectStorageClient{BaseClient: baseClient}
 	err = client.setConfigurationProvider(configProvider)
 	return

--- a/oce/oce_oceinstance_client.go
+++ b/oce/oce_oceinstance_client.go
@@ -50,6 +50,9 @@ func NewOceInstanceClientWithOboToken(configProvider common.ConfigurationProvide
 }
 
 func newOceInstanceClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client OceInstanceClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = OceInstanceClient{BaseClient: baseClient}
 	client.BasePath = "20190912"
 	err = client.setConfigurationProvider(configProvider)

--- a/ocvp/ocvp_esxihost_client.go
+++ b/ocvp/ocvp_esxihost_client.go
@@ -50,6 +50,9 @@ func NewEsxiHostClientWithOboToken(configProvider common.ConfigurationProvider, 
 }
 
 func newEsxiHostClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client EsxiHostClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = EsxiHostClient{BaseClient: baseClient}
 	client.BasePath = "20200501"
 	err = client.setConfigurationProvider(configProvider)

--- a/ocvp/ocvp_sddc_client.go
+++ b/ocvp/ocvp_sddc_client.go
@@ -50,6 +50,9 @@ func NewSddcClientWithOboToken(configProvider common.ConfigurationProvider, oboT
 }
 
 func newSddcClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client SddcClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = SddcClient{BaseClient: baseClient}
 	client.BasePath = "20200501"
 	err = client.setConfigurationProvider(configProvider)

--- a/ocvp/ocvp_workrequest_client.go
+++ b/ocvp/ocvp_workrequest_client.go
@@ -50,6 +50,9 @@ func NewWorkRequestClientWithOboToken(configProvider common.ConfigurationProvide
 }
 
 func newWorkRequestClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client WorkRequestClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = WorkRequestClient{BaseClient: baseClient}
 	client.BasePath = "20200501"
 	err = client.setConfigurationProvider(configProvider)

--- a/oda/oda_client.go
+++ b/oda/oda_client.go
@@ -50,6 +50,9 @@ func NewOdaClientWithOboToken(configProvider common.ConfigurationProvider, oboTo
 }
 
 func newOdaClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client OdaClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = OdaClient{BaseClient: baseClient}
 	client.BasePath = "20190506"
 	err = client.setConfigurationProvider(configProvider)

--- a/ons/ons_notificationcontrolplane_client.go
+++ b/ons/ons_notificationcontrolplane_client.go
@@ -51,6 +51,9 @@ func NewNotificationControlPlaneClientWithOboToken(configProvider common.Configu
 }
 
 func newNotificationControlPlaneClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client NotificationControlPlaneClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = NotificationControlPlaneClient{BaseClient: baseClient}
 	client.BasePath = "20181201"
 	err = client.setConfigurationProvider(configProvider)

--- a/ons/ons_notificationdataplane_client.go
+++ b/ons/ons_notificationdataplane_client.go
@@ -51,6 +51,9 @@ func NewNotificationDataPlaneClientWithOboToken(configProvider common.Configurat
 }
 
 func newNotificationDataPlaneClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client NotificationDataPlaneClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = NotificationDataPlaneClient{BaseClient: baseClient}
 	client.BasePath = "20181201"
 	err = client.setConfigurationProvider(configProvider)

--- a/operatoraccesscontrol/operatoraccesscontrol_accessrequests_client.go
+++ b/operatoraccesscontrol/operatoraccesscontrol_accessrequests_client.go
@@ -52,6 +52,9 @@ func NewAccessRequestsClientWithOboToken(configProvider common.ConfigurationProv
 }
 
 func newAccessRequestsClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client AccessRequestsClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = AccessRequestsClient{BaseClient: baseClient}
 	client.BasePath = "20200630"
 	err = client.setConfigurationProvider(configProvider)

--- a/operatoraccesscontrol/operatoraccesscontrol_operatoractions_client.go
+++ b/operatoraccesscontrol/operatoraccesscontrol_operatoractions_client.go
@@ -52,6 +52,9 @@ func NewOperatorActionsClientWithOboToken(configProvider common.ConfigurationPro
 }
 
 func newOperatorActionsClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client OperatorActionsClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = OperatorActionsClient{BaseClient: baseClient}
 	client.BasePath = "20200630"
 	err = client.setConfigurationProvider(configProvider)

--- a/operatoraccesscontrol/operatoraccesscontrol_operatorcontrol_client.go
+++ b/operatoraccesscontrol/operatoraccesscontrol_operatorcontrol_client.go
@@ -52,6 +52,9 @@ func NewOperatorControlClientWithOboToken(configProvider common.ConfigurationPro
 }
 
 func newOperatorControlClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client OperatorControlClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = OperatorControlClient{BaseClient: baseClient}
 	client.BasePath = "20200630"
 	err = client.setConfigurationProvider(configProvider)

--- a/operatoraccesscontrol/operatoraccesscontrol_operatorcontrolassignment_client.go
+++ b/operatoraccesscontrol/operatoraccesscontrol_operatorcontrolassignment_client.go
@@ -52,6 +52,9 @@ func NewOperatorControlAssignmentClientWithOboToken(configProvider common.Config
 }
 
 func newOperatorControlAssignmentClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client OperatorControlAssignmentClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = OperatorControlAssignmentClient{BaseClient: baseClient}
 	client.BasePath = "20200630"
 	err = client.setConfigurationProvider(configProvider)

--- a/opsi/opsi_operationsinsights_client.go
+++ b/opsi/opsi_operationsinsights_client.go
@@ -52,6 +52,9 @@ func NewOperationsInsightsClientWithOboToken(configProvider common.Configuration
 }
 
 func newOperationsInsightsClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client OperationsInsightsClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = OperationsInsightsClient{BaseClient: baseClient}
 	client.BasePath = "20200630"
 	err = client.setConfigurationProvider(configProvider)

--- a/optimizer/optimizer_client.go
+++ b/optimizer/optimizer_client.go
@@ -50,6 +50,9 @@ func NewOptimizerClientWithOboToken(configProvider common.ConfigurationProvider,
 }
 
 func newOptimizerClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client OptimizerClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = OptimizerClient{BaseClient: baseClient}
 	client.BasePath = "20200606"
 	err = client.setConfigurationProvider(configProvider)

--- a/osmanagement/osmanagement_client.go
+++ b/osmanagement/osmanagement_client.go
@@ -51,6 +51,9 @@ func NewOsManagementClientWithOboToken(configProvider common.ConfigurationProvid
 }
 
 func newOsManagementClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client OsManagementClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = OsManagementClient{BaseClient: baseClient}
 	client.BasePath = "20190801"
 	err = client.setConfigurationProvider(configProvider)

--- a/osmanagement/osmanagement_event_client.go
+++ b/osmanagement/osmanagement_event_client.go
@@ -51,6 +51,9 @@ func NewEventClientWithOboToken(configProvider common.ConfigurationProvider, obo
 }
 
 func newEventClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client EventClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = EventClient{BaseClient: baseClient}
 	client.BasePath = "20190801"
 	err = client.setConfigurationProvider(configProvider)

--- a/resourcemanager/resourcemanager_client.go
+++ b/resourcemanager/resourcemanager_client.go
@@ -53,6 +53,9 @@ func NewResourceManagerClientWithOboToken(configProvider common.ConfigurationPro
 }
 
 func newResourceManagerClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ResourceManagerClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = ResourceManagerClient{BaseClient: baseClient}
 	client.BasePath = "20180917"
 	err = client.setConfigurationProvider(configProvider)

--- a/resourcesearch/resourcesearch_client.go
+++ b/resourcesearch/resourcesearch_client.go
@@ -50,6 +50,9 @@ func NewResourceSearchClientWithOboToken(configProvider common.ConfigurationProv
 }
 
 func newResourceSearchClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ResourceSearchClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = ResourceSearchClient{BaseClient: baseClient}
 	client.BasePath = "20180409"
 	err = client.setConfigurationProvider(configProvider)

--- a/rover/rover_rovercluster_client.go
+++ b/rover/rover_rovercluster_client.go
@@ -50,6 +50,9 @@ func NewRoverClusterClientWithOboToken(configProvider common.ConfigurationProvid
 }
 
 func newRoverClusterClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client RoverClusterClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = RoverClusterClient{BaseClient: baseClient}
 	client.BasePath = "20201210"
 	err = client.setConfigurationProvider(configProvider)

--- a/rover/rover_roverentitlement_client.go
+++ b/rover/rover_roverentitlement_client.go
@@ -50,6 +50,9 @@ func NewRoverEntitlementClientWithOboToken(configProvider common.ConfigurationPr
 }
 
 func newRoverEntitlementClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client RoverEntitlementClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = RoverEntitlementClient{BaseClient: baseClient}
 	client.BasePath = "20201210"
 	err = client.setConfigurationProvider(configProvider)

--- a/rover/rover_rovernode_client.go
+++ b/rover/rover_rovernode_client.go
@@ -50,6 +50,9 @@ func NewRoverNodeClientWithOboToken(configProvider common.ConfigurationProvider,
 }
 
 func newRoverNodeClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client RoverNodeClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = RoverNodeClient{BaseClient: baseClient}
 	client.BasePath = "20201210"
 	err = client.setConfigurationProvider(configProvider)

--- a/sch/sch_serviceconnector_client.go
+++ b/sch/sch_serviceconnector_client.go
@@ -52,6 +52,9 @@ func NewServiceConnectorClientWithOboToken(configProvider common.ConfigurationPr
 }
 
 func newServiceConnectorClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ServiceConnectorClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = ServiceConnectorClient{BaseClient: baseClient}
 	client.BasePath = "20200909"
 	err = client.setConfigurationProvider(configProvider)

--- a/secrets/secrets_client.go
+++ b/secrets/secrets_client.go
@@ -50,6 +50,9 @@ func NewSecretsClientWithOboToken(configProvider common.ConfigurationProvider, o
 }
 
 func newSecretsClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client SecretsClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = SecretsClient{BaseClient: baseClient}
 	client.BasePath = "20190301"
 	err = client.setConfigurationProvider(configProvider)

--- a/servicecatalog/servicecatalog_client.go
+++ b/servicecatalog/servicecatalog_client.go
@@ -50,6 +50,9 @@ func NewServiceCatalogClientWithOboToken(configProvider common.ConfigurationProv
 }
 
 func newServiceCatalogClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ServiceCatalogClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = ServiceCatalogClient{BaseClient: baseClient}
 	client.BasePath = "20210527"
 	err = client.setConfigurationProvider(configProvider)

--- a/streaming/streaming_stream_client.go
+++ b/streaming/streaming_stream_client.go
@@ -50,6 +50,9 @@ func NewStreamClientWithOboToken(configProvider common.ConfigurationProvider, ob
 }
 
 func newStreamClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider, endpoint string) (client StreamClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = StreamClient{BaseClient: baseClient}
 	client.BasePath = "20180418"
 	client.Host = endpoint

--- a/streaming/streaming_streamadmin_client.go
+++ b/streaming/streaming_streamadmin_client.go
@@ -50,6 +50,9 @@ func NewStreamAdminClientWithOboToken(configProvider common.ConfigurationProvide
 }
 
 func newStreamAdminClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client StreamAdminClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = StreamAdminClient{BaseClient: baseClient}
 	client.BasePath = "20180418"
 	err = client.setConfigurationProvider(configProvider)

--- a/tenantmanagercontrolplane/tenantmanagercontrolplane_domain_client.go
+++ b/tenantmanagercontrolplane/tenantmanagercontrolplane_domain_client.go
@@ -50,6 +50,9 @@ func NewDomainClientWithOboToken(configProvider common.ConfigurationProvider, ob
 }
 
 func newDomainClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client DomainClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = DomainClient{BaseClient: baseClient}
 	client.BasePath = "20200801"
 	err = client.setConfigurationProvider(configProvider)

--- a/tenantmanagercontrolplane/tenantmanagercontrolplane_domaingovernance_client.go
+++ b/tenantmanagercontrolplane/tenantmanagercontrolplane_domaingovernance_client.go
@@ -50,6 +50,9 @@ func NewDomainGovernanceClientWithOboToken(configProvider common.ConfigurationPr
 }
 
 func newDomainGovernanceClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client DomainGovernanceClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = DomainGovernanceClient{BaseClient: baseClient}
 	client.BasePath = "20200801"
 	err = client.setConfigurationProvider(configProvider)

--- a/tenantmanagercontrolplane/tenantmanagercontrolplane_link_client.go
+++ b/tenantmanagercontrolplane/tenantmanagercontrolplane_link_client.go
@@ -50,6 +50,9 @@ func NewLinkClientWithOboToken(configProvider common.ConfigurationProvider, oboT
 }
 
 func newLinkClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client LinkClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = LinkClient{BaseClient: baseClient}
 	client.BasePath = "20200801"
 	err = client.setConfigurationProvider(configProvider)

--- a/tenantmanagercontrolplane/tenantmanagercontrolplane_orders_client.go
+++ b/tenantmanagercontrolplane/tenantmanagercontrolplane_orders_client.go
@@ -50,6 +50,9 @@ func NewOrdersClientWithOboToken(configProvider common.ConfigurationProvider, ob
 }
 
 func newOrdersClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client OrdersClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = OrdersClient{BaseClient: baseClient}
 	client.BasePath = "20200801"
 	err = client.setConfigurationProvider(configProvider)

--- a/tenantmanagercontrolplane/tenantmanagercontrolplane_recipientinvitation_client.go
+++ b/tenantmanagercontrolplane/tenantmanagercontrolplane_recipientinvitation_client.go
@@ -50,6 +50,9 @@ func NewRecipientInvitationClientWithOboToken(configProvider common.Configuratio
 }
 
 func newRecipientInvitationClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client RecipientInvitationClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = RecipientInvitationClient{BaseClient: baseClient}
 	client.BasePath = "20200801"
 	err = client.setConfigurationProvider(configProvider)

--- a/tenantmanagercontrolplane/tenantmanagercontrolplane_senderinvitation_client.go
+++ b/tenantmanagercontrolplane/tenantmanagercontrolplane_senderinvitation_client.go
@@ -50,6 +50,9 @@ func NewSenderInvitationClientWithOboToken(configProvider common.ConfigurationPr
 }
 
 func newSenderInvitationClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client SenderInvitationClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = SenderInvitationClient{BaseClient: baseClient}
 	client.BasePath = "20200801"
 	err = client.setConfigurationProvider(configProvider)

--- a/tenantmanagercontrolplane/tenantmanagercontrolplane_workrequest_client.go
+++ b/tenantmanagercontrolplane/tenantmanagercontrolplane_workrequest_client.go
@@ -50,6 +50,9 @@ func NewWorkRequestClientWithOboToken(configProvider common.ConfigurationProvide
 }
 
 func newWorkRequestClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client WorkRequestClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = WorkRequestClient{BaseClient: baseClient}
 	client.BasePath = "20200801"
 	err = client.setConfigurationProvider(configProvider)

--- a/usageapi/usageapi_client.go
+++ b/usageapi/usageapi_client.go
@@ -50,6 +50,9 @@ func NewUsageapiClientWithOboToken(configProvider common.ConfigurationProvider, 
 }
 
 func newUsageapiClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client UsageapiClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = UsageapiClient{BaseClient: baseClient}
 	client.BasePath = "20200107"
 	err = client.setConfigurationProvider(configProvider)

--- a/vault/vault_vaults_client.go
+++ b/vault/vault_vaults_client.go
@@ -50,6 +50,9 @@ func NewVaultsClientWithOboToken(configProvider common.ConfigurationProvider, ob
 }
 
 func newVaultsClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client VaultsClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = VaultsClient{BaseClient: baseClient}
 	client.BasePath = "20180608"
 	err = client.setConfigurationProvider(configProvider)

--- a/vulnerabilityscanning/vulnerabilityscanning_client.go
+++ b/vulnerabilityscanning/vulnerabilityscanning_client.go
@@ -50,6 +50,9 @@ func NewVulnerabilityScanningClientWithOboToken(configProvider common.Configurat
 }
 
 func newVulnerabilityScanningClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client VulnerabilityScanningClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = VulnerabilityScanningClient{BaseClient: baseClient}
 	client.BasePath = "20210215"
 	err = client.setConfigurationProvider(configProvider)

--- a/waas/waas_client.go
+++ b/waas/waas_client.go
@@ -50,6 +50,9 @@ func NewWaasClientWithOboToken(configProvider common.ConfigurationProvider, oboT
 }
 
 func newWaasClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client WaasClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = WaasClient{BaseClient: baseClient}
 	client.BasePath = "20181116"
 	err = client.setConfigurationProvider(configProvider)

--- a/waas/waas_redirect_client.go
+++ b/waas/waas_redirect_client.go
@@ -50,6 +50,9 @@ func NewRedirectClientWithOboToken(configProvider common.ConfigurationProvider, 
 }
 
 func newRedirectClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client RedirectClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = RedirectClient{BaseClient: baseClient}
 	client.BasePath = "20181116"
 	err = client.setConfigurationProvider(configProvider)

--- a/waf/waf_client.go
+++ b/waf/waf_client.go
@@ -51,6 +51,9 @@ func NewWafClientWithOboToken(configProvider common.ConfigurationProvider, oboTo
 }
 
 func newWafClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client WafClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = WafClient{BaseClient: baseClient}
 	client.BasePath = "20210930"
 	err = client.setConfigurationProvider(configProvider)

--- a/workrequests/workrequests_workrequest_client.go
+++ b/workrequests/workrequests_workrequest_client.go
@@ -54,6 +54,9 @@ func NewWorkRequestClientWithOboToken(configProvider common.ConfigurationProvide
 }
 
 func newWorkRequestClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client WorkRequestClient, err error) {
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
 	client = WorkRequestClient{BaseClient: baseClient}
 	client.BasePath = "20160918"
 	err = client.setConfigurationProvider(configProvider)


### PR DESCRIPTION
### Added

- Support for creating database systems from backups with database software images in the Database service

- Support for optionally providing a SID prefix during Exadata database creation in the Database service

- Support for node subsetting on VM clusters in the Database service

- Support for non-CDB to PDB conversion in the Database service

- Support for default homepages, unprocessed data buckets, and parsing geostats in the Logging Analytics service

- Support for creating instance principal delegation token in a specific region

- Support for circuit breaker feature


