### PR TITLE
Support hardware-backed signers such as Yubikey

### DIFF
--- a/common/auth/configuration.go
+++ b/common/auth/configuration.go
@@ -4,7 +4,7 @@
 package auth
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -77,7 +77,7 @@ func InstancePrincipalConfigurationWithCerts(region common.Region, leafCertifica
 
 }
 
-func (p instancePrincipalConfigurationProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
+func (p instancePrincipalConfigurationProvider) PrivateRSAKey() (crypto.Signer, error) {
 	return p.keyProvider.PrivateRSAKey()
 }
 

--- a/common/auth/federation_client.go
+++ b/common/auth/federation_client.go
@@ -6,6 +6,7 @@ package auth
 
 import (
 	"context"
+	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -171,7 +172,7 @@ func (c *oAuth2FederationClient) KeyID() (string, error) {
 }
 
 // PrivateRSAKey calls the PrivateRSAKey method of the auth provider given to the federation client
-func (c *oAuth2FederationClient) PrivateRSAKey() (*rsa.PrivateKey, error) {
+func (c *oAuth2FederationClient) PrivateRSAKey() (crypto.Signer, error) {
 	return c.authClientKeyProvider.PrivateRSAKey()
 }
 
@@ -407,7 +408,7 @@ func (c *x509FederationClient) KeyID() (string, error) {
 }
 
 // For authClient to sign requests to X509 Federation Endpoint
-func (c *x509FederationClient) PrivateRSAKey() (*rsa.PrivateKey, error) {
+func (c *x509FederationClient) PrivateRSAKey() (crypto.Signer, error) {
 	key := c.leafCertificateRetriever.PrivateKey()
 	if key == nil {
 		return nil, fmt.Errorf("can not read private key from leaf certificate. Likely an error in the metadata service")

--- a/common/auth/instance_principal_delegation_token_provider.go
+++ b/common/auth/instance_principal_delegation_token_provider.go
@@ -4,7 +4,7 @@
 package auth
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -56,7 +56,7 @@ func (p instancePrincipalDelegationTokenConfigurationProvider) getInstancePrinci
 	return p, nil
 }
 
-func (p instancePrincipalDelegationTokenConfigurationProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
+func (p instancePrincipalDelegationTokenConfigurationProvider) PrivateRSAKey() (crypto.Signer, error) {
 	return p.instancePrincipalKeyProvider.PrivateRSAKey()
 }
 

--- a/common/auth/instance_principal_key_provider.go
+++ b/common/auth/instance_principal_key_provider.go
@@ -5,7 +5,7 @@ package auth
 
 import (
 	"bytes"
-	"crypto/rsa"
+	"crypto"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -133,7 +133,7 @@ func (p *instancePrincipalKeyProvider) RegionForFederationClient() common.Region
 	return p.Region
 }
 
-func (p *instancePrincipalKeyProvider) PrivateRSAKey() (privateKey *rsa.PrivateKey, err error) {
+func (p *instancePrincipalKeyProvider) PrivateRSAKey() (privateKey crypto.Signer, err error) {
 	if privateKey, err = p.FederationClient.PrivateKey(); err != nil {
 		err = fmt.Errorf("failed to get private key: %s", err.Error())
 		return nil, instancePrincipalError{err: err}

--- a/common/auth/oauth2_provider.go
+++ b/common/auth/oauth2_provider.go
@@ -4,7 +4,7 @@
 package auth
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -49,7 +49,7 @@ func (p OAuth2ConfigurationProvider) KeyID() (string, error) {
 }
 
 // PrivateRSAKey returns the private key of the session key supplier created for the OAuth Provider
-func (p OAuth2ConfigurationProvider) PrivateRSAKey() (privateKey *rsa.PrivateKey, err error) {
+func (p OAuth2ConfigurationProvider) PrivateRSAKey() (privateKey crypto.Signer, err error) {
 	if privateKey, err = p.federationClient.PrivateKey(); err != nil {
 		err = fmt.Errorf("failed to get private key: %s", err.Error())
 		return nil, err

--- a/common/auth/resource_principal_delegation_token_provider.go
+++ b/common/auth/resource_principal_delegation_token_provider.go
@@ -4,7 +4,7 @@
 package auth
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -16,7 +16,7 @@ type resourcePrincipalDelegationTokenConfigurationProvider struct {
 	region                       *common.Region
 }
 
-func (r resourcePrincipalDelegationTokenConfigurationProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
+func (r resourcePrincipalDelegationTokenConfigurationProvider) PrivateRSAKey() (crypto.Signer, error) {
 	return r.resourcePrincipalKeyProvider.PrivateRSAKey()
 }
 

--- a/common/auth/resource_principal_key_provider.go
+++ b/common/auth/resource_principal_key_provider.go
@@ -4,7 +4,7 @@
 package auth
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"crypto/x509"
 	"errors"
 	"fmt"
@@ -413,7 +413,7 @@ func newOkeWorkloadIdentityProvider(proxymuxEndpoint string, saTokenProvider Ser
 	return &rs, nil
 }
 
-func (p *resourcePrincipalKeyProvider) PrivateRSAKey() (privateKey *rsa.PrivateKey, err error) {
+func (p *resourcePrincipalKeyProvider) PrivateRSAKey() (privateKey crypto.Signer, err error) {
 	if privateKey, err = p.FederationClient.PrivateKey(); err != nil {
 		err = fmt.Errorf("failed to get private key: %s", err.Error())
 		return nil, resourcePrincipalError{err: err}

--- a/common/auth/resource_principals_v1.go
+++ b/common/auth/resource_principals_v1.go
@@ -5,6 +5,7 @@ package auth
 
 import (
 	"context"
+	"crypto"
 	"crypto/rsa"
 	"fmt"
 
@@ -203,7 +204,7 @@ func (c *resourcePrincipalFederationClient) SecurityToken() (token string, err e
 	return c.securityToken.String(), nil
 }
 
-func (p *resourcePrincipalConfigurationProvider) PrivateRSAKey() (privateKey *rsa.PrivateKey, err error) {
+func (p *resourcePrincipalConfigurationProvider) PrivateRSAKey() (privateKey crypto.Signer, err error) {
 	if privateKey, err = p.keyProvider.ResourcePrincipalClient.PrivateKey(); err != nil {
 		err = fmt.Errorf("failed to get resource principal private key: %s", err.Error())
 		return nil, err

--- a/common/auth/resource_principals_v3.go
+++ b/common/auth/resource_principals_v3.go
@@ -5,6 +5,7 @@ package auth
 
 import (
 	"context"
+	"crypto"
 	"crypto/rsa"
 	"fmt"
 	"net/http"
@@ -243,7 +244,7 @@ func (r *resourcePrincipalV30ConfigurationProvider) Refreshable() bool {
 	return true
 }
 
-func (r *resourcePrincipalV30ConfigurationProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
+func (r *resourcePrincipalV30ConfigurationProvider) PrivateRSAKey() (crypto.Signer, error) {
 	privateKey, err := r.keyProvider.resourcePrincipalClient.PrivateKey()
 	if err != nil {
 		err = fmt.Errorf("failed to get resource principal private key: %s", err.Error())

--- a/common/auth/resource_principals_v3_test.go
+++ b/common/auth/resource_principals_v3_test.go
@@ -4,7 +4,7 @@
 package auth
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -131,7 +131,7 @@ func (f *fakeConfigProviderWithClaimAccess) KeyID() (string, error) {
 	return "keyId", nil
 }
 
-func (f *fakeConfigProviderWithClaimAccess) PrivateRSAKey() (*rsa.PrivateKey, error) {
+func (f *fakeConfigProviderWithClaimAccess) PrivateRSAKey() (crypto.Signer, error) {
 	block, _ := pem.Decode([]byte(testPrivateKey))
 	key, _ := x509.ParsePKCS1PrivateKey(block.Bytes)
 	return key, nil

--- a/common/auth/workload_identity_federation.go
+++ b/common/auth/workload_identity_federation.go
@@ -4,8 +4,8 @@
 package auth
 
 import (
+	"crypto"
 	"crypto/md5"
-	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
@@ -129,7 +129,7 @@ func (c TokenExchangeConfigurationProvider) KeyID() (string, error) {
 	return c.federationClient.SecurityToken()
 }
 
-func (c TokenExchangeConfigurationProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
+func (c TokenExchangeConfigurationProvider) PrivateRSAKey() (crypto.Signer, error) {
 	return c.federationClient.PrivateKey()
 }
 

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -6,7 +6,7 @@ package common
 import (
 	"bytes"
 	"context"
-	"crypto/rsa"
+	"crypto"
 	"errors"
 	"fmt"
 	"io"
@@ -39,7 +39,7 @@ func (c customConfig) UserOCID() (string, error) {
 func (c customConfig) TenancyOCID() (string, error) {
 	return "ocid1", nil
 }
-func (c customConfig) PrivateRSAKey() (*rsa.PrivateKey, error) {
+func (c customConfig) PrivateRSAKey() (crypto.Signer, error) {
 	key, _ := PrivateKeyFromBytes([]byte(testPrivateKeyConf), nil)
 	return key, nil
 }

--- a/common/configuration.go
+++ b/common/configuration.go
@@ -4,7 +4,7 @@
 package common
 
 import (
-	"crypto/rsa"
+	"crypto"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -116,7 +116,7 @@ func NewRawConfigurationProvider(tenancy, user, region, fingerprint, privateKey 
 	return rawConfigurationProvider{tenancy, user, region, fingerprint, privateKey, privateKeyPassphrase}
 }
 
-func (p rawConfigurationProvider) PrivateRSAKey() (key *rsa.PrivateKey, err error) {
+func (p rawConfigurationProvider) PrivateRSAKey() (key crypto.Signer, err error) {
 	return PrivateKeyFromBytes([]byte(p.privateKey), p.privateKeyPassphrase)
 }
 
@@ -186,7 +186,7 @@ func (p environmentConfigurationProvider) String() string {
 	return fmt.Sprintf("Configuration provided by environment variables prefixed with: %s", p.EnvironmentVariablePrefix)
 }
 
-func (p environmentConfigurationProvider) PrivateRSAKey() (key *rsa.PrivateKey, err error) {
+func (p environmentConfigurationProvider) PrivateRSAKey() (key crypto.Signer, err error) {
 	environmentVariable := fmt.Sprintf("%s_%s", p.EnvironmentVariablePrefix, "private_key_path")
 	var ok bool
 	var value string
@@ -550,7 +550,7 @@ func (p fileConfigurationProvider) KeyID() (keyID string, err error) {
 	return
 }
 
-func (p fileConfigurationProvider) PrivateRSAKey() (key *rsa.PrivateKey, err error) {
+func (p fileConfigurationProvider) PrivateRSAKey() (key crypto.Signer, err error) {
 	info, err := p.readAndParseConfigFile()
 	if err != nil {
 		err = fileConfigurationProviderError{err: fmt.Errorf("can not read tenancy configuration due to: %s", err.Error())}
@@ -709,7 +709,7 @@ func (c composingConfigurationProvider) KeyID() (string, error) {
 	return "", fmt.Errorf("did not find a proper configuration for key id")
 }
 
-func (c composingConfigurationProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
+func (c composingConfigurationProvider) PrivateRSAKey() (crypto.Signer, error) {
 	for _, p := range c.Providers {
 		val, err := p.PrivateRSAKey()
 		if err == nil {

--- a/common/http_signer.go
+++ b/common/http_signer.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"crypto"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
@@ -24,7 +23,7 @@ type HTTPRequestSigner interface {
 
 // KeyProvider interface that wraps information about the key's account owner
 type KeyProvider interface {
-	PrivateRSAKey() (*rsa.PrivateKey, error)
+	PrivateRSAKey() (crypto.Signer, error)
 	KeyID() (string, error)
 }
 
@@ -228,7 +227,7 @@ func (signer ociRequestSigner) computeSignature(request *http.Request) (signatur
 	}
 
 	var unencodedSig []byte
-	unencodedSig, e := rsa.SignPKCS1v15(rand.Reader, privateKey, crypto.SHA256, hashed)
+	unencodedSig, e := privateKey.Sign(rand.Reader, hashed, crypto.SHA256)
 	if e != nil {
 		err = fmt.Errorf("can not compute signature while signing the request %s: ", e.Error())
 		return

--- a/common/http_signer_test.go
+++ b/common/http_signer_test.go
@@ -5,7 +5,7 @@ package common
 
 import (
 	"bytes"
-	"crypto/rsa"
+	"crypto"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -71,7 +71,7 @@ x-content-sha256: V9Z20UJTvkvpJ50flBzKE32+6m2zJjweHpDMX/U4Uy0=`
 
 type testKeyProvider struct{}
 
-func (kp testKeyProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
+func (kp testKeyProvider) PrivateRSAKey() (crypto.Signer, error) {
 	pass := ""
 	key, e := PrivateKeyFromBytes([]byte(testPrivateKey), &pass)
 	return key, e


### PR DESCRIPTION
The motivation here is to allow hardware-backed signer, such as a Yubikey PIV key, to authenticate to OCI. This is working for me with a local fork.

rsa.PrivateKey is an in-memory key, and so doesn't permit using hardware-backed signers.

This is a non-breaking change, since *rsa.PrivateKey implements crypto.Signer.