### PR TITLE
Add Queue capabilities support

### DIFF
--- a/queue/create_queue_details.go
+++ b/queue/create_queue_details.go
@@ -11,8 +11,9 @@ package queue
 
 import (
 	"fmt"
-	"github.com/oracle/oci-go-sdk/v65/common"
 	"strings"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
 )
 
 // CreateQueueDetails The information about a new queue.
@@ -49,6 +50,10 @@ type CreateQueueDetails struct {
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// Example: `{"foo-namespace": {"bar-key": "value"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// The capabilities configuration for the queue.
+	// Example: `[{"type": "CONSUMER_GROUPS", "isPrimaryConsumerGroupEnabled": false}]`
+	Capabilities []QueueCapability `mandatory:"false" json:"capabilities"`
 }
 
 func (m CreateQueueDetails) String() string {

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -11,8 +11,9 @@ package queue
 
 import (
 	"fmt"
-	"github.com/oracle/oci-go-sdk/v65/common"
 	"strings"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
 )
 
 // Queue A detailed representation of a queue and its configuration.
@@ -73,6 +74,10 @@ type Queue struct {
 
 	// The percentage of allocated queue resources that can be consumed by a single channel. For example, if a queue has a storage limit of 2Gb, and a single channel consumption limit is 0.1 (10%), that means data size of a single channel  can't exceed 200Mb. Consumption limit of 100% (default) means that a single channel can consume up-to all allocated queue's resources.
 	ChannelConsumptionLimit *int `mandatory:"false" json:"channelConsumptionLimit"`
+
+	// The capabilities configuration for the queue.
+	// Example: `[{"type": "CONSUMER_GROUPS", "isPrimaryConsumerGroupEnabled": false}]`
+	Capabilities []QueueCapability `mandatory:"false" json:"capabilities"`
 }
 
 func (m Queue) String() string {

--- a/queue/queue_capability.go
+++ b/queue/queue_capability.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2016, 2018, 2025, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Queue API
+//
+// Use the Queue API to produce and consume messages, create queues, and manage related items. For more information, see Queue (https://docs.oracle.com/iaas/Content/queue/overview.htm).
+//
+
+package queue
+
+import (
+	"github.com/oracle/oci-go-sdk/v65/common"
+)
+
+// QueueCapability A capability configuration for a queue.
+type QueueCapability struct {
+
+	// The type of capability.
+	// Example: CONSUMER_GROUPS
+	Type *string `mandatory:"false" json:"type,omitempty"`
+
+	// Whether the primary consumer group is enabled for this capability.
+	IsPrimaryConsumerGroupEnabled *bool `mandatory:"false" json:"isPrimaryConsumerGroupEnabled,omitempty"`
+}
+
+func (m QueueCapability) String() string {
+	return common.PointerString(m)
+}

--- a/queue/update_queue_details.go
+++ b/queue/update_queue_details.go
@@ -11,8 +11,9 @@ package queue
 
 import (
 	"fmt"
-	"github.com/oracle/oci-go-sdk/v65/common"
 	"strings"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
 )
 
 // UpdateQueueDetails The information to be updated.
@@ -45,6 +46,10 @@ type UpdateQueueDetails struct {
 	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
 	// Example: `{"foo-namespace": {"bar-key": "value"}}`
 	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// The capabilities configuration for the queue.
+	// Example: `[{"type": "CONSUMER_GROUPS", "isPrimaryConsumerGroupEnabled": false}]`
+	Capabilities []QueueCapability `mandatory:"false" json:"capabilities"`
 }
 
 func (m UpdateQueueDetails) String() string {


### PR DESCRIPTION
## Description

This PR adds support for queue capabilities configuration in the Queue service API. This enables users to configure capabilities such as consumer groups when creating or updating queues. 

## Changes Made

This PR introduces the `QueueCapability` model and integrates it into queue creation, update, and retrieval operations:

1. **New Model: `QueueCapability`** (`queue/queue_capability.go`)
   - `Type` (string, optional): The type of capability (e.g., "CONSUMER_GROUPS")
   - `IsPrimaryConsumerGroupEnabled` (bool, optional): Whether the primary consumer group is enabled for this capability

2. **Updated Models:**
   - `CreateQueueDetails`: Added `Capabilities []QueueCapability` field
   - `UpdateQueueDetails`: Added `Capabilities []QueueCapability` field  
   - `Queue`: Added `Capabilities []QueueCapability` field
