### PR TITLE
Fix sdkTimeFormat

### DIFF
--- a/common/helpers.go
+++ b/common/helpers.go
@@ -124,7 +124,7 @@ var sdkDateType = reflect.TypeOf(SDKDate{})
 var sdkDateTypePtr = reflect.TypeOf(&SDKDate{})
 
 //Formats for sdk supported time representations
-const sdkTimeFormat = time.RFC3339Nano
+const sdkTimeFormat = "2006-01-02T15:04:05.000Z07:00"
 const rfc1123OptionalLeadingDigitsInDay = "Mon, _2 Jan 2006 15:04:05 MST"
 const sdkDateFormat = "2006-01-02"
 
@@ -132,7 +132,7 @@ func tryParsingTimeWithValidFormatsForHeaders(data []byte, headerName string) (t
 	header := strings.ToLower(headerName)
 	switch header {
 	case "lastmodified", "date":
-		t, err = tryParsing(data, time.RFC3339Nano, time.RFC3339, time.RFC1123, rfc1123OptionalLeadingDigitsInDay, time.RFC850, time.ANSIC)
+		t, err = tryParsing(data, time.RFC3339Nano, sdkTimeFormat, time.RFC3339, time.RFC1123, rfc1123OptionalLeadingDigitsInDay, time.RFC850, time.ANSIC)
 		return
 	default: //By default we parse with RFC3339
 		t, err = time.Parse(sdkTimeFormat, string(data))

--- a/common/http_test.go
+++ b/common/http_test.go
@@ -241,7 +241,7 @@ func TestHttpMarshalerAll(t *testing.T) {
 	var content map[string]string
 	body, _ := ioutil.ReadAll(request.Body)
 	json.Unmarshal(body, &content)
-	when := s.When.Format(time.RFC3339Nano)
+	when := s.When.Format(sdkTimeFormat)
 	assert.True(t, request.URL.Path == "//101")
 	assert.True(t, request.URL.Query().Get("name") == s.Name)
 	assert.True(t, request.URL.Query().Get("income") == strconv.FormatFloat(float64(s.Income), 'f', 2, 32))
@@ -314,7 +314,7 @@ func TestHttpMarshallerSimpleStructPointers(t *testing.T) {
 	assert.Equal(t, "", request.Header.Get(requestHeaderOpcRetryToken))
 	assert.True(t, strings.Contains(request.URL.Path, "111"))
 	assert.True(t, strings.Contains(string(all), "thekey"))
-	assert.Contains(t, string(all), now.Format(time.RFC3339Nano))
+	assert.Contains(t, string(all), now.Format(sdkTimeFormat))
 }
 
 func TestHttpMarshallerSimpleStructPointersFilled(t *testing.T) {
@@ -1190,11 +1190,11 @@ func TestToStringValue_TimeFormat(t *testing.T) {
 	}{
 		{
 			Input:    "2018-10-15T19:43:05.080Z",
-			Expected: "2018-10-15T19:43:05.08Z",
+			Expected: "2018-10-15T19:43:05.080Z",
 		},
 		{
 			Input:    "2018-10-15T19:43:05Z",
-			Expected: "2018-10-15T19:43:05Z",
+			Expected: "2018-10-15T19:43:05.000Z",
 		},
 	}
 


### PR DESCRIPTION
OCI server accept milliseconds not nanoseconds for any datetime formats. I noticed this issue because oracle/oci-dotnet-sdk does not get errors for loggingingestion.PutLogs but Go get errors. Python SDK might have same issue.

Related issue:
https://github.com/oracle/oci-python-sdk/issues/333