### PR TITLE
don't hijack TF_VAR, please use OCI instead.

### DIFF
--- a/common/client.go
+++ b/common/client.go
@@ -319,11 +319,11 @@ func getHomeFolder() string {
 }
 
 // DefaultConfigProvider returns the default config provider. The default config provider
-// will look for configurations in 3 places: file in $HOME/.oci/config, HOME/.obmcs/config and
-// variables names starting with the string TF_VAR. If the same configuration is found in multiple
-// places the provider will prefer the first one.
-// If the config file is not placed in the default location, the environment variable
-// OCI_CONFIG_FILE can provide the config file location.
+// will look for configurations in 3 places: file in $HOME/.oci/config, HOME/.obmcs/config,
+// and variables names starting with the string OCI_. If the same configuration is found in
+// multiple places the provider will prefer the first one. If the config file is not placed
+// in the default location, the environment variable OCI_CONFIG_FILE can provide the config
+// file location.
 func DefaultConfigProvider() ConfigurationProvider {
 	defaultConfigFile := getDefaultConfigFilePath()
 	homeFolder := getHomeFolder()
@@ -331,7 +331,7 @@ func DefaultConfigProvider() ConfigurationProvider {
 
 	defaultFileProvider, _ := ConfigurationProviderFromFile(defaultConfigFile, "")
 	secondaryFileProvider, _ := ConfigurationProviderFromFile(secondaryConfigFile, "")
-	environmentProvider := environmentConfigurationProvider{EnvironmentVariablePrefix: "TF_VAR"}
+	environmentProvider := environmentConfigurationProvider{EnvironmentVariablePrefix: "OCI"}
 
 	provider, _ := ComposingConfigurationProvider([]ConfigurationProvider{defaultFileProvider, secondaryFileProvider, environmentProvider})
 	Debugf("Configuration provided by: %s", provider)
@@ -393,8 +393,8 @@ func setRawPath(u *url.URL) error {
 }
 
 // CustomProfileConfigProvider returns the config provider of given profile. The custom profile config provider
-// will look for configurations in 2 places: file in $HOME/.oci/config,  and variables names starting with the
-// string TF_VAR. If the same configuration is found in multiple places the provider will prefer the first one.
+// will look for configurations in 2 places: file in $HOME/.oci/config and variables names starting with the
+// string OCI. If the same configuration is found in multiple places the provider will prefer the first one.
 func CustomProfileConfigProvider(customConfigPath string, profile string) ConfigurationProvider {
 	homeFolder := getHomeFolder()
 	if customConfigPath == "" {
@@ -402,7 +402,7 @@ func CustomProfileConfigProvider(customConfigPath string, profile string) Config
 	}
 	customFileProvider, _ := ConfigurationProviderFromFileWithProfile(customConfigPath, profile, "")
 	defaultFileProvider, _ := ConfigurationProviderFromFileWithProfile(customConfigPath, "DEFAULT", "")
-	environmentProvider := environmentConfigurationProvider{EnvironmentVariablePrefix: "TF_VAR"}
+	environmentProvider := environmentConfigurationProvider{EnvironmentVariablePrefix: "OCI"}
 	provider, _ := ComposingConfigurationProvider([]ConfigurationProvider{customFileProvider, defaultFileProvider, environmentProvider})
 	Debugf("Configuration provided by: %s", provider)
 	return provider


### PR DESCRIPTION
Please consider using your own prefix for environment variables (`OCI` suggested here). For consumers of this SDK that are not using terraform, `TF_VAR` is nonsensical. For consumers of terraform, the fact that `TF_VAR` references are accepted with no corresponding terraform variable blocks is very confusing.

Given this local configuration...
```bash
export TF_VAR_tenancy_ocid="..."
export TF_VAR_compartment_ocid="..."
export TF_VAR_user_ocid="..."
export TF_VAR_fingerprint="..."
export TF_VAR_private_key="..."
```

It should NOT be possible to authenticate to OCI using this terraform configuration:
```hcl
provider "oci" {}
```

When using `TF_VAR` as a prefix, in every other case within terraform, this configuration would be consistent with every other usage of terraform that exists in the ecosystem today:
```hcl
provider "oci" {
  region       = "us-chicago-1"
  tenancy_ocid = var.tenancy_ocid
  user_ocid    = var.user_ocid
  fingerprint  = var.fingerprint
  private_key  = var.private_key
}

variable "tenancy_ocid" {}
variable "user_ocid" {}
variable "fingerprint" {}
variable "private_key" {}
```

By changing the supported prefix to `OCI` and removing `TF_VAR` you would be introducing a breaking change for downstream consumers. Authentication with explicit variable references would stop working. This breaking change is _expected_ behavior everywhere else in the terraform ecosystem.

If this change is landed, the following configuration would produce "normal" behavior consistent with every other provider in the ecosystem:
```bash
export OCI_tenancy_ocid="..."
export OCI_compartment_ocid="..."
export OCI_user_ocid="..."
export OCI_fingerprint="..."
export OCI_private_key="..."
```

```hcl
provider oci {}
```.

For reference, in the AWS world the same is possible using AWS-prefixed environment variables like `AWS_ACCESS_KEY` etc.

If this is landed, the documentation [here](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/terraformproviderconfiguration.htm#APIKeyAuth) should simply switch from TF_VAR prefixes to OCI prefixes. Again, though this would be a breaking change, it would produce behavior consistent with the entire terraform ecosystem. If there are OSS repositories for this documentation I would be happy to submit companion PRs that explain this "fix".

/ref https://github.com/oracle/oci-go-sdk/issues/318#issuecomment-2074824309
