### PR TITLE
auth: fix incorrect env var name in resource principal error message …

### DIFF
--- a/common/auth/resource_principal_key_provider.go
+++ b/common/auth/resource_principal_key_provider.go
@@ -89,7 +89,7 @@ func ResourcePrincipalConfigurationProvider() (ConfigurationProviderWithClaimAcc
 	case ResourcePrincipalVersion2_2:
 		rpst := requireEnv(ResourcePrincipalRPSTEnvVar)
 		if rpst == nil {
-			err := fmt.Errorf("can not create resource principal, environment variable: %s, not present", ResourcePrincipalVersionEnvVar)
+			err := fmt.Errorf("can not create resource principal, environment variable: %s, not present", ResourcePrincipalRPSTEnvVar)
 			return nil, resourcePrincipalError{err: err}
 		}
 		private := requireEnv(ResourcePrincipalPrivatePEMEnvVar)


### PR DESCRIPTION
## Description
This PR fixes a bug in `resource_principal_key_provider.go` where the error message incorrectly identified the missing environment variable. 

When `OCI_RESOURCE_PRINCIPAL_RPST` was missing, the SDK incorrectly reported that `OCI_RESOURCE_PRINCIPAL_VERSION` was the cause of the failure.

## Changes
- Modified `common/auth/resource_principal_key_provider.go` to use the `ResourcePrincipalRPSTEnvVar` constant in the error string when the RPST lookup fails.

## Validation
- **Reproduction:** Verified using a local script that the error message now correctly identifies `OCI_RESOURCE_PRINCIPAL_RPST`.
- **Unit Tests:** Ran `go test -v ./common/auth`. All 42 tests passed.
- **Compliance:** Commit includes the `Signed-off-by` footer as required by the Oracle Contributor Agreement (OCA).

Fixes #609